### PR TITLE
Add kitspace.yml for rev C1

### DIFF
--- a/kitspace.yml
+++ b/kitspace.yml
@@ -1,0 +1,5 @@
+gerbers: hardware/boards/glasgow/revC1
+bom: hardware/boards/glasgow/revC1/bom.csv
+color: blue
+summary: Glasgow Debug Tool rev C1
+site: https://github.com/GlasgowEmbedded/glasgow


### PR DESCRIPTION
Add kitspace yaml to facilitate ordering rev C1 boards and components via https://kitspace.org