### PR TITLE
REPL script support

### DIFF
--- a/examples/i2c-pcf8574.py
+++ b/examples/i2c-pcf8574.py
@@ -1,0 +1,16 @@
+"""
+An example of a script that can be used with the run-script mode.
+
+This will read and write the pins of a PCF8574. Once connected, run:
+
+    glasgow run-script i2c-pcf8574.py i2c-initiator -V 3.3
+"""
+
+# read pin values
+print('I/O pin state: 0b{:08b}'.format((await iface.read(0x20, 1))[0]))
+
+# write pin values
+await iface.write(0x20, [ 0x55 ])
+
+# power down the device after use
+await device.set_voltage("AB", 0)

--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import ast
 import logging
 import argparse
 import textwrap
@@ -142,16 +143,16 @@ def get_argparser():
                     "tests", metavar="TEST", nargs="*",
                     help="test cases to run")
 
-            if mode in ("build", "run", "run-repl"):
+            if mode in ("build", "run", "run-repl", "run-script"):
                 access_args = DirectArguments(applet_name=applet_name,
                                               default_port="AB",
                                               pin_count=16)
-                if mode in ("run", "run-repl"):
+                if mode in ("run", "run-repl", "run-script"):
                     g_applet_build = p_applet.add_argument_group("build arguments")
                     applet.add_build_arguments(g_applet_build, access_args)
                     g_applet_run = p_applet.add_argument_group("run arguments")
                     applet.add_run_arguments(g_applet_run, access_args)
-                    if mode != "run-repl":
+                    if mode not in ( "run-repl", "run-script" ):
                         # FIXME: this makes it impossible to add subparsers in applets
                         # g_applet_interact = p_applet.add_argument_group("interact arguments")
                         # applet.add_interact_arguments(g_applet_interact)
@@ -244,6 +245,15 @@ def get_argparser():
         help="run an applet and open a REPL to use its low-level interface")
     add_run_args(p_run_repl)
     add_applet_arg(p_run_repl, mode="run-repl")
+
+    p_run_script = subparsers.add_parser(
+        "run-script", formatter_class=TextHelpFormatter,
+        help="run an applet and execute a script against its low-level interface")
+    add_run_args(p_run_script)
+    p_run_script.add_argument(
+        "script", metavar="SCRIPT", type=argparse.FileType("r"),
+        help="the script to run")
+    add_applet_arg(p_run_script, mode="run-script")
 
     p_run_prebuilt = subparsers.add_parser(
         "run-prebuilt", formatter_class=TextHelpFormatter,
@@ -495,12 +505,12 @@ async def _main():
                 print("{}\t{:.2}\t{:.2}"
                       .format(port, vio, vlimit))
 
-        if args.action in ("run", "run-repl", "run-prebuilt"):
+        if args.action in ("run", "run-repl", "run-script", "run-prebuilt"):
             target, applet = _applet(device.revision, args)
             device.demultiplexer = DirectDemultiplexer(device, target.multiplexer.pipe_count)
             plan = target.build_plan()
 
-            if args.action in ("run", "run-repl"):
+            if args.action in ("run", "run-repl", "run-script"):
                 await device.download_target(plan, rebuild=args.rebuild)
             if args.action == "run-prebuilt":
                 bitstream_file = args.bitstream or open("{}.bin".format(args.applet), "rb")
@@ -589,6 +599,12 @@ async def _main():
                         logger.info("dropping to REPL; use 'help(iface)' to see available APIs")
                         await AsyncInteractiveConsole(locals={"iface":iface},
                             run_callback=device.demultiplexer.flush).interact()
+
+                    if args.action == "run-script":
+                        c = compile(args.script.read(), filename=args.script.name, mode="exec",
+                            flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT)
+                        await eval(c, {"iface":iface, "device":device})
+
                 except GlasgowAppletError as e:
                     applet.logger.error(str(e))
                 except asyncio.CancelledError:

--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -597,7 +597,7 @@ async def _main():
                             logger.warn("applet provides customized REPL(s); consider using `run "
                                         "{} ...-repl` subcommands".format(applet.name))
                         logger.info("dropping to REPL; use 'help(iface)' to see available APIs")
-                        await AsyncInteractiveConsole(locals={"iface":iface},
+                        await AsyncInteractiveConsole(locals={"iface":iface, "device":device},
                             run_callback=device.demultiplexer.flush).interact()
 
                     if args.action == "run-script":


### PR DESCRIPTION
This patchset will add support for `run-repl --script ${FILENAME}`, permitting a user to write a python script to directly interface with the `iface`.

I have also included an example script that will communicate with a BMP085 temperature and pressure sensor.

I wonder if it might also be beneficial for the script to have access to `device`, for functions like `device.set_voltage()`. This would permit power cycling the DUT from the script if / when necessary.