### PR TITLE
Add "eda" field to kitspace.yml

### DIFF
--- a/kitspace.yml
+++ b/kitspace.yml
@@ -5,3 +5,6 @@ multi:
         color: green
         summary: Glasgow Debug Tool Revision C1
         site: https://github.com/GlasgowEmbedded/glasgow/tree/master/hardware/boards/glasgow/revC1
+        eda:
+            type: kicad
+            pcb: hardware/boards/glasgow/glasgow.kicad_pcb


### PR DESCRIPTION
This will give you a KiCad Interactive HTML BOM on kitspace.org. It does need to use the KiCad file rather than the gerbers so it might not be completly the right version (revC1) but I don't know how you want to handle that. 