### PR TITLE
Add support for Out-of-Tree applets

### DIFF
--- a/examples/out-of-tree-applet/glasgow_oot/__init__.py
+++ b/examples/out-of-tree-applet/glasgow_oot/__init__.py
@@ -1,0 +1,1 @@
+from .uart import CustomUARTApplet

--- a/examples/out-of-tree-applet/glasgow_oot/uart.py
+++ b/examples/out-of-tree-applet/glasgow_oot/uart.py
@@ -1,0 +1,9 @@
+from glasgow.applet.interface.uart import UARTApplet
+
+# Don't forget to set a new name if you're re-implementing an existing applet!
+class CustomUARTApplet(UARTApplet, name="uart-custom"):
+    async def interact(self, *args, **kwargs):
+        print("Custom UART ready!")
+        ret = await super().interact(*args, **kwargs)
+        print("Custom UART shutdown...")
+        return ret

--- a/examples/out-of-tree-applet/setup.py
+++ b/examples/out-of-tree-applet/setup.py
@@ -1,0 +1,19 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="glasgow-oot",
+    description="Example Out-Of-Tree Applet for Glasgow",
+    license="0-clause BSD License",
+    python_requires="~=3.7",
+    install_requires=[
+        "glasgow",
+    ],
+    packages=find_packages(),
+    entry_points={
+        "glasgow": [
+            # NOTE: You don't need to specifically import the class... so long as
+            #       it is loaded (e.g: via an import), the applet will be available.
+            "glasgow_oot = glasgow_oot",
+        ],
+    },
+)

--- a/software/glasgow/applet/__init__.py
+++ b/software/glasgow/applet/__init__.py
@@ -23,6 +23,10 @@ class GlasgowAppletMeta(ABCMeta):
             namespace["name"] = name
 
         cls = ABCMeta.__new__(metacls, clsname, bases, namespace, **kwargs)
+
+        if not namespace['__module__'].startswith('glasgow.applet.'):
+            cls.help += ' [Out-of-Tree]'
+
         if name is not None:
             metacls.all_applets[name] = cls
         return cls

--- a/software/glasgow/applet/external.py
+++ b/software/glasgow/applet/external.py
@@ -1,4 +1,6 @@
+import os
 import pkg_resources
 
-for entry_point in pkg_resources.iter_entry_points('glasgow'):
-    entry_point.load()
+if "GLASGOW_DISABLE_OOT" not in os.environ:
+    for entry_point in pkg_resources.iter_entry_points('glasgow'):
+        entry_point.load()

--- a/software/glasgow/applet/external.py
+++ b/software/glasgow/applet/external.py
@@ -1,0 +1,4 @@
+import pkg_resources
+
+for entry_point in pkg_resources.iter_entry_points('glasgow'):
+    entry_point.load()

--- a/software/glasgow/applet/external.py
+++ b/software/glasgow/applet/external.py
@@ -1,6 +1,17 @@
 import os
+import sys
+import logging
+import traceback
 import pkg_resources
+
+logger = logging.getLogger(__name__)
 
 if "GLASGOW_DISABLE_OOT" not in os.environ:
     for entry_point in pkg_resources.iter_entry_points('glasgow'):
-        entry_point.load()
+        try:
+            entry_point.load()
+        except Exception as e:
+            exc_type, exc_obj, exc_tb = sys.exc_info()
+            exc_frame = traceback.extract_tb(exc_tb)[-1]
+            exc_source = "{}:{}".format(exc_frame.filename, exc_frame.lineno)
+            logger.error("failed to load external applet: %s: %s: %s", entry_point.name, exc_source, e)

--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -74,7 +74,9 @@ class TextHelpFormatter(argparse.HelpFormatter):
 
 
 def create_argparser():
-    parser = argparse.ArgumentParser(formatter_class=TextHelpFormatter)
+    parser = argparse.ArgumentParser(formatter_class=TextHelpFormatter,
+        epilog="Set the GLASGOW_DISABLE_OOT environment variable to disable loading of "
+               "out-of-tree applets")
 
     version = "Glasgow version {version} (Python {python_version})" \
         .format(python_version=".".join(str(n) for n in sys.version_info[:3]),

--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -29,7 +29,7 @@ from .gateware.analyzer import TraceDecoder
 from .device.hardware import VID_QIHW, PID_GLASGOW, GlasgowHardwareDevice
 from .access.direct import *
 from .applet import *
-from .applet import all
+from .applet import all, external
 
 
 # When running as `-m glasgow.cli`, `__name__` is `__main__`, and the real name


### PR DESCRIPTION
It sounded like this was a reasonable idea when we were discussing it the other day... and I think I'd appreciate it!
Fundamentally, this implements the ability to add (or subclass) applets that are stored out-of-tree, and in another package.

A basic example that re-implements the `UARTApplet` is given in `/examples/out-of-tree-applet/`.
I've used the `glasgow` entrypoint for this, but I've not looked to see if that's already used by another project (the package name is free on pypi still, so I feel it's somewhat safe... perhaps "_we_" should grab it?).

Due to the way that merely declaring a subclass of `GlasgowApplet` will register the applet, we don't need to give the specific module / class name in the entry point... so long as it's parsed and loaded it'll be available.

All external applets are tagged `[Out-of-Tree]` in the help output.

Setting `GLASGOW_DISABLE_OOT` in your environment will disable all external applets (may be helpful if/when issues arise).