### PR TITLE
revC1: Added BOM management keys to the schematic.

### DIFF
--- a/hardware/boards/glasgow/glasgow-cache.lib
+++ b/hardware/boards/glasgow/glasgow-cache.lib
@@ -808,7 +808,7 @@ ENDDEF
 #
 # Graphic_Logo_Open_Hardware_Large
 #
-DEF ~Graphic_Logo_Open_Hardware_Large #LOGO 0 40 Y Y 1 F N
+DEF Graphic_Logo_Open_Hardware_Large #LOGO 0 40 Y Y 1 F N
 F0 "#LOGO" 0 500 50 H I C CNN
 F1 "Graphic_Logo_Open_Hardware_Large" 0 -400 50 H I C CNN
 F2 "" 0 0 50 H I C CNN

--- a/hardware/boards/glasgow/glasgow.sch
+++ b/hardware/boards/glasgow/glasgow.sch
@@ -24,6 +24,7 @@ F 2 "Package_DFN_QFN:Cypress_QFN-56-1EP_8x8mm_P0.5mm_EP6.22x6.22mm_ThermalVias" 
 F 3 "http://www.cypress.com/file/138911/download" H 3550 4050 50  0001 C CNN
 F 4 "Cypress" H 650 -250 50  0001 C CNN "Mfg"
 F 5 "CY7C68013A-56LTXC" H 650 -250 50  0001 C CNN "MPN"
+F 6 "ic-cy7c68013a-56ltx" H 3550 3850 50  0001 C CNN "1b2-bom-key"
 	1    3550 3850
 	1    0    0    -1  
 $EndComp
@@ -37,6 +38,7 @@ F 2 "Connector_USB:USB_Micro-B_Molex_47346-0001" H 1150 4500 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/276/0473460001_IO_CONNECTORS-229243.pdf" H 1150 4500 50  0001 C CNN
 F 4 "Molex" H -50 400 50  0001 C CNN "Mfg"
 F 5 "47346-0001" H -50 400 50  0001 C CNN "MPN"
+F 6 "conn-smd-usb-micro-b" H 1000 4550 50  0001 C CNN "1b2-bom-key"
 	1    1000 4550
 	1    0    0    -1  
 $EndComp
@@ -111,6 +113,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 2238 2300 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 2200 2450 50  0001 C CNN
 F 4 "Yageo" H 650 -250 50  0001 C CNN "Mfg"
 F 5 "CC0603JRNPO8BN180" H 650 -250 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-18p" H 2200 2450 50  0001 C CNN "1b2-bom-key"
 	1    2200 2450
 	0    1    1    0   
 $EndComp
@@ -205,6 +208,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 1030 5450 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/447/PYu-RC_Group_51_RoHS_L_9-1314892.pdf" H 1100 5450 50  0001 C CNN
 F 4 "Yageo" H -50 400 50  0001 C CNN "Mfg"
 F 5 "RC0603FR-131ML" H -50 400 50  0001 C CNN "MPN"
+F 6 "res-0402-1m" H 1100 5450 50  0001 C CNN "1b2-bom-key"
 	1    1100 5450
 	1    0    0    -1  
 $EndComp
@@ -250,6 +254,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 1438 1000 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 1400 1150 50  0001 C CNN
 F 4 "Taiyo Yuden" H -450 -250 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H -450 -250 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 1400 1150 50  0001 C CNN "1b2-bom-key"
 	1    1400 1150
 	1    0    0    -1  
 $EndComp
@@ -311,6 +316,7 @@ F 2 "Capacitor_SMD:C_0603_1608Metric_Pad1.05x0.95mm_HandSolder" H 1038 1000 50  
 F 3 "https://www.mouser.com/datasheet/2/400/lcc_commercial_general_en-837201.pdf" H 1000 1150 50  0001 C CNN
 F 4 "Taiyo Yuden" H -450 -250 50  0001 C CNN "Mfg"
 F 5 "LMK107BJ475KAHT" H -450 -250 50  0001 C CNN "MPN"
+F 6 "cap-cer-0603-4u7" H 1000 1150 50  0001 C CNN "1b2-bom-key"
 	1    1000 1150
 	1    0    0    -1  
 $EndComp
@@ -334,6 +340,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 1738 1000 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 1700 1150 50  0001 C CNN
 F 4 "Taiyo Yuden" H -450 -250 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H -450 -250 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 1700 1150 50  0001 C CNN "1b2-bom-key"
 	1    1700 1150
 	1    0    0    -1  
 $EndComp
@@ -347,6 +354,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 2038 1000 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 2000 1150 50  0001 C CNN
 F 4 "Taiyo Yuden" H -450 -250 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H -450 -250 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 2000 1150 50  0001 C CNN "1b2-bom-key"
 	1    2000 1150
 	1    0    0    -1  
 $EndComp
@@ -360,6 +368,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 2338 1000 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 2300 1150 50  0001 C CNN
 F 4 "Taiyo Yuden" H -450 -250 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H -450 -250 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 2300 1150 50  0001 C CNN "1b2-bom-key"
 	1    2300 1150
 	1    0    0    -1  
 $EndComp
@@ -373,6 +382,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 2638 1000 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 2600 1150 50  0001 C CNN
 F 4 "Taiyo Yuden" H -450 -250 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H -450 -250 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 2600 1150 50  0001 C CNN "1b2-bom-key"
 	1    2600 1150
 	1    0    0    -1  
 $EndComp
@@ -386,6 +396,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 2938 1000 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 2900 1150 50  0001 C CNN
 F 4 "Taiyo Yuden" H -450 -250 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H -450 -250 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 2900 1150 50  0001 C CNN "1b2-bom-key"
 	1    2900 1150
 	1    0    0    -1  
 $EndComp
@@ -399,6 +410,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 3238 1000 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 3200 1150 50  0001 C CNN
 F 4 "Taiyo Yuden" H -450 -250 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H -450 -250 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 3200 1150 50  0001 C CNN "1b2-bom-key"
 	1    3200 1150
 	1    0    0    -1  
 $EndComp
@@ -412,6 +424,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 788 5300 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 750 5450 50  0001 C CNN
 F 4 "Taiyo Yuden" H -50 400 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H -50 400 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 750 5450 50  0001 C CNN "1b2-bom-key"
 	1    750  5450
 	1    0    0    -1  
 $EndComp
@@ -451,6 +464,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 2238 2800 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 2200 2950 50  0001 C CNN
 F 4 "Yageo" H 650 -250 50  0001 C CNN "Mfg"
 F 5 "CC0603JRNPO8BN180" H 650 -250 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-18p" H 2200 2950 50  0001 C CNN "1b2-bom-key"
 	1    2200 2950
 	0    1    1    0   
 $EndComp
@@ -468,6 +482,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 2580 4700 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/447/PYu-RC_Group_51_RoHS_L_9-1314892.pdf" H 2650 4700 50  0001 C CNN
 F 4 "Yageo" H 650 -250 50  0001 C CNN "Mfg"
 F 5 "RC0603FR-132K2L" H 650 -250 50  0001 C CNN "MPN"
+F 6 "res-0402-2k2" H 2650 4700 50  0001 C CNN "1b2-bom-key"
 	1    2650 4700
 	-1   0    0    1   
 $EndComp
@@ -481,6 +496,7 @@ F 2 "Package_SO:SOIC-8_3.9x4.9mm_P1.27mm" H 4200 7250 50  0001 C CNN
 F 3 "https://www.onsemi.com/pub/Collateral/CAT24M01-D.PDF" H 4200 7000 50  0001 C CNN
 F 4 "ON Semiconductor" H 350 0   50  0001 C CNN "Mfg"
 F 5 "CAT24M01WI-GT3" H 350 0   50  0001 C CNN "MPN"
+F 6 "ic-soic8-cat24m01w" H 4200 7000 50  0001 C CNN "1b2-bom-key"
 	1    4200 7000
 	1    0    0    -1  
 $EndComp
@@ -494,6 +510,7 @@ F 2 "Package_SO:SOIC-8_3.9x4.9mm_P1.27mm" H 5900 7000 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/308/CAT24C256-D-769998.pdf" H 5900 7000 50  0001 C CNN
 F 4 "ON Semiconductor" H 0   0   50  0001 C CNN "Mfg"
 F 5 "CAT24C256WI-GT3" H 0   0   50  0001 C CNN "MPN"
+F 6 "ic-soic8-cat24c256w" H 5900 7000 50  0001 C CNN "1b2-bom-key"
 	1    5900 7000
 	1    0    0    -1  
 $EndComp
@@ -607,6 +624,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 3488 6850 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 3450 7000 50  0001 C CNN
 F 4 "Taiyo Yuden" H 350 0   50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H 350 0   50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 3450 7000 50  0001 C CNN "1b2-bom-key"
 	1    3450 7000
 	1    0    0    -1  
 $EndComp
@@ -642,6 +660,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 4988 6850 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 4950 7000 50  0001 C CNN
 F 4 "Taiyo Yuden" H -200 0   50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H -200 0   50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 4950 7000 50  0001 C CNN "1b2-bom-key"
 	1    4950 7000
 	1    0    0    -1  
 $EndComp
@@ -757,6 +776,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 3538 1000 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 3500 1150 50  0001 C CNN
 F 4 "Taiyo Yuden" H -450 -250 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H -450 -250 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 3500 1150 50  0001 C CNN "1b2-bom-key"
 	1    3500 1150
 	1    0    0    -1  
 $EndComp
@@ -927,6 +947,7 @@ F 2 "Capacitor_SMD:C_0603_1608Metric_Pad1.05x0.95mm_HandSolder" H 5188 1000 50  
 F 3 "https://www.mouser.com/datasheet/2/400/lcc_commercial_general_en-837201.pdf" H 5150 1150 50  0001 C CNN
 F 4 "Taiyo Yuden" H 450 -250 50  0001 C CNN "Mfg"
 F 5 "LMK107BJ475KAHT" H 450 -250 50  0001 C CNN "MPN"
+F 6 "cap-cer-0603-4u7" H 5150 1150 50  0001 C CNN "1b2-bom-key"
 	1    5150 1150
 	1    0    0    -1  
 $EndComp
@@ -940,6 +961,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 5588 1000 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 5550 1150 50  0001 C CNN
 F 4 "Taiyo Yuden" H 450 -250 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H 450 -250 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 5550 1150 50  0001 C CNN "1b2-bom-key"
 	1    5550 1150
 	1    0    0    -1  
 $EndComp
@@ -953,6 +975,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 5938 1000 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 5900 1150 50  0001 C CNN
 F 4 "Taiyo Yuden" H 450 -250 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H 450 -250 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 5900 1150 50  0001 C CNN "1b2-bom-key"
 	1    5900 1150
 	1    0    0    -1  
 $EndComp
@@ -966,6 +989,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 6288 1000 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 6250 1150 50  0001 C CNN
 F 4 "Taiyo Yuden" H 100 -250 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H 100 -250 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 6250 1150 50  0001 C CNN "1b2-bom-key"
 	1    6250 1150
 	1    0    0    -1  
 $EndComp
@@ -979,6 +1003,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 7738 1000 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 7700 1150 50  0001 C CNN
 F 4 "Taiyo Yuden" H 1050 -250 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H 1050 -250 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 7700 1150 50  0001 C CNN "1b2-bom-key"
 	1    7700 1150
 	1    0    0    -1  
 $EndComp
@@ -992,6 +1017,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 8088 1000 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 8050 1150 50  0001 C CNN
 F 4 "Taiyo Yuden" H 1050 -250 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H 1050 -250 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 8050 1150 50  0001 C CNN "1b2-bom-key"
 	1    8050 1150
 	1    0    0    -1  
 $EndComp
@@ -1100,6 +1126,7 @@ F 2 "Package_SO:MSOP-8-1EP_3x3mm_P0.65mm_EP2.54x2.8mm_ThermalVias" H 10750 5500 
 F 3 "http://ww1.microchip.com/downloads/en/DeviceDoc/mic5355_6.pdf" H 9450 6100 50  0001 C CNN
 F 4 "Microchip" H -450 0   50  0001 C CNN "Mfg"
 F 5 "MIC5355-S4YMME" H -450 0   50  0001 C CNN "MPN"
+F 6 "ic-msop8-mic5355-s4ymme" H 9450 5750 50  0001 C CNN "1b2-bom-key"
 	1    9450 5750
 	1    0    0    -1  
 $EndComp
@@ -1113,6 +1140,7 @@ F 2 "Package_TO_SOT_SMD:SOT-23-6" H 10100 4150 50  0001 C CNN
 F 3 "http://www.ti.com/lit/ds/symlink/lm3880.pdf" H 9450 4400 50  0001 C CNN
 F 4 "Texas Instruments" H 1750 -1350 50  0001 C CNN "Mfg"
 F 5 "LM3880MFX-1AF/NOPB" H 1750 -1350 50  0001 C CNN "MPN"
+F 6 "ic-sot23-6-lm3880mf-1af" H 9450 4400 50  0001 C CNN "1b2-bom-key"
 	1    9450 4400
 	1    0    0    -1  
 $EndComp
@@ -1214,6 +1242,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 8430 5750 50  0001 C CNN
 F 3 "" H 8500 5750 50  0001 C CNN
 F 4 "Yageo" H -450 0   50  0001 C CNN "Mfg"
 F 5 "RC0603FR-10100KL" H -450 0   50  0001 C CNN "MPN"
+F 6 "res-0402-100k" H 8500 5750 50  0001 C CNN "1b2-bom-key"
 	1    8500 5750
 	0    1    1    0   
 $EndComp
@@ -1265,6 +1294,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 8430 5850 50  0001 C CNN
 F 3 "" H 8500 5850 50  0001 C CNN
 F 4 "Yageo" H -450 0   50  0001 C CNN "Mfg"
 F 5 "RC0603FR-10100KL" H -450 0   50  0001 C CNN "MPN"
+F 6 "res-0402-100k" H 8500 5850 50  0001 C CNN "1b2-bom-key"
 	1    8500 5850
 	0    1    -1   0   
 $EndComp
@@ -1322,6 +1352,7 @@ F 2 "Capacitor_SMD:C_0603_1608Metric_Pad1.05x0.95mm_HandSolder" H 9038 5900 50  
 F 3 "https://www.mouser.com/datasheet/2/400/lcc_commercial_general_en-837201.pdf" H 9000 6050 50  0001 C CNN
 F 4 "Taiyo Yuden" H -450 0   50  0001 C CNN "Mfg"
 F 5 "LMK107BJ475KAHT" H -450 0   50  0001 C CNN "MPN"
+F 6 "cap-cer-0603-4u7" H 9000 6050 50  0001 C CNN "1b2-bom-key"
 	1    9000 6050
 	1    0    0    -1  
 $EndComp
@@ -1335,6 +1366,7 @@ F 2 "Capacitor_SMD:C_0603_1608Metric_Pad1.05x0.95mm_HandSolder" H 9988 5900 50  
 F 3 "https://www.mouser.com/datasheet/2/400/lcc_commercial_general_en-837201.pdf" H 9950 6050 50  0001 C CNN
 F 4 "Taiyo Yuden" H -450 0   50  0001 C CNN "Mfg"
 F 5 "LMK107BJ475KAHT" H -450 0   50  0001 C CNN "MPN"
+F 6 "cap-cer-0603-4u7" H 9950 6050 50  0001 C CNN "1b2-bom-key"
 	1    9950 6050
 	1    0    0    -1  
 $EndComp
@@ -1348,6 +1380,7 @@ F 2 "Capacitor_SMD:C_0603_1608Metric_Pad1.05x0.95mm_HandSolder" H 10388 5900 50 
 F 3 "https://www.mouser.com/datasheet/2/400/lcc_commercial_general_en-837201.pdf" H 10350 6050 50  0001 C CNN
 F 4 "Taiyo Yuden" H -450 0   50  0001 C CNN "Mfg"
 F 5 "LMK107BJ475KAHT" H -450 0   50  0001 C CNN "MPN"
+F 6 "cap-cer-0603-4u7" H 10350 6050 50  0001 C CNN "1b2-bom-key"
 	1    10350 6050
 	1    0    0    -1  
 $EndComp
@@ -1361,6 +1394,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 2730 3350 50  0001 C CNN
 F 3 "" H 2800 3350 50  0001 C CNN
 F 4 "Yageo" H 650 -250 50  0001 C CNN "Mfg"
 F 5 "RC0603FR-10100KL" H 650 -250 50  0001 C CNN "MPN"
+F 6 "res-0402-100k" H 2800 3350 50  0001 C CNN "1b2-bom-key"
 	1    2800 3350
 	1    0    0    1   
 $EndComp
@@ -1392,6 +1426,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 8680 4600 50  0001 C CNN
 F 3 "" H 8750 4600 50  0001 C CNN
 F 4 "Yageo" H 1750 -1350 50  0001 C CNN "Mfg"
 F 5 "RC0603FR-10100KL" H 1750 -1350 50  0001 C CNN "MPN"
+F 6 "res-0402-100k" H 8750 4600 50  0001 C CNN "1b2-bom-key"
 	1    8750 4600
 	1    0    0    1   
 $EndComp
@@ -1405,6 +1440,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 8680 4200 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/447/PYu-RC_Group_51_RoHS_L_9-1314892.pdf" H 8750 4200 50  0001 C CNN
 F 4 "Yageo" H 1750 -1350 50  0001 C CNN "Mfg"
 F 5 "RC0603FR-10220KL" H 1750 -1350 50  0001 C CNN "MPN"
+F 6 "res-0402-220k" H 8750 4200 50  0001 C CNN "1b2-bom-key"
 	1    8750 4200
 	1    0    0    1   
 $EndComp
@@ -1459,6 +1495,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 7530 1750 50  0001 C CNN
 F 3 "" H 7600 1750 50  0001 C CNN
 F 4 "Yageo" H 3200 -1800 50  0001 C CNN "Mfg"
 F 5 "RC0603FR-10100KL" H 3200 -1800 50  0001 C CNN "MPN"
+F 6 "res-0402-100k" H 7600 1750 50  0001 C CNN "1b2-bom-key"
 	1    7600 1750
 	0    -1   1    0   
 $EndComp
@@ -1564,6 +1601,7 @@ F 2 "LED_SMD:LED_0603_1608Metric_Pad0.82x1.00mm_HandSolder" H 9800 900 50  0001 
 F 3 "https://www.mouser.com/datasheet/2/445/150060GS75000-368921.pdf" H 9800 900 50  0001 C CNN
 F 4 "Wurth Electronics" H -450 0   50  0001 C CNN "Mfg"
 F 5 "150060GS75000" H -450 0   50  0001 C CNN "MPN"
+F 6 "led-0603-grn" H 9800 900 50  0001 C CNN "1b2-bom-key"
 	1    9800 900 
 	-1   0    0    1   
 $EndComp
@@ -1590,6 +1628,7 @@ F 2 "LED_SMD:LED_0603_1608Metric_Pad0.82x1.00mm_HandSolder" H 9800 1100 50  0001
 F 3 "https://www.mouser.com/datasheet/2/445/150060GS75000-368921.pdf" H 9800 1100 50  0001 C CNN
 F 4 "Wurth Electronics" H -450 0   50  0001 C CNN "Mfg"
 F 5 "150060GS75000" H -450 0   50  0001 C CNN "MPN"
+F 6 "led-0603-grn" H 9800 1100 50  0001 C CNN "1b2-bom-key"
 	1    9800 1100
 	-1   0    0    1   
 $EndComp
@@ -1603,6 +1642,7 @@ F 2 "LED_SMD:LED_0603_1608Metric_Pad0.82x1.00mm_HandSolder" H 9800 1300 50  0001
 F 3 "https://www.mouser.com/datasheet/2/445/150060GS75000-368921.pdf" H 9800 1300 50  0001 C CNN
 F 4 "Wurth Electronics" H -450 0   50  0001 C CNN "Mfg"
 F 5 "150060GS75000" H -450 0   50  0001 C CNN "MPN"
+F 6 "led-0603-grn" H 9800 1300 50  0001 C CNN "1b2-bom-key"
 	1    9800 1300
 	-1   0    0    1   
 $EndComp
@@ -1616,6 +1656,7 @@ F 2 "LED_SMD:LED_0603_1608Metric_Pad0.82x1.00mm_HandSolder" H 9800 1500 50  0001
 F 3 "https://www.mouser.com/datasheet/2/445/150060YS75000-368983.pdf" H 9800 1500 50  0001 C CNN
 F 4 "Wurth Electronics" H -450 0   50  0001 C CNN "Mfg"
 F 5 "150060YS75000" H -450 0   50  0001 C CNN "MPN"
+F 6 "led-0603-yel" H 9800 1500 50  0001 C CNN "1b2-bom-key"
 	1    9800 1500
 	-1   0    0    1   
 $EndComp
@@ -1629,6 +1670,7 @@ F 2 "LED_SMD:LED_0603_1608Metric_Pad0.82x1.00mm_HandSolder" H 9800 1700 50  0001
 F 3 "https://www.mouser.com/datasheet/2/445/150060RS75000-368563.pdf" H 9800 1700 50  0001 C CNN
 F 4 "Wurth Electronics" H -450 0   50  0001 C CNN "Mfg"
 F 5 "150060RS75000" H -450 0   50  0001 C CNN "MPN"
+F 6 "led-0603-red" H 9800 1700 50  0001 C CNN "1b2-bom-key"
 	1    9800 1700
 	-1   0    0    1   
 $EndComp
@@ -1674,6 +1716,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 9380 900 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/447/PYu-RC_Group_51_RoHS_L_9-1314892.pdf" H 9450 900 50  0001 C CNN
 F 4 "Yageo" H -450 0   50  0001 C CNN "Mfg"
 F 5 "RC0603FR-132K2L" H -450 0   50  0001 C CNN "MPN"
+F 6 "res-0402-20k" H 9450 900 50  0001 C CNN "1b2-bom-key"
 	1    9450 900 
 	0    -1   1    0   
 $EndComp
@@ -1709,6 +1752,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 9380 1500 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/447/PYu-RC_Group_51_RoHS_L_9-1314892.pdf" H 9450 1500 50  0001 C CNN
 F 4 "Yageo" H -450 0   50  0001 C CNN "Mfg"
 F 5 "RC0603FR-13390RL" H -450 0   50  0001 C CNN "MPN"
+F 6 "res-0402-2k2" H 9450 1500 50  0001 C CNN "1b2-bom-key"
 	1    9450 1500
 	0    -1   1    0   
 $EndComp
@@ -1736,6 +1780,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 9380 1700 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/447/PYu-RC_Group_51_RoHS_L_9-1314892.pdf" H 9450 1700 50  0001 C CNN
 F 4 "Yageo" H -450 0   50  0001 C CNN "Mfg"
 F 5 "RC0603FR-07604RL" H -450 0   50  0001 C CNN "MPN"
+F 6 "res-0402-10k" H 9450 1700 50  0001 C CNN "1b2-bom-key"
 	1    9450 1700
 	0    -1   1    0   
 $EndComp
@@ -1749,6 +1794,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 9380 1100 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/447/PYu-RC_Group_51_RoHS_L_9-1314892.pdf" H 9450 1100 50  0001 C CNN
 F 4 "Yageo" H -450 0   50  0001 C CNN "Mfg"
 F 5 "RC0603FR-132K2L" H -450 0   50  0001 C CNN "MPN"
+F 6 "res-0402-20k" H 9450 1100 50  0001 C CNN "1b2-bom-key"
 	1    9450 1100
 	0    -1   1    0   
 $EndComp
@@ -1762,6 +1808,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 9380 1300 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/447/PYu-RC_Group_51_RoHS_L_9-1314892.pdf" H 9450 1300 50  0001 C CNN
 F 4 "Yageo" H -450 0   50  0001 C CNN "Mfg"
 F 5 "RC0603FR-132K2L" H -450 0   50  0001 C CNN "MPN"
+F 6 "res-0402-20k" H 9450 1300 50  0001 C CNN "1b2-bom-key"
 	1    9450 1300
 	0    -1   1    0   
 $EndComp
@@ -1779,6 +1826,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 4980 4450 50  0001 C CNN
 F 3 "" H 5050 4450 50  0001 C CNN
 F 4 "Yageo" H 650 -850 50  0001 C CNN "Mfg"
 F 5 "RC0603FR-10100KL" H 650 -850 50  0001 C CNN "MPN"
+F 6 "res-0402-100k" H 5050 4450 50  0001 C CNN "1b2-bom-key"
 	1    5050 4450
 	0    -1   -1   0   
 $EndComp
@@ -1841,6 +1889,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 4980 3600 50  0001 C CNN
 F 3 "" H 5050 3600 50  0001 C CNN
 F 4 "Yageo" H 650 -450 50  0001 C CNN "Mfg"
 F 5 "RC0603FR-10100KL" H 650 -450 50  0001 C CNN "MPN"
+F 6 "res-0402-100k" H 5050 3600 50  0001 C CNN "1b2-bom-key"
 	1    5050 3600
 	0    -1   1    0   
 $EndComp
@@ -1856,6 +1905,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 4980 3100 50  0001 C CNN
 F 3 "" H 5050 3100 50  0001 C CNN
 F 4 "Yageo" H 650 -100 50  0001 C CNN "Mfg"
 F 5 "RC0603FR-10100KL" H 650 -100 50  0001 C CNN "MPN"
+F 6 "res-0402-100k" H 5050 3100 50  0001 C CNN "1b2-bom-key"
 	1    5050 3100
 	0    -1   1    0   
 $EndComp
@@ -1950,6 +2000,7 @@ F 2 "Crystals:Crystal_SMD_3225-4pin_3.2x2.5mm" H 2450 2700 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/741/LFXTAL058124Reel-940455.pdf" H 2450 2700 50  0001 C CNN
 F 4 "IQD" H 650 -250 50  0001 C CNN "Mfg"
 F 5 "LFXTAL058124REEL" H 650 -250 50  0001 C CNN "MPN"
+F 6 "xtal-lfxtal-24mhz" H 2450 2700 50  0001 C CNN "1b2-bom-key"
 	1    2450 2700
 	0    -1   -1   0   
 $EndComp
@@ -2046,6 +2097,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 1088 3550 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 1050 3700 50  0001 C CNN
 F 4 "Taiyo Yuden" H -2050 -3300 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H -2050 -3300 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 1050 3700 50  0001 C CNN "1b2-bom-key"
 	1    1050 3700
 	1    0    0    -1  
 $EndComp
@@ -2077,6 +2129,7 @@ F 0 "U30" H 7500 1900 50  0000 R CNN
 F 1 "ICE40HX8K-BG121" H 7500 1800 50  0000 R CNN
 F 2 "Package_BGA:BGA-121_9.0x9.0mm_Layout11x11_P0.8mm_Ball0.4mm_Pad0.35mm_NSMD" H 6800 1700 50  0001 C CNN
 F 3 "http://www.latticesemi.com/Products/FPGAandCPLD/iCE40" H 5950 4150 50  0001 C CNN
+F 4 "ic-ice40hx8k-bg121" H 6800 3150 50  0001 C CNN "1b2-bom-key"
 	3    6800 3150
 	-1   0    0    -1  
 $EndComp
@@ -2088,6 +2141,7 @@ F 0 "U30" H 6850 4800 50  0000 L CNN
 F 1 "ICE40HX8K-BG121" H 6850 4700 50  0000 L CNN
 F 2 "Package_BGA:BGA-121_9.0x9.0mm_Layout11x11_P0.8mm_Ball0.4mm_Pad0.35mm_NSMD" H 7050 3950 50  0001 C CNN
 F 3 "http://www.latticesemi.com/Products/FPGAandCPLD/iCE40" H 6200 6400 50  0001 C CNN
+F 4 "ic-ice40hx8k-bg121" H 7050 5400 50  0001 C CNN "1b2-bom-key"
 	5    7050 5400
 	-1   0    0    -1  
 $EndComp
@@ -2150,6 +2204,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 8438 1000 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 8400 1150 50  0001 C CNN
 F 4 "Taiyo Yuden" H 1400 -250 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H 1400 -250 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 8400 1150 50  0001 C CNN "1b2-bom-key"
 	1    8400 1150
 	1    0    0    -1  
 $EndComp
@@ -2163,6 +2218,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 6438 5100 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/400/lcc_commercial_general_en-837201.pdf" H 6400 5250 50  0001 C CNN
 F 4 "Taiyo Yuden" H -1200 3700 50  0001 C CNN "Mfg"
 F 5 "LMK107BJ475KAHT" H -1200 3700 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 6400 5250 50  0001 C CNN "1b2-bom-key"
 	1    6400 5250
 	-1   0    0    -1  
 $EndComp
@@ -2176,6 +2232,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 6438 5500 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/400/lcc_commercial_general_en-837201.pdf" H 6400 5650 50  0001 C CNN
 F 4 "Taiyo Yuden" H -1200 4100 50  0001 C CNN "Mfg"
 F 5 "LMK107BJ475KAHT" H -1200 4100 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 6400 5650 50  0001 C CNN "1b2-bom-key"
 	1    6400 5650
 	-1   0    0    -1  
 $EndComp
@@ -2189,6 +2246,7 @@ F 2 "Capacitor_SMD:C_0603_1608Metric_Pad1.05x0.95mm_HandSolder" H 6038 5500 50  
 F 3 "https://www.mouser.com/datasheet/2/400/lcc_commercial_general_en-837201.pdf" H 6000 5650 50  0001 C CNN
 F 4 "Taiyo Yuden" H -1600 4100 50  0001 C CNN "Mfg"
 F 5 "LMK107BJ475KAHT" H -1600 4100 50  0001 C CNN "MPN"
+F 6 "cap-cer-0603-4u7" H 6000 5650 50  0001 C CNN "1b2-bom-key"
 	1    6000 5650
 	-1   0    0    -1  
 $EndComp
@@ -2202,6 +2260,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 5430 5100 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/447/PYu-RC_Group_51_RoHS_L_9-1314892.pdf" H 5500 5100 50  0001 C CNN
 F 4 "Yageo" H -2100 3950 50  0001 C CNN "Mfg"
 F 5 "RC0603FR-07100RL" H -2100 3950 50  0001 C CNN "MPN"
+F 6 "res-0402-100" H 5500 5100 50  0001 C CNN "1b2-bom-key"
 	1    5500 5100
 	0    1    1    0   
 $EndComp
@@ -2215,6 +2274,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 5430 5500 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/447/PYu-RC_Group_51_RoHS_L_9-1314892.pdf" H 5500 5500 50  0001 C CNN
 F 4 "Yageo" H -2100 4350 50  0001 C CNN "Mfg"
 F 5 "RC0603FR-07100RL" H -2100 4350 50  0001 C CNN "MPN"
+F 6 "res-0402-100" H 5500 5500 50  0001 C CNN "1b2-bom-key"
 	1    5500 5500
 	0    1    1    0   
 $EndComp
@@ -2252,6 +2312,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 7388 1000 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 7350 1150 50  0001 C CNN
 F 4 "Taiyo Yuden" H 700 -250 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H 700 -250 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 7350 1150 50  0001 C CNN "1b2-bom-key"
 	1    7350 1150
 	1    0    0    -1  
 $EndComp
@@ -2299,6 +2360,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 6638 1000 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 6600 1150 50  0001 C CNN
 F 4 "Taiyo Yuden" H 450 -250 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H 450 -250 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 6600 1150 50  0001 C CNN "1b2-bom-key"
 	1    6600 1150
 	1    0    0    -1  
 $EndComp
@@ -2477,6 +2539,7 @@ F 2 "Package_TO_SOT_SMD:SOT-23-6" H 1750 3950 50  0001 C CNN
 F 3 "http://www.ti.com/lit/ds/symlink/tpd3s014.pdf" H 1550 3850 50  0001 C CNN
 F 4 "TPD3S014DBVR" H 250 0   50  0001 C CNN "MPN"
 F 5 "Texas Instruments" H 250 0   50  0001 C CNN "Mfg"
+F 6 "ic-sot23-6-tpd3s014" H 1750 3600 50  0001 C CNN "1b2-bom-key"
 	1    1750 3600
 	1    0    0    -1  
 $EndComp
@@ -2511,6 +2574,7 @@ F 2 "Capacitor_SMD:C_0603_1608Metric_Pad1.05x0.95mm_HandSolder" H 7038 1000 50  
 F 3 "https://www.mouser.com/datasheet/2/400/lcc_commercial_general_en-837201.pdf" H 7000 1150 50  0001 C CNN
 F 4 "Taiyo Yuden" H 5550 -250 50  0001 C CNN "Mfg"
 F 5 "LMK107BJ475KAHT" H 5550 -250 50  0001 C CNN "MPN"
+F 6 "cap-cer-0603-4u7" H 7000 1150 50  0001 C CNN "1b2-bom-key"
 	1    7000 1150
 	1    0    0    -1  
 $EndComp
@@ -2580,6 +2644,7 @@ F 2 "Capacitor_SMD:C_0603_1608Metric_Pad1.05x0.95mm_HandSolder" H 6038 5100 50  
 F 3 "https://www.mouser.com/datasheet/2/400/lcc_commercial_general_en-837201.pdf" H 6000 5250 50  0001 C CNN
 F 4 "Taiyo Yuden" H -1600 3700 50  0001 C CNN "Mfg"
 F 5 "LMK107BJ475KAHT" H -1600 3700 50  0001 C CNN "MPN"
+F 6 "cap-cer-0603-4u7" H 6000 5250 50  0001 C CNN "1b2-bom-key"
 	1    6000 5250
 	-1   0    0    -1  
 $EndComp
@@ -2615,6 +2680,7 @@ F 0 "U34" H 2450 7250 50  0000 R CNN
 F 1 "ATECC508A" H 3050 7250 50  0000 R CNN
 F 2 "Package_DFN_QFN:WDFN-8-1EP_3x2mm_P0.5mm_EP1.3x1.4mm" H 2600 7000 50  0001 C CNN
 F 3 "http://ww1.microchip.com/downloads/en/DeviceDoc/20005927A.pdf" H 2600 7000 50  0001 C CNN
+F 4 "ic-wdfn8-atecc508a" H 2600 7000 50  0001 C CNN "1b2-bom-key"
 	1    2600 7000
 	1    0    0    -1  
 $EndComp
@@ -2662,6 +2728,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 1988 6850 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 1950 7000 50  0001 C CNN
 F 4 "Taiyo Yuden" H -1150 0   50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H -1150 0   50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 1950 7000 50  0001 C CNN "1b2-bom-key"
 	1    1950 7000
 	1    0    0    -1  
 $EndComp
@@ -2703,6 +2770,7 @@ F 0 "FB1" H 1200 4150 50  0000 R CNN
 F 1 "Ferrite_Bead" H 1200 4250 50  0000 R CNN
 F 2 "Inductor_SMD:L_0402_1005Metric" V 1280 4050 50  0001 C CNN
 F 3 "~" H 1350 4050 50  0001 C CNN
+F 4 "ferrite-0402-600" H 1350 4050 50  0001 C CNN "1b2-bom-key"
 	1    1350 4050
 	-1   0    0    1   
 $EndComp
@@ -2948,6 +3016,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 2480 4700 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/447/PYu-RC_Group_51_RoHS_L_9-1314892.pdf" H 2550 4700 50  0001 C CNN
 F 4 "Yageo" H 650 -250 50  0001 C CNN "Mfg"
 F 5 "RC0603FR-132K2L" H 650 -250 50  0001 C CNN "MPN"
+F 6 "res-0402-2k2" H 2550 4700 50  0001 C CNN "1b2-bom-key"
 	1    2550 4700
 	1    0    0    1   
 $EndComp
@@ -3020,12 +3089,6 @@ Wire Wire Line
 	950  2550 1350 2550
 Wire Wire Line
 	950  2500 950  2550
-Wire Bus Line
-	4700 6250 7850 6250
-Wire Bus Line
-	7850 2550 7850 6250
-Wire Bus Line
-	4700 2150 4700 6250
 $Comp
 L Connector:TestPoint TP17
 U 1 1 5CC2ABF8
@@ -3037,4 +3100,10 @@ F 3 "~" H 1550 2550 50  0001 C CNN
 	1    1350 2550
 	0    1    1    0   
 $EndComp
+Wire Bus Line
+	4700 6250 7850 6250
+Wire Bus Line
+	7850 2550 7850 6250
+Wire Bus Line
+	4700 2150 4700 6250
 $EndSCHEMATC

--- a/hardware/boards/glasgow/io_banks.sch
+++ b/hardware/boards/glasgow/io_banks.sch
@@ -151,6 +151,7 @@ F 0 "U30" H 4450 3000 50  0000 L CNN
 F 1 "ICE40HX8K-BG121" H 4400 3100 50  0000 L CNN
 F 2 "Package_BGA:BGA-121_9.0x9.0mm_Layout11x11_P0.8mm_Ball0.4mm_Pad0.35mm_NSMD" H 4750 3000 50  0001 C CNN
 F 3 "http://www.latticesemi.com/Products/FPGAandCPLD/iCE40" H 3900 5450 50  0001 C CNN
+F 4 "ic-ice40hx8k-bg121" H 4750 4450 50  0001 C CNN "1b2-bom-key"
 	2    4750 4450
 	-1   0    0    -1  
 $EndComp
@@ -164,6 +165,7 @@ F 0 "U30" H 7900 2500 50  0000 L CNN
 F 1 "ICE40HX8K-BG121" H 7900 2600 50  0000 L CNN
 F 2 "Package_BGA:BGA-121_9.0x9.0mm_Layout11x11_P0.8mm_Ball0.4mm_Pad0.35mm_NSMD" H 8250 2750 50  0001 C CNN
 F 3 "http://www.latticesemi.com/Products/FPGAandCPLD/iCE40" H 7400 5200 50  0001 C CNN
+F 4 "ic-ice40hx8k-bg121" H 8250 4200 50  0001 C CNN "1b2-bom-key"
 	4    8250 4200
 	-1   0    0    -1  
 $EndComp
@@ -298,6 +300,7 @@ F 0 "J5" H 10050 5517 50  0000 C CNN
 F 1 "Conn_02x22_Odd_Even" H 10050 5426 50  0000 C CNN
 F 2 "Connector_PinHeader_1.27mm:PinHeader_2x22_P1.27mm_Vertical_SMD" H 10000 4300 50  0001 C CNN
 F 3 "~" H 10000 4300 50  0001 C CNN
+F 4 "conn-smd-005in-22-2-hdr" H 10000 4300 50  0001 C CNN "1b2-bom-key"
 	1    10000 4300
 	1    0    0    -1  
 $EndComp
@@ -482,6 +485,7 @@ F 2 "LED_SMD:LED_0603_1608Metric_Pad0.82x1.00mm_HandSolder" H 9800 1050 50  0001
 F 3 "https://www.mouser.com/datasheet/2/445/150060GS75000-368921.pdf" H 9800 1050 50  0001 C CNN
 F 4 "Wurth Electronics" H -450 150 50  0001 C CNN "Mfg"
 F 5 "150060GS75000" H -450 150 50  0001 C CNN "MPN"
+F 6 "led-0603-blu" H 9800 1050 50  0001 C CNN "1b2-bom-key"
 	1    9800 1050
 	-1   0    0    1   
 $EndComp
@@ -499,6 +503,7 @@ F 2 "LED_SMD:LED_0603_1608Metric_Pad0.82x1.00mm_HandSolder" H 9800 1250 50  0001
 F 3 "https://www.mouser.com/datasheet/2/445/150060GS75000-368921.pdf" H 9800 1250 50  0001 C CNN
 F 4 "Wurth Electronics" H -450 150 50  0001 C CNN "Mfg"
 F 5 "150060GS75000" H -450 150 50  0001 C CNN "MPN"
+F 6 "led-0603-pnk" H 9800 1250 50  0001 C CNN "1b2-bom-key"
 	1    9800 1250
 	-1   0    0    1   
 $EndComp
@@ -514,6 +519,7 @@ F 2 "LED_SMD:LED_0603_1608Metric_Pad0.82x1.00mm_HandSolder" H 9800 1450 50  0001
 F 3 "https://www.mouser.com/datasheet/2/445/150060GS75000-368921.pdf" H 9800 1450 50  0001 C CNN
 F 4 "Wurth Electronics" H -450 150 50  0001 C CNN "Mfg"
 F 5 "150060GS75000" H -450 150 50  0001 C CNN "MPN"
+F 6 "led-0603-wht" H 9800 1450 50  0001 C CNN "1b2-bom-key"
 	1    9800 1450
 	-1   0    0    1   
 $EndComp
@@ -529,6 +535,7 @@ F 2 "LED_SMD:LED_0603_1608Metric_Pad0.82x1.00mm_HandSolder" H 9800 1650 50  0001
 F 3 "https://www.mouser.com/datasheet/2/445/150060YS75000-368983.pdf" H 9800 1650 50  0001 C CNN
 F 4 "Wurth Electronics" H -450 150 50  0001 C CNN "Mfg"
 F 5 "150060YS75000" H -450 150 50  0001 C CNN "MPN"
+F 6 "led-0603-pnk" H 9800 1650 50  0001 C CNN "1b2-bom-key"
 	1    9800 1650
 	-1   0    0    1   
 $EndComp
@@ -544,6 +551,7 @@ F 2 "LED_SMD:LED_0603_1608Metric_Pad0.82x1.00mm_HandSolder" H 9800 1850 50  0001
 F 3 "https://www.mouser.com/datasheet/2/445/150060RS75000-368563.pdf" H 9800 1850 50  0001 C CNN
 F 4 "Wurth Electronics" H -450 150 50  0001 C CNN "Mfg"
 F 5 "150060RS75000" H -450 150 50  0001 C CNN "MPN"
+F 6 "led-0603-blu" H 9800 1850 50  0001 C CNN "1b2-bom-key"
 	1    9800 1850
 	-1   0    0    1   
 $EndComp
@@ -585,6 +593,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 9380 1050 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/447/PYu-RC_Group_51_RoHS_L_9-1314892.pdf" H 9450 1050 50  0001 C CNN
 F 4 "Yageo" H -450 150 50  0001 C CNN "Mfg"
 F 5 "RC0603FR-132K2L" H -450 150 50  0001 C CNN "MPN"
+F 6 "res-0402-4k7" H 9450 1050 50  0001 C CNN "1b2-bom-key"
 	1    9450 1050
 	0    -1   1    0   
 $EndComp
@@ -602,6 +611,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 9380 1650 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/447/PYu-RC_Group_51_RoHS_L_9-1314892.pdf" H 9450 1650 50  0001 C CNN
 F 4 "Yageo" H -450 150 50  0001 C CNN "Mfg"
 F 5 "RC0603FR-13390RL" H -450 150 50  0001 C CNN "MPN"
+F 6 "res-0402-10k" H 9450 1650 50  0001 C CNN "1b2-bom-key"
 	1    9450 1650
 	0    -1   1    0   
 $EndComp
@@ -625,6 +635,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 9380 1850 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/447/PYu-RC_Group_51_RoHS_L_9-1314892.pdf" H 9450 1850 50  0001 C CNN
 F 4 "Yageo" H -450 150 50  0001 C CNN "Mfg"
 F 5 "RC0603FR-07604RL" H -450 150 50  0001 C CNN "MPN"
+F 6 "res-0402-4k7" H 9450 1850 50  0001 C CNN "1b2-bom-key"
 	1    9450 1850
 	0    -1   1    0   
 $EndComp
@@ -640,6 +651,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 9380 1250 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/447/PYu-RC_Group_51_RoHS_L_9-1314892.pdf" H 9450 1250 50  0001 C CNN
 F 4 "Yageo" H -450 150 50  0001 C CNN "Mfg"
 F 5 "RC0603FR-132K2L" H -450 150 50  0001 C CNN "MPN"
+F 6 "res-0402-10k" H 9450 1250 50  0001 C CNN "1b2-bom-key"
 	1    9450 1250
 	0    -1   1    0   
 $EndComp
@@ -655,6 +667,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 9380 1450 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/447/PYu-RC_Group_51_RoHS_L_9-1314892.pdf" H 9450 1450 50  0001 C CNN
 F 4 "Yageo" H -450 150 50  0001 C CNN "Mfg"
 F 5 "RC0603FR-132K2L" H -450 150 50  0001 C CNN "MPN"
+F 6 "res-0402-6k8" H 9450 1450 50  0001 C CNN "1b2-bom-key"
 	1    9450 1450
 	0    -1   1    0   
 $EndComp
@@ -1105,6 +1118,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 8888 2500 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 8850 2650 50  0001 C CNN
 F 4 "Taiyo Yuden" H 2200 1250 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H 2200 1250 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 8850 2650 50  0001 C CNN "1b2-bom-key"
 	1    8850 2650
 	1    0    0    -1  
 $EndComp
@@ -1335,6 +1349,7 @@ F 0 "J10" H 3550 3450 50  0000 L CNN
 F 1 "Conn_01x03" H 3450 3350 50  0000 L CNN
 F 2 "Connector_PinHeader_2.54mm:PinHeader_1x03_P2.54mm_Vertical" H 3450 3550 50  0001 C CNN
 F 3 "~" H 3450 3550 50  0001 C CNN
+F 4 "conn-th-01in-3-1-hdr" H 3450 3550 50  0001 C CNN "1b2-bom-key"
 	1    3450 3550
 	1    0    0    -1  
 $EndComp
@@ -1363,6 +1378,7 @@ F 2 "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Horizontal" H 4500 2500 5
 F 3 "https://www.mouser.hk/datasheet/2/418/NG_CD_640455_Y3-1255934.pdf" H 4500 2500 50  0001 C CNN
 F 4 "Molex" H -6100 -350 50  0001 C CNN "Mfg"
 F 5 "22-05-3021" H -6100 -350 50  0001 C CNN "MPN"
+F 6 "conn-th-01in-2-1-hdr-ra" H 4500 2500 50  0001 C CNN "1b2-bom-key"
 	1    4500 2500
 	1    0    0    1   
 $EndComp
@@ -1393,6 +1409,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 1880 2750 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/447/PYu-AC_51_RoHS_L_6-1152827.pdf" H 1950 2750 50  0001 C CNN
 F 4 "Yageo" H -8400 200 50  0001 C CNN "Mfg"
 F 5 "AC0603FR-07130RL" H -8400 200 50  0001 C CNN "MPN"
+F 6 "res-0402-1k" H 1950 2750 50  0001 C CNN "1b2-bom-key"
 	1    1950 2750
 	-1   0    0    -1  
 $EndComp
@@ -1406,6 +1423,7 @@ F 0 "U30" H 950 2600 50  0000 L CNN
 F 1 "ICE40HX8K-BG121" H 950 2700 50  0000 L CNN
 F 2 "Package_BGA:BGA-121_9.0x9.0mm_Layout11x11_P0.8mm_Ball0.4mm_Pad0.35mm_NSMD" H 1300 2800 50  0001 C CNN
 F 3 "http://www.latticesemi.com/Products/FPGAandCPLD/iCE40" H 450 5250 50  0001 C CNN
+F 4 "ic-ice40hx8k-bg121" H 1300 4250 50  0001 C CNN "1b2-bom-key"
 	1    1300 4250
 	-1   0    0    -1  
 $EndComp
@@ -1461,6 +1479,7 @@ F 0 "U32" H 2850 2850 50  0000 L CNN
 F 1 "SN74LVC1T45DRL" H 2850 2750 50  0000 L CNN
 F 2 "Glasgow:SOT-563" H 2650 1950 50  0001 C CNN
 F 3 "http://www.ti.com/lit/ds/symlink/sn74lvc1t45.pdf" H 1750 1750 50  0001 C CNN
+F 4 "ic-sot563-sn74lvc1t45drl" H 2650 2400 50  0001 C CNN "1b2-bom-key"
 	1    2650 2400
 	1    0    0    -1  
 $EndComp
@@ -1536,6 +1555,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 2138 1750 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 2100 1900 50  0001 C CNN
 F 4 "Taiyo Yuden" H -4550 500 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H -4550 500 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 2100 1900 50  0001 C CNN "1b2-bom-key"
 	1    2100 1900
 	1    0    0    -1  
 $EndComp
@@ -1581,6 +1601,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 3180 2400 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/447/PYu-AC_51_RoHS_L_6-1152827.pdf" H 3250 2400 50  0001 C CNN
 F 4 "Yageo" H -7100 -150 50  0001 C CNN "Mfg"
 F 5 "AC0603FR-07130RL" H -7100 -150 50  0001 C CNN "MPN"
+F 6 "res-0402-47" H 3250 2400 50  0001 C CNN "1b2-bom-key"
 	1    3250 2400
 	0    1    -1   0   
 $EndComp
@@ -1598,6 +1619,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 2380 3550 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/447/PYu-AC_51_RoHS_L_6-1152827.pdf" H 2450 3550 50  0001 C CNN
 F 4 "Yageo" H -7900 1000 50  0001 C CNN "Mfg"
 F 5 "AC0603FR-07130RL" H -7900 1000 50  0001 C CNN "MPN"
+F 6 "res-0402-47" H 2450 3550 50  0001 C CNN "1b2-bom-key"
 	1    2450 3550
 	0    1    -1   0   
 $EndComp
@@ -1613,6 +1635,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 2380 3650 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/447/PYu-AC_51_RoHS_L_6-1152827.pdf" H 2450 3650 50  0001 C CNN
 F 4 "Yageo" H -7900 1100 50  0001 C CNN "Mfg"
 F 5 "AC0603FR-07130RL" H -7900 1100 50  0001 C CNN "MPN"
+F 6 "res-0402-47" H 2450 3650 50  0001 C CNN "1b2-bom-key"
 	1    2450 3650
 	0    1    -1   0   
 $EndComp
@@ -1642,6 +1665,7 @@ F 0 "D11" V 3604 2629 50  0000 L CNN
 F 1 "ESD5Z5.0T1G" V 3695 2629 50  0000 L CNN
 F 2 "Diode_SMD:D_SOD-523" H 3650 2550 50  0001 C CNN
 F 3 "https://www.onsemi.com/pub/Collateral/ESD5Z2.5T1-D.PDF" H 3650 2550 50  0001 C CNN
+F 4 "esd-diode-sod523-esd5z5_0t1g" H 3650 2550 50  0001 C CNN "1b2-bom-key"
 	1    3650 2550
 	0    1    1    0   
 $EndComp
@@ -1665,6 +1689,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 3580 2150 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/447/PYu-AC_51_RoHS_L_6-1152827.pdf" H 3650 2150 50  0001 C CNN
 F 4 "Yageo" H -6700 -400 50  0001 C CNN "Mfg"
 F 5 "AC0603FR-07130RL" H -6700 -400 50  0001 C CNN "MPN"
+F 6 "res-0402-10k" H 3650 2150 50  0001 C CNN "1b2-bom-key"
 	1    3650 2150
 	1    0    0    1   
 $EndComp
@@ -1709,6 +1734,7 @@ F 0 "D12" V 2600 3250 50  0000 L CNN
 F 1 "ESD5Z5.0T1G" H 2550 3450 50  0000 L CNN
 F 2 "Diode_SMD:D_SOD-523" H 2700 3350 50  0001 C CNN
 F 3 "https://www.onsemi.com/pub/Collateral/ESD5Z2.5T1-D.PDF" H 2700 3350 50  0001 C CNN
+F 4 "esd-diode-sod523-esd5z5_0t1g" H 2700 3350 50  0001 C CNN "1b2-bom-key"
 	1    2700 3350
 	0    -1   -1   0   
 $EndComp
@@ -1720,6 +1746,7 @@ F 0 "D13" V 2900 3250 50  0000 L CNN
 F 1 "ESD5Z5.0T1G" H 2850 3450 50  0000 L CNN
 F 2 "Diode_SMD:D_SOD-523" H 3000 3350 50  0001 C CNN
 F 3 "https://www.onsemi.com/pub/Collateral/ESD5Z2.5T1-D.PDF" H 3000 3350 50  0001 C CNN
+F 4 "esd-diode-sod523-esd5z5_0t1g" H 3000 3350 50  0001 C CNN "1b2-bom-key"
 	1    3000 3350
 	0    -1   -1   0   
 $EndComp
@@ -1781,6 +1808,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 1980 2400 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/447/PYu-AC_51_RoHS_L_6-1152827.pdf" H 2050 2400 50  0001 C CNN
 F 4 "Yageo" H -8300 -150 50  0001 C CNN "Mfg"
 F 5 "AC0603FR-07130RL" H -8300 -150 50  0001 C CNN "MPN"
+F 6 "res-0402-33" H 2050 2400 50  0001 C CNN "1b2-bom-key"
 	1    2050 2400
 	0    1    -1   0   
 $EndComp

--- a/hardware/boards/glasgow/io_buffer.sch
+++ b/hardware/boards/glasgow/io_buffer.sch
@@ -92,6 +92,7 @@ F 2 "Connector_IDC:IDC-Header_2x10_P2.54mm_Vertical" H 8250 2700 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/276/0878342019_PCB_HEADERS-152849.pdf" H 8250 2700 50  0001 C CNN
 F 4 "Molex" H 4550 -450 50  0001 C CNN "Mfg"
 F 5 "87834-2019" H 4550 -450 50  0001 C CNN "MPN"
+F 6 "conn-th-01in-10-2-hdr-shr" H 8250 2700 50  0001 C CNN "1b2-bom-key"
 	1    8250 2700
 	1    0    0    -1  
 $EndComp
@@ -114,6 +115,7 @@ F 2 "Package_TO_SOT_SMD:SOT-23-6" H 10450 4150 50  0001 C CNN
 F 3 "http://www.ti.com/lit/ds/symlink/dac081c081.pdf" H 9800 4400 50  0001 C CNN
 F 4 "Texas Instruments" H 6550 -450 50  0001 C CNN "Mfg"
 F 5 "DAC081C081CIMK/NOPB" H 6550 -450 50  0001 C CNN "MPN"
+F 6 "ic-sot23-6-dac081c081cimk" H 9800 4400 50  0001 C CNN "1b2-bom-key"
 	1    9800 4400
 	1    0    0    -1  
 $EndComp
@@ -131,6 +133,7 @@ F 2 "Package_SO:MSOP-8_3x3mm_P0.65mm" H 10950 2650 50  0001 C CNN
 F 3 "http://www.ti.com/lit/ds/symlink/adc081c021.pdf" H 10150 3100 50  0001 C CNN
 F 4 "Texas Instruments" H 4050 -150 50  0001 C CNN "Mfg"
 F 5 "ADC081C021CIMM/NOPB" H 4050 -150 50  0001 C CNN "MPN"
+F 6 "ic-msop8-adc081c021cimm" H 10150 3000 50  0001 C CNN "1b2-bom-key"
 	1    10150 3000
 	1    0    0    -1  
 $EndComp
@@ -257,6 +260,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 8288 900 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 8250 1050 50  0001 C CNN
 F 4 "Taiyo Yuden" H 3550 -450 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H 3550 -450 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 8250 1050 50  0001 C CNN "1b2-bom-key"
 	1    8250 1050
 	1    0    0    -1  
 $EndComp
@@ -308,6 +312,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 8638 900 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 8600 1050 50  0001 C CNN
 F 4 "Taiyo Yuden" H 3550 -450 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H 3550 -450 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 8600 1050 50  0001 C CNN "1b2-bom-key"
 	1    8600 1050
 	1    0    0    -1  
 $EndComp
@@ -332,6 +337,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 9288 2650 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/447/UPY-GPHC_X7R_6.3V-to-50V_18-1154002.pdf" H 9250 2800 50  0001 C CNN
 F 4 "Yageo" H 4550 -450 50  0001 C CNN "Mfg"
 F 5 "CC0603KRX7R8BB123" H 4550 -450 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-12n" H 9250 2800 50  0001 C CNN "1b2-bom-key"
 	1    9250 2800
 	1    0    0    -1  
 $EndComp
@@ -349,6 +355,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 8830 2400 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/447/PYu-RC_Group_51_RoHS_L_9-1314892.pdf" H 8900 2400 50  0001 C CNN
 F 4 "Yageo" H 4550 -450 50  0001 C CNN "Mfg"
 F 5 "RC0603FR-1010KL" H 4550 -450 50  0001 C CNN "MPN"
+F 6 "res-0402-10k" H 8900 2400 50  0001 C CNN "1b2-bom-key"
 	1    8900 2400
 	-1   0    0    1   
 $EndComp
@@ -411,6 +418,7 @@ F 2 "Package_TO_SOT_SMD:SOT-23-5" H 9800 5875 50  0001 C CIN
 F 3 "http://www.ti.com/lit/ds/symlink/tps731.pdf" H 9800 5500 50  0001 C CNN
 F 4 "Texas Instruments" H 4300 700 50  0001 C CNN "Mfg"
 F 5 "TPS73101DBVR" H 4300 700 50  0001 C CNN "MPN"
+F 6 "ic-sot23-5-tps73101dbv" H 9800 5550 50  0001 C CNN "1b2-bom-key"
 	1    9800 5550
 	1    0    0    -1  
 $EndComp
@@ -464,6 +472,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 9288 1850 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/400/lcc_commercial_general_en-837201.pdf" H 9250 2000 50  0001 C CNN
 F 4 "Taiyo Yuden" H 5950 500 50  0001 C CNN "Mfg"
 F 5 "LMK107BJ475KAHT" H 5950 500 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 9250 2000 50  0001 C CNN "1b2-bom-key"
 	1    9250 2000
 	1    0    0    -1  
 $EndComp
@@ -498,6 +507,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 10730 5650 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/447/PYu-AC_51_RoHS_L_6-1152827.pdf" H 10800 5650 50  0001 C CNN
 F 4 "Yageo" H 4650 700 50  0001 C CNN "Mfg"
 F 5 "RC0603FR-0759KL" H 4650 700 50  0001 C CNN "MPN"
+F 6 "res-0402-59k" H 10800 5650 50  0001 C CNN "1b2-bom-key"
 	1    10800 5650
 	-1   0    0    1   
 $EndComp
@@ -517,6 +527,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 10730 6050 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/447/PYu-AC_51_RoHS_L_6-1152827.pdf" H 10800 6050 50  0001 C CNN
 F 4 "Yageo" H 4650 700 50  0001 C CNN "Mfg"
 F 5 "AC0603FR-0724K3L" H 4650 700 50  0001 C CNN "MPN"
+F 6 "res-0402-24k3" H 10800 6050 50  0001 C CNN "1b2-bom-key"
 	1    10800 6050
 	-1   0    0    1   
 $EndComp
@@ -541,6 +552,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 10430 4400 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/447/PYu-AC_51_RoHS_L_6-1152827.pdf" H 10500 4400 50  0001 C CNN
 F 4 "Yageo" H 6350 -450 50  0001 C CNN "Mfg"
 F 5 "RC0603FR-0749K9L" H 6350 -450 50  0001 C CNN "MPN"
+F 6 "res-0402-49k9" H 10500 4400 50  0001 C CNN "1b2-bom-key"
 	1    10500 4400
 	0    -1   -1   0   
 $EndComp
@@ -575,6 +587,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 8830 2800 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/447/PYu-RC_Group_51_RoHS_L_9-1314892.pdf" H 8900 2800 50  0001 C CNN
 F 4 "Yageo" H 4550 -450 50  0001 C CNN "Mfg"
 F 5 "RC0603FR-1010KL" H 4550 -450 50  0001 C CNN "MPN"
+F 6 "res-0402-10k" H 8900 2800 50  0001 C CNN "1b2-bom-key"
 	1    8900 2800
 	-1   0    0    1   
 $EndComp
@@ -596,6 +609,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 8938 5500 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 8900 5650 50  0001 C CNN
 F 4 "Taiyo Yuden" H 4300 700 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H 4300 700 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 8900 5650 50  0001 C CNN "1b2-bom-key"
 	1    8900 5650
 	1    0    0    -1  
 $EndComp
@@ -649,6 +663,7 @@ F 0 "U22" H 2650 1100 50  0000 L CNN
 F 1 "SN74LVC1T45DRL" H 2650 1000 50  0000 L CNN
 F 2 "Glasgow:SOT-563" H 2500 950 50  0001 C CNN
 F 3 "http://www.ti.com/lit/ds/symlink/sn74lvc1t45.pdf" H 1600 800 50  0001 C CNN
+F 4 "ic-sot563-sn74lvc1t45drl" H 2500 1450 50  0001 C CNN "1b2-bom-key"
 	1    2500 1450
 	1    0    0    -1  
 $EndComp
@@ -668,6 +683,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 2038 900 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 2000 1050 50  0001 C CNN
 F 4 "Taiyo Yuden" H -500 -450 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H -500 -450 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 2000 1050 50  0001 C CNN "1b2-bom-key"
 	1    2000 1050
 	1    0    0    -1  
 $EndComp
@@ -719,6 +735,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 3038 900 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 3000 1050 50  0001 C CNN
 F 4 "Taiyo Yuden" H 500 -450 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H 500 -450 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 3000 1050 50  0001 C CNN "1b2-bom-key"
 	1    3000 1050
 	1    0    0    -1  
 $EndComp
@@ -759,6 +776,7 @@ F 0 "U23" H 2650 2700 50  0000 L CNN
 F 1 "SN74LVC1T45DRL" H 2650 2600 50  0000 L CNN
 F 2 "Glasgow:SOT-563" H 2500 2550 50  0001 C CNN
 F 3 "http://www.ti.com/lit/ds/symlink/sn74lvc1t45.pdf" H 1600 2400 50  0001 C CNN
+F 4 "ic-sot563-sn74lvc1t45drl" H 2500 3050 50  0001 C CNN "1b2-bom-key"
 	1    2500 3050
 	1    0    0    -1  
 $EndComp
@@ -776,6 +794,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 2038 2500 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 2000 2650 50  0001 C CNN
 F 4 "Taiyo Yuden" H -500 1150 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H -500 1150 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 2000 2650 50  0001 C CNN "1b2-bom-key"
 	1    2000 2650
 	1    0    0    -1  
 $EndComp
@@ -827,6 +846,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 3038 2500 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 3000 2650 50  0001 C CNN
 F 4 "Taiyo Yuden" H 500 1150 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H 500 1150 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 3000 2650 50  0001 C CNN "1b2-bom-key"
 	1    3000 2650
 	1    0    0    -1  
 $EndComp
@@ -867,6 +887,7 @@ F 0 "U24" H 2650 4300 50  0000 L CNN
 F 1 "SN74LVC1T45DRL" H 2650 4200 50  0000 L CNN
 F 2 "Glasgow:SOT-563" H 2500 4150 50  0001 C CNN
 F 3 "http://www.ti.com/lit/ds/symlink/sn74lvc1t45.pdf" H 1600 4000 50  0001 C CNN
+F 4 "ic-sot563-sn74lvc1t45drl" H 2500 4650 50  0001 C CNN "1b2-bom-key"
 	1    2500 4650
 	1    0    0    -1  
 $EndComp
@@ -884,6 +905,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 2038 4100 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 2000 4250 50  0001 C CNN
 F 4 "Taiyo Yuden" H -500 2750 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H -500 2750 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 2000 4250 50  0001 C CNN "1b2-bom-key"
 	1    2000 4250
 	1    0    0    -1  
 $EndComp
@@ -935,6 +957,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 3038 4100 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 3000 4250 50  0001 C CNN
 F 4 "Taiyo Yuden" H 500 2750 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H 500 2750 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 3000 4250 50  0001 C CNN "1b2-bom-key"
 	1    3000 4250
 	1    0    0    -1  
 $EndComp
@@ -975,6 +998,7 @@ F 0 "U25" H 2650 5900 50  0000 L CNN
 F 1 "SN74LVC1T45DRL" H 2650 5800 50  0000 L CNN
 F 2 "Glasgow:SOT-563" H 2500 5750 50  0001 C CNN
 F 3 "http://www.ti.com/lit/ds/symlink/sn74lvc1t45.pdf" H 1600 5600 50  0001 C CNN
+F 4 "ic-sot563-sn74lvc1t45drl" H 2500 6250 50  0001 C CNN "1b2-bom-key"
 	1    2500 6250
 	1    0    0    -1  
 $EndComp
@@ -992,6 +1016,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 2038 5700 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 2000 5850 50  0001 C CNN
 F 4 "Taiyo Yuden" H -500 4350 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H -500 4350 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 2000 5850 50  0001 C CNN "1b2-bom-key"
 	1    2000 5850
 	1    0    0    -1  
 $EndComp
@@ -1043,6 +1068,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 3038 5700 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 3000 5850 50  0001 C CNN
 F 4 "Taiyo Yuden" H 500 4350 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H 500 4350 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 3000 5850 50  0001 C CNN "1b2-bom-key"
 	1    3000 5850
 	1    0    0    -1  
 $EndComp
@@ -1083,6 +1109,7 @@ F 0 "U26" H 4400 1900 50  0000 L CNN
 F 1 "SN74LVC1T45DRL" H 4400 1800 50  0000 L CNN
 F 2 "Glasgow:SOT-563" H 4250 1750 50  0001 C CNN
 F 3 "http://www.ti.com/lit/ds/symlink/sn74lvc1t45.pdf" H 3350 1600 50  0001 C CNN
+F 4 "ic-sot563-sn74lvc1t45drl" H 4250 2250 50  0001 C CNN "1b2-bom-key"
 	1    4250 2250
 	1    0    0    -1  
 $EndComp
@@ -1100,6 +1127,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 3788 1700 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 3750 1850 50  0001 C CNN
 F 4 "Taiyo Yuden" H 1250 350 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H 1250 350 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 3750 1850 50  0001 C CNN "1b2-bom-key"
 	1    3750 1850
 	1    0    0    -1  
 $EndComp
@@ -1151,6 +1179,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 4788 1700 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 4750 1850 50  0001 C CNN
 F 4 "Taiyo Yuden" H 2250 350 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H 2250 350 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 4750 1850 50  0001 C CNN "1b2-bom-key"
 	1    4750 1850
 	1    0    0    -1  
 $EndComp
@@ -1191,6 +1220,7 @@ F 0 "U27" H 4400 3500 50  0000 L CNN
 F 1 "SN74LVC1T45DRL" H 4400 3400 50  0000 L CNN
 F 2 "Glasgow:SOT-563" H 4250 3350 50  0001 C CNN
 F 3 "http://www.ti.com/lit/ds/symlink/sn74lvc1t45.pdf" H 3350 3200 50  0001 C CNN
+F 4 "ic-sot563-sn74lvc1t45drl" H 4250 3850 50  0001 C CNN "1b2-bom-key"
 	1    4250 3850
 	1    0    0    -1  
 $EndComp
@@ -1208,6 +1238,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 3788 3300 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 3750 3450 50  0001 C CNN
 F 4 "Taiyo Yuden" H 1250 1950 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H 1250 1950 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 3750 3450 50  0001 C CNN "1b2-bom-key"
 	1    3750 3450
 	1    0    0    -1  
 $EndComp
@@ -1259,6 +1290,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 4788 3300 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 4750 3450 50  0001 C CNN
 F 4 "Taiyo Yuden" H 2250 1950 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H 2250 1950 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 4750 3450 50  0001 C CNN "1b2-bom-key"
 	1    4750 3450
 	1    0    0    -1  
 $EndComp
@@ -1299,6 +1331,7 @@ F 0 "U28" H 4400 5100 50  0000 L CNN
 F 1 "SN74LVC1T45DRL" H 4400 5000 50  0000 L CNN
 F 2 "Glasgow:SOT-563" H 4250 4950 50  0001 C CNN
 F 3 "http://www.ti.com/lit/ds/symlink/sn74lvc1t45.pdf" H 3350 4800 50  0001 C CNN
+F 4 "ic-sot563-sn74lvc1t45drl" H 4250 5450 50  0001 C CNN "1b2-bom-key"
 	1    4250 5450
 	1    0    0    -1  
 $EndComp
@@ -1316,6 +1349,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 3788 4900 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 3750 5050 50  0001 C CNN
 F 4 "Taiyo Yuden" H 1250 3550 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H 1250 3550 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 3750 5050 50  0001 C CNN "1b2-bom-key"
 	1    3750 5050
 	1    0    0    -1  
 $EndComp
@@ -1367,6 +1401,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 4788 4900 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 4750 5050 50  0001 C CNN
 F 4 "Taiyo Yuden" H 2250 3550 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H 2250 3550 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 4750 5050 50  0001 C CNN "1b2-bom-key"
 	1    4750 5050
 	1    0    0    -1  
 $EndComp
@@ -1407,6 +1442,7 @@ F 0 "U29" H 4400 6700 50  0000 L CNN
 F 1 "SN74LVC1T45DRL" H 4400 6600 50  0000 L CNN
 F 2 "Glasgow:SOT-563" H 4250 6550 50  0001 C CNN
 F 3 "http://www.ti.com/lit/ds/symlink/sn74lvc1t45.pdf" H 3350 6400 50  0001 C CNN
+F 4 "ic-sot563-sn74lvc1t45drl" H 4250 7050 50  0001 C CNN "1b2-bom-key"
 	1    4250 7050
 	1    0    0    -1  
 $EndComp
@@ -1424,6 +1460,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 3788 6500 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 3750 6650 50  0001 C CNN
 F 4 "Taiyo Yuden" H 1250 5150 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H 1250 5150 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 3750 6650 50  0001 C CNN "1b2-bom-key"
 	1    3750 6650
 	1    0    0    -1  
 $EndComp
@@ -1475,6 +1512,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 4788 6500 50  0001 C CNN
 F 3 "https://www.mouser.hk/datasheet/2/396/mlcc02_e-1307760.pdf" H 4750 6650 50  0001 C CNN
 F 4 "Taiyo Yuden" H 2250 5150 50  0001 C CNN "Mfg"
 F 5 "TMK107BJ154KA-T" H 2250 5150 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 4750 6650 50  0001 C CNN "1b2-bom-key"
 	1    4750 6650
 	1    0    0    -1  
 $EndComp
@@ -1538,11 +1576,11 @@ AR Path="/5AFBDC9E/5B586EFA" Ref="RN4"  Part="1"
 AR Path="/5C7B59B0/5C9E337E/5B586EFA" Ref="RN5"  Part="1" 
 AR Path="/5C7B59B0/5C9E338E/5B586EFA" Ref="RN4"  Part="1" 
 F 0 "RN4" V 5475 2800 50  0000 C CNN
-F 1 "R_Pack08" V 5474 2800 50  0001 C CNN
+F 1 "100" V 5474 2800 50  0001 C CNN
 F 2 "Resistor_SMD:R_Array_Convex_8x0602" V 6475 2800 50  0001 C CNN
 F 3 "~" H 6000 2800 50  0001 C CNN
-F 4 "" H 2850 -450 50  0001 C CNN "Mfg"
-F 5 "TBD" H 2850 -450 50  0001 C CNN "MPN"
+F 4 "TBD" H 2850 -450 50  0001 C CNN "MPN"
+F 5 "res-0602cv-array-8-100" H 6000 2800 50  0001 C CNN "1b2-bom-key"
 	1    6000 2800
 	0    1    1    0   
 $EndComp
@@ -1571,11 +1609,11 @@ AR Path="/5AFBDC9E/5B5A19A9" Ref="RN3"  Part="1"
 AR Path="/5C7B59B0/5C9E337E/5B5A19A9" Ref="RN1"  Part="1" 
 AR Path="/5C7B59B0/5C9E338E/5B5A19A9" Ref="RN3"  Part="1" 
 F 0 "RN3" V 525 2800 50  0000 C CNN
-F 1 "R_Pack08" V 524 2800 50  0001 C CNN
+F 1 "100" V 524 2800 50  0001 C CNN
 F 2 "Resistor_SMD:R_Array_Convex_8x0602" V 1525 2800 50  0001 C CNN
 F 3 "~" H 1050 2800 50  0001 C CNN
-F 4 "" H -2100 -450 50  0001 C CNN "Mfg"
-F 5 "TBD" H -2100 -450 50  0001 C CNN "MPN"
+F 4 "TBD" H -2100 -450 50  0001 C CNN "MPN"
+F 5 "res-0602cv-array-8-100" H 1050 2800 50  0001 C CNN "1b2-bom-key"
 	1    1050 2800
 	0    1    1    0   
 $EndComp
@@ -1657,6 +1695,7 @@ F 0 "U5" H 6300 4400 50  0000 L CNN
 F 1 "PCA6408APW" H 6700 4400 50  0000 L CNN
 F 2 "Package_SO:TSSOP-16_4.4x5mm_P0.65mm" H 7600 4500 50  0001 C CNN
 F 3 "https://www.nxp.com/docs/en/data-sheet/PCA6408A.pdf" H 6750 4950 50  0001 C CNN
+F 4 "ic-tssop16-pca6408apw" H 6650 5050 50  0001 C CNN "1b2-bom-key"
 	1    6650 5050
 	1    0    0    -1  
 $EndComp
@@ -1673,6 +1712,7 @@ F 1 "10k" H 6970 4495 50  0000 R CNN
 F 2 "Resistor_SMD:R_Array_Convex_8x0602" V 7925 4450 50  0001 C CNN
 F 3 "~" H 7450 4450 50  0001 C CNN
 F 4 "TBD" H 4300 1200 50  0001 C CNN "MPN"
+F 5 "res-0602cv-array-8-10k" H 7450 4450 50  0001 C CNN "1b2-bom-key"
 	1    7450 4450
 	-1   0    0    1   
 $EndComp
@@ -1881,6 +1921,7 @@ F 0 "J6" V 8467 3696 50  0000 C CNN
 F 1 "Conn_01x08" V 8376 3696 50  0000 C CNN
 F 2 "Connector_PinSocket_1.27mm:PinSocket_1x08_P1.27mm_Vertical" H 8250 3750 50  0001 C CNN
 F 3 "~" H 8250 3750 50  0001 C CNN
+F 4 "conn-th-005in-8-1-rec" H 8250 3750 50  0001 C CNN "1b2-bom-key"
 	1    8250 3750
 	1    0    0    -1  
 $EndComp
@@ -1918,6 +1959,7 @@ F 0 "J7" V 8475 4975 50  0000 L CNN
 F 1 "Conn_01x08" V 8375 4775 50  0000 L CNN
 F 2 "Connector_PinSocket_1.27mm:PinSocket_1x08_P1.27mm_Vertical" H 8250 5050 50  0001 C CNN
 F 3 "~" H 8250 5050 50  0001 C CNN
+F 4 "conn-th-005in-8-1-rec" H 8250 5050 50  0001 C CNN "1b2-bom-key"
 	1    8250 5050
 	1    0    0    -1  
 $EndComp
@@ -1975,6 +2017,7 @@ F 2 "Capacitor_SMD:C_0603_1608Metric_Pad1.05x0.95mm_HandSolder" H 10488 5500 50 
 F 3 "https://www.mouser.com/datasheet/2/400/lcc_commercial_general_en-837201.pdf" H 10450 5650 50  0001 C CNN
 F 4 "Taiyo Yuden" H 7150 4150 50  0001 C CNN "Mfg"
 F 5 "LMK107BJ475KAHT" H 7150 4150 50  0001 C CNN "MPN"
+F 6 "cap-cer-0603-4u7" H 10450 5650 50  0001 C CNN "1b2-bom-key"
 	1    10450 5650
 	1    0    0    -1  
 $EndComp
@@ -2033,6 +2076,7 @@ F 2 "Capacitor_SMD:C_0603_1608Metric_Pad1.05x0.95mm_HandSolder" H 8538 5500 50  
 F 3 "https://www.mouser.com/datasheet/2/400/lcc_commercial_general_en-837201.pdf" H 8500 5650 50  0001 C CNN
 F 4 "Taiyo Yuden" H 5200 4150 50  0001 C CNN "Mfg"
 F 5 "LMK107BJ475KAHT" H 5200 4150 50  0001 C CNN "MPN"
+F 6 "cap-cer-0603-4u7" H 8500 5650 50  0001 C CNN "1b2-bom-key"
 	1    8500 5650
 	1    0    0    -1  
 $EndComp
@@ -2092,6 +2136,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 6888 4050 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/400/lcc_commercial_general_en-837201.pdf" H 6850 4200 50  0001 C CNN
 F 4 "Taiyo Yuden" H 3550 2700 50  0001 C CNN "Mfg"
 F 5 "LMK107BJ475KAHT" H 3550 2700 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 6850 4200 50  0001 C CNN "1b2-bom-key"
 	1    6850 4200
 	1    0    0    -1  
 $EndComp
@@ -2145,6 +2190,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 9530 2000 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/447/PYu-AC_51_RoHS_L_6-1152827.pdf" H 9600 2000 50  0001 C CNN
 F 4 "Yageo" H 3450 -2950 50  0001 C CNN "Mfg"
 F 5 "RC0603FR-0759KL" H 3450 -2950 50  0001 C CNN "MPN"
+F 6 "res-0402-1k" H 9600 2000 50  0001 C CNN "1b2-bom-key"
 	1    9600 2000
 	-1   0    0    1   
 $EndComp
@@ -2205,6 +2251,7 @@ F 2 "Capacitor_SMD:C_0402_1005Metric" H 6388 4050 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/400/lcc_commercial_general_en-837201.pdf" H 6350 4200 50  0001 C CNN
 F 4 "Taiyo Yuden" H 3050 2700 50  0001 C CNN "Mfg"
 F 5 "LMK107BJ475KAHT" H 3050 2700 50  0001 C CNN "MPN"
+F 6 "cap-cer-0402-100n" H 6350 4200 50  0001 C CNN "1b2-bom-key"
 	1    6350 4200
 	-1   0    0    -1  
 $EndComp
@@ -2256,6 +2303,7 @@ F 2 "Resistor_SMD:R_0402_1005Metric" V 5780 4500 50  0001 C CNN
 F 3 "https://www.mouser.com/datasheet/2/447/PYu-RC_Group_51_RoHS_L_9-1314892.pdf" H 5850 4500 50  0001 C CNN
 F 4 "Yageo" H 1500 1250 50  0001 C CNN "Mfg"
 F 5 "RC0603FR-1010KL" H 1500 1250 50  0001 C CNN "MPN"
+F 6 "res-0402-10k" H 5850 4500 50  0001 C CNN "1b2-bom-key"
 	1    5850 4500
 	-1   0    0    1   
 $EndComp
@@ -2360,6 +2408,7 @@ F 0 "U33" H 7520 1696 50  0000 R CNN
 F 1 "MG2048" H 7520 1605 50  0000 R CNN
 F 2 "Glasgow:UDFN-18-3EP_5.5x1.5mm_P0.5mm_EP0.5x0.5mm" H 8190 2090 50  0001 C CNN
 F 3 "https://www.onsemi.com/pub/Collateral/MG2040-D.PDF" H 7800 1725 50  0001 C CNN
+F 4 "ic-udfn18-mg2048" H 7750 1650 50  0001 C CNN "1b2-bom-key"
 	1    7750 1650
 	-1   0    0    -1  
 $EndComp


### PR DESCRIPTION
This is needed for 1BitSquared production management.