### PR TITLE
Add comments about IO-buffer enabling being only on revAB

### DIFF
--- a/firmware/dac_ldo.c
+++ b/firmware/dac_ldo.c
@@ -15,17 +15,17 @@ static const struct buffer_desc buffers[] = {
 
 void iobuf_init_dac_ldo() {
   // Configure I/O buffer pins as open-source/open-drain; they have 100k pulls
-  IOD  = IOD & ~((1<<PIND_ENVA)|(1<<PIND_ENVB)) | (1<<PIND_OEQ_N);
-  OED |=        ((1<<PIND_ENVA)|(1<<PIND_ENVB)  | (1<<PIND_OEQ_N));
+  IOD  = IOD & ~((1<<PIND_ENVA)|(1<<PIND_ENVB)) | (1<<PIND_OEQ_N_REVAB);
+  OED |=        ((1<<PIND_ENVA)|(1<<PIND_ENVB)  | (1<<PIND_OEQ_N_REVAB));
 
   // Enable I/O buffers, just existing on revAB
-  IOD &= ~ (1<<PIND_OEQ_N);
+  IOD &= ~ (1<<PIND_OEQ_N_REVAB);
 }
 
 void iobuf_enable(bool on) {
   // I/O buffers just existing on revAB, pin is unconnected on revC
-  if(on) IOD &= ~(1<<PIND_OEQ_N);
-  else   IOD |=  (1<<PIND_OEQ_N);
+  if(on) IOD &= ~(1<<PIND_OEQ_N_REVAB);
+  else   IOD |=  (1<<PIND_OEQ_N_REVAB);
 }
 
 static bool dac_start(uint8_t mask, bool read) {

--- a/firmware/dac_ldo.c
+++ b/firmware/dac_ldo.c
@@ -18,11 +18,12 @@ void iobuf_init_dac_ldo() {
   IOD  = IOD & ~((1<<PIND_ENVA)|(1<<PIND_ENVB)) | (1<<PIND_OEQ_N);
   OED |=        ((1<<PIND_ENVA)|(1<<PIND_ENVB)  | (1<<PIND_OEQ_N));
 
-  // Enable I/O buffers
+  // Enable I/O buffers, just existing on revAB
   IOD &= ~ (1<<PIND_OEQ_N);
 }
 
 void iobuf_enable(bool on) {
+  // I/O buffers just existing on revAB, pin is unconnected on revC
   if(on) IOD &= ~(1<<PIND_OEQ_N);
   else   IOD |=  (1<<PIND_OEQ_N);
 }

--- a/firmware/glasgow.h
+++ b/firmware/glasgow.h
@@ -35,7 +35,7 @@ enum {
 #define PIND_LED_ACT          4
 #define PIND_LED_ERR          5
 #define PIND_ENVB             6
-#define PIND_OEQ_N            7
+#define PIND_OEQ_N_REVAB      7
 
 enum {
   // I2C addresses (unshifted)

--- a/software/glasgow/applet/internal/selftest/__init__.py
+++ b/software/glasgow/applet/internal/selftest/__init__.py
@@ -137,9 +137,15 @@ class SelfTestApplet(GlasgowApplet, name="selftest"):
             if mode in ("pins-int", "pins-ext", "pins-pull"):
                 if mode == "pins-int":
                     await device.set_voltage("AB", 0)
+
+                    # disable the IO-buffers (FXMA108) on revAB to not influence the external ports
+                    # no effect on other revisions
                     await device._iobuf_enable(False)
                 elif mode in ("pins-ext", "pins-pull"):
                     await device.set_voltage("AB", 3.3)
+
+                    # re-enable the IO-buffers (FXMA108) on revAB
+                    # no effect on other revisions
                     await device._iobuf_enable(True)
                 use_pull = (mode == "pins-pull")
 
@@ -172,6 +178,9 @@ class SelfTestApplet(GlasgowApplet, name="selftest"):
                     report.append((mode, "fail short: {}".format(" ".join(sorted(pins)))))
 
                 await device.set_voltage("AB", 0)
+
+                # re-enable the IO-buffers (FXMA108) on revAB, they are on by default
+                # no effect on other revisions
                 await device._iobuf_enable(True)
 
             if mode == "pins-loop":

--- a/software/glasgow/device/hardware.py
+++ b/software/glasgow/device/hardware.py
@@ -363,6 +363,8 @@ class GlasgowHardwareDevice:
             await self.download_bitstream(plan.execute(), plan.bitstream_id)
 
     async def _iobuf_enable(self, on):
+        # control the IO-buffers (FXMA108) on revAB, they are on by default
+        # no effect on other revisions
         await self.control_write(usb1.REQUEST_TYPE_VENDOR, REQ_IOBUF_ENABLE, on, 0, [])
 
     @staticmethod


### PR DESCRIPTION
PIND_OEQ_N, USB_REQ_IOBUF_ENABLE and device._iobuf_enable is only relevant on revAB, on revC all of this has no effect. 

This can be confusing if you don't know about these rev differences. So add comments to the source explaining it.

