### PR TITLE
Method to list connected Glasgow boards

### DIFF
--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -325,6 +325,10 @@ def get_argparser():
         default=datetime.now().strftime("%Y%m%dT%H%M%SZ"),
         help="serial number in ISO 8601 format (if not specified: %(default)s)")
 
+    p_list = subparsers.add_parser(
+        "list", formatter_class=TextHelpFormatter,
+        help="list devices connected to the system")
+
     return parser
 
 
@@ -439,6 +443,11 @@ async def _main():
             elif args.action == "factory":
                 device = GlasgowHardwareDevice(args.serial, firmware_filename,
                                                _factory_rev=args.factory_rev)
+            elif args.action == "list":
+                serial_list = GlasgowHardwareDevice.get_serial_list(firmware_filename)
+                for serial in sorted(serial_list):
+                    print(serial)
+                return 0
             else:
                 device = GlasgowHardwareDevice(args.serial, firmware_filename)
 

--- a/software/glasgow/device/hardware.py
+++ b/software/glasgow/device/hardware.py
@@ -54,9 +54,8 @@ class _PollerThread(threading.Thread):
 
 
 class GlasgowHardwareDevice:
-    def __init__(self, serial=None, firmware_filename=None, *, _factory_rev=None):
-        usb_context = usb1.USBContext()
-
+    @staticmethod
+    def _enumerate_devices(usb_context, firmware_filename=None, _factory_rev=None):
         firmware = None
         handles  = {}
         discover = True
@@ -112,6 +111,12 @@ class GlasgowHardwareDevice:
             if discover:
                 # Give every device we loaded firmware onto a bit of time to reenumerate.
                 time.sleep(1.0)
+
+        return handles
+
+    def __init__(self, serial=None, firmware_filename=None, *, _factory_rev=None):
+        usb_context = usb1.USBContext()
+        handles = self._enumerate_devices(usb_context, firmware_filename, _factory_rev)
 
         if len(handles) == 0:
             raise GlasgowDeviceError("device not found")

--- a/software/glasgow/device/hardware.py
+++ b/software/glasgow/device/hardware.py
@@ -114,6 +114,12 @@ class GlasgowHardwareDevice:
 
         return handles
 
+    @classmethod
+    def get_serial_list(cls, firmware_filename=None, *, _factory_rev=None):
+        with usb1.USBContext() as usb_context:
+            handles = cls._enumerate_devices(usb_context, firmware_filename, _factory_rev)
+        return list(handles.keys())
+
     def __init__(self, serial=None, firmware_filename=None, *, _factory_rev=None):
         usb_context = usb1.USBContext()
         handles = self._enumerate_devices(usb_context, firmware_filename, _factory_rev)


### PR DESCRIPTION
This patchset addresses #206.

I have broken `GlasgowHardwareDevice.__init__()` in half, to better support acquiring a list of Glasgow boards, and maintaining the existing firmware loading and filtering of USB devices.

The output of `glasgow list` defaults to a text-based table - I've implemented a very simplistic table using only `str.format()` to avoid adding any dependencies.

If the user wishes, `glasgow list -j` can be used to get output as JSON instead, which can then in turn be paired with tools like `jq` to perform more complex filtering.

Examples:

```
venv:$ glasgow list
Serial              : Rev   : USB Path
------------------- : ----- : --------
C1-20200923T174926Z : revC1 : 1-4.4.4
C1-20200923T190627Z : revC1 : 1-2
```

```
venv:$ glasgow list -j
[{"serial": "C1-20200923T174926Z", "revision": "C1", "usb_path": "1-4.4.4"}, {"serial": "C1-20200923T190627Z", "revision": "C1", "usb_path": "1-2"}]
```

```
venv:$ glasgow list -j | jq -r '.[] | select(.usb_path == "1-2") | .serial'
C1-20200923T190627Z
```