### PR TITLE
Add kitspace.yml to revC1 branch

### DIFF
--- a/kitspace.yml
+++ b/kitspace.yml
@@ -1,0 +1,10 @@
+multi:
+    Glasgow_revC1:
+        gerbers: hardware/boards/glasgow/revC1
+        bom: hardware/boards/glasgow/revC1/bom.csv
+        color: green
+        summary: Glasgow Debug Tool Revision C1
+        site: https://github.com/GlasgowEmbedded/glasgow/tree/master/hardware/boards/glasgow/revC1
+        eda:
+            type: kicad
+            pcb: hardware/boards/glasgow/glasgow.kicad_pcb


### PR DESCRIPTION
This allows us to pin the Kitspace page to revC1 for now and the kicad_pcb file can be used for the upcoming IBOM feature.