### PR TITLE
cli: error when no applet is specified

### DIFF
--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -333,6 +333,10 @@ def _applet(revision, args):
     target = GlasgowHardwareTarget(revision=revision,
                                    multiplexer_cls=DirectMultiplexer,
                                    with_analyzer=hasattr(args, "trace") and args.trace)
+    if not args.applet:
+        logger.error("no applet specified")
+        raise SystemExit()
+
     applet = GlasgowApplet.all_applets[args.applet]()
     try:
         message = ("applet requires device rev{}+, rev{} found"


### PR DESCRIPTION
I am not sure how this came to be but apparently args.applet could be None, so we
need to check its value.

```
Traceback (most recent call last):
  File "/home/anubis/.virtualenvs/glasgow/bin/glasgow", line 11, in <module>
    load_entry_point('glasgow', 'console_scripts', 'glasgow')()
  File "/home/anubis/git/glasgow/software/glasgow/cli.py", line 803, in main
    exit(loop.run_until_complete(_main()))
  File "/usr/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/home/anubis/git/glasgow/software/glasgow/cli.py", line 490, in _main
    target, applet = _applet(device.revision, args)
  File "/home/anubis/git/glasgow/software/glasgow/cli.py", line 336, in _applet
    applet = GlasgowApplet.all_applets[args.applet]()
KeyError: None
```

Signed-off-by: Filipe Laíns <lains@archlinux.org>