### PR TITLE
applet.internal.selftest: permit pin mapping to be direct instead of swapped

### DIFF
--- a/software/glasgow/applet/internal/selftest/__init__.py
+++ b/software/glasgow/applet/internal/selftest/__init__.py
@@ -54,7 +54,7 @@ class SelfTestApplet(GlasgowApplet, name="selftest"):
         * pins-pull: detects faults in pull resistor circuits
           (all pins on all I/O connectors must be floating)
         * pins-loop: detect faults anywhere in the I/O ciruits
-          (pins A0:A7 must be connected to B7:B0)
+          (pins A0:A7 must be connected to B0:B7)
         * voltage: detect ADC, DAC or LDO faults
           (on all ports, Vsense and Vio pins must be connected)
         * loopback: detect faults in USB FIFO traces
@@ -193,7 +193,7 @@ class SelfTestApplet(GlasgowApplet, name="selftest"):
                         i, desc = await check_pins(o, o, use_pull=False)
                         self.logger.debug("%s: %s", mode, desc)
 
-                        e = (1 << bit) | (1 << (15 - bit))
+                        e = ((o << 8) | o) if (o & 0xFF) else (o | (o >> 8))
                         if i != e:
                             passed = False
                             pins = decode_pins(i | e)


### PR DESCRIPTION
Currently, the `glasgow run selftest pins-loop` test requires that pins are mapped as opposites / swapped (i.e: A0:A7 to B7:B0).
I don't think it's possible to achieve the required mapping with ribbon cables, as each port's data pins would end up on the opposite port's ground pins (in a cable where pin 1 maps to pin 20 on the other end).

As I have direct cables to hand (where pin 1 maps to pin 1 on both ends), I'd like to use this to perform the self test, instead of 8x jumpers.

This patch adds a `--pinmap-straight` flag that permits the "_straight-through_" A0:A7 -> B0:B7 mapping, instead of the "_straight across the board_" mapping that currently stands.

It's not likely to be beneficial for production runs where a test jig is available, but should help those who don't have access to one, and are bringing up / testing a non-trivial number of boards.
