### PR TITLE
cli: make output legible on black-on-white terminals too

### DIFF
--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -346,9 +346,9 @@ def _applet(revision, args):
 
 class TerminalFormatter(logging.Formatter):
     LOG_COLORS = {
-        "TRACE"   : "\033[37m",
+        "TRACE"   : "\033[0m",
         "DEBUG"   : "\033[36m",
-        "INFO"    : "\033[1;37m",
+        "INFO"    : "\033[1m",
         "WARNING" : "\033[1;33m",
         "ERROR"   : "\033[1;31m",
         "CRITICAL": "\033[1;41m",


### PR DESCRIPTION
If you happen to use a black-on-white terminal, the regular output (info level) is white on white -> invisible. 

I tried that this afternoon while showing Glasgow on a foreign machine and was wondering why there are just empty lines on the screen and first thought the Glasgow software stack I just installed was somehow broken. While testing a few things I provoked an error and then I saw what was going on. But a new user might be lost at first.

So do not enforce white, just keep the colors as they are by default. This should produce legible
output on white-on-black and black-on-white.

The only remaining problem is the warning level: it uses yellow which is very hard to read on a white background. Maybe change the warning color to red, bold red for errors, no color differentiation for critical (bold red too as they are now)?