### PR TITLE
applet.internal.selftest: disable voltage output after test completes

### DIFF
--- a/software/glasgow/applet/internal/selftest/__init__.py
+++ b/software/glasgow/applet/internal/selftest/__init__.py
@@ -219,6 +219,8 @@ class SelfTestApplet(GlasgowApplet, name="selftest"):
                                                  "Vio={:.2f} Vsense={:.2f}"
                                                  .format(port, vout, vin)))
 
+                    await device.set_voltage(port, 0)
+
             if mode == "loopback":
                 iface_1 = await device.demultiplexer.claim_interface(
                     self, self.mux_interface_1, None)


### PR DESCRIPTION
I've noticed that after running `glasgow run selftest voltage`, the outputs are left enabled.

This patch will disable the outputs after the test completes for each port.