### PR TITLE
RevC1: Added missing component MPN/Mfg values

### DIFF
--- a/hardware/boards/glasgow/glasgow.sch
+++ b/hardware/boards/glasgow/glasgow.sch
@@ -2061,6 +2061,8 @@ F 1 "ICE40HX8K-BG121" H 7500 1800 50  0000 R CNN
 F 2 "Package_BGA:BGA-121_9.0x9.0mm_Layout11x11_P0.8mm_Ball0.4mm_Pad0.35mm_NSMD" H 6800 1700 50  0001 C CNN
 F 3 "http://www.latticesemi.com/Products/FPGAandCPLD/iCE40" H 5950 4150 50  0001 C CNN
 F 4 "ic-ice40hx8k-bg121" H 6800 3150 50  0001 C CNN "1b2-bom-key"
+F 5 "ICE40HX8K-BG121" H 6800 3150 50  0001 C CNN "MPN"
+F 6 "Lattice Semiconductor Corporation" H 6800 3150 50  0001 C CNN "Mfg"
 	3    6800 3150
 	-1   0    0    -1  
 $EndComp
@@ -2073,6 +2075,8 @@ F 1 "ICE40HX8K-BG121" H 6850 4700 50  0000 L CNN
 F 2 "Package_BGA:BGA-121_9.0x9.0mm_Layout11x11_P0.8mm_Ball0.4mm_Pad0.35mm_NSMD" H 7050 3950 50  0001 C CNN
 F 3 "http://www.latticesemi.com/Products/FPGAandCPLD/iCE40" H 6200 6400 50  0001 C CNN
 F 4 "ic-ice40hx8k-bg121" H 7050 5400 50  0001 C CNN "1b2-bom-key"
+F 5 "ICE40HX8K-BG121" H 7050 5400 50  0001 C CNN "MPN"
+F 6 "Lattice Semiconductor Corporation" H 7050 5400 50  0001 C CNN "Mfg"
 	5    7050 5400
 	-1   0    0    -1  
 $EndComp
@@ -2607,7 +2611,7 @@ F 1 "ATECC508A" H 3050 7250 50  0000 R CNN
 F 2 "Package_DFN_QFN:WDFN-8-1EP_3x2mm_P0.5mm_EP1.3x1.4mm" H 2600 7000 50  0001 C CNN
 F 3 "http://ww1.microchip.com/downloads/en/DeviceDoc/20005927A.pdf" H 2600 7000 50  0001 C CNN
 F 4 "Microchip" H 2600 7000 50  0001 C CNN "Mfg"
-F 5 "ATECC508A" H 2600 7000 50  0001 C CNN "MPN"
+F 5 "ATECC508A-MAHDA-T" H 2600 7000 50  0001 C CNN "MPN"
 F 6 "ic-wdfn8-atecc508a" H 2600 7000 50  0001 C CNN "1b2-bom-key"
 	1    2600 7000
 	1    0    0    -1  
@@ -3039,6 +3043,8 @@ F 1 "TLV73312PQDRVRQ1" H 9800 5001 50  0000 C CNN
 F 2 "Glasgow:DFN-6-1EP_2x2mm_P0.65mm_EP1x1.6mm_ThermalVias" H 9800 5075 50  0001 C CIN
 F 3 "http://www.ti.com/lit/ds/symlink/tlv733p-q1.pdf" H 9800 4800 50  0001 C CNN
 F 4 "ic-dfn6-tlv73312pqrdvrq1" H 9800 4750 50  0001 C CNN "1b2-bom-key"
+F 5 "TLV73312PQDRVRQ1" H 9800 4750 50  0001 C CNN "MPN"
+F 6 "Texas Instruments" H 9800 4750 50  0001 C CNN "Mfg"
 	1    9800 4750
 	1    0    0    -1  
 $EndComp
@@ -3051,6 +3057,8 @@ F 1 "TLV75533PDRVR" H 9800 6051 50  0000 C CNN
 F 2 "Glasgow:DFN-6-1EP_2x2mm_P0.65mm_EP1x1.6mm_ThermalVias" H 9800 6125 50  0001 C CIN
 F 3 "http://www.ti.com/lit/ds/symlink/tlv755p.pdf" H 9800 5850 50  0001 C CNN
 F 4 "ic-dfn6-tlv75533pdrvr" H 9800 5800 50  0001 C CNN "1b2-bom-key"
+F 5 "TLV75533PDRVR" H 9800 5800 50  0001 C CNN "MPN"
+F 6 "Texas Instruments" H 9800 5800 50  0001 C CNN "Mfg"
 	1    9800 5800
 	1    0    0    -1  
 $EndComp

--- a/hardware/boards/glasgow/io_banks.sch
+++ b/hardware/boards/glasgow/io_banks.sch
@@ -152,6 +152,8 @@ F 1 "ICE40HX8K-BG121" H 4400 3100 50  0000 L CNN
 F 2 "Package_BGA:BGA-121_9.0x9.0mm_Layout11x11_P0.8mm_Ball0.4mm_Pad0.35mm_NSMD" H 4750 3000 50  0001 C CNN
 F 3 "http://www.latticesemi.com/Products/FPGAandCPLD/iCE40" H 3900 5450 50  0001 C CNN
 F 4 "ic-ice40hx8k-bg121" H 4750 4450 50  0001 C CNN "1b2-bom-key"
+F 5 "ICE40HX8K-BG121" H 4750 4450 50  0001 C CNN "MPN"
+F 6 "Lattice Semiconductor Corporation" H 4750 4450 50  0001 C CNN "Mfg"
 	2    4750 4450
 	-1   0    0    -1  
 $EndComp
@@ -166,6 +168,8 @@ F 1 "ICE40HX8K-BG121" H 7900 2600 50  0000 L CNN
 F 2 "Package_BGA:BGA-121_9.0x9.0mm_Layout11x11_P0.8mm_Ball0.4mm_Pad0.35mm_NSMD" H 8250 2750 50  0001 C CNN
 F 3 "http://www.latticesemi.com/Products/FPGAandCPLD/iCE40" H 7400 5200 50  0001 C CNN
 F 4 "ic-ice40hx8k-bg121" H 8250 4200 50  0001 C CNN "1b2-bom-key"
+F 5 "ICE40HX8K-BG121" H 8250 4200 50  0001 C CNN "MPN"
+F 6 "Lattice Semiconductor Corporation" H 8250 4200 50  0001 C CNN "Mfg"
 	4    8250 4200
 	-1   0    0    -1  
 $EndComp
@@ -301,6 +305,8 @@ F 1 "Conn_02x22_Odd_Even" H 10050 5426 50  0000 C CNN
 F 2 "Connector_PinHeader_1.27mm:PinHeader_2x22_P1.27mm_Vertical_SMD" H 10000 4300 50  0001 C CNN
 F 3 "~" H 10000 4300 50  0001 C CNN
 F 4 "conn-smd-005in-22-2-hdr" H 10000 4300 50  0001 C CNN "1b2-bom-key"
+F 5 "FTS-122-01-L-DV" H 10000 4300 50  0001 C CNN "MPN"
+F 6 "Samtec Inc." H 10000 4300 50  0001 C CNN "Mfg"
 	1    10000 4300
 	1    0    0    -1  
 $EndComp
@@ -1425,6 +1431,8 @@ F 1 "ICE40HX8K-BG121" H 950 2700 50  0000 L CNN
 F 2 "Package_BGA:BGA-121_9.0x9.0mm_Layout11x11_P0.8mm_Ball0.4mm_Pad0.35mm_NSMD" H 1300 2800 50  0001 C CNN
 F 3 "http://www.latticesemi.com/Products/FPGAandCPLD/iCE40" H 450 5250 50  0001 C CNN
 F 4 "ic-ice40hx8k-bg121" H 1300 4250 50  0001 C CNN "1b2-bom-key"
+F 5 "ICE40HX8K-BG121" H 1300 4250 50  0001 C CNN "MPN"
+F 6 "Lattice Semiconductor Corporation" H 1300 4250 50  0001 C CNN "Mfg"
 	1    1300 4250
 	-1   0    0    -1  
 $EndComp


### PR DESCRIPTION
4 parts (J5, U8, U30, U36) were missing the MPN/Mfg schematic field values which help with automated Bill-of-Materials generation.

Also added the full variant part number for the ATECC508A. This should resolve #141 