### PR TITLE
applet: fix repl format conversion

### DIFF
--- a/software/glasgow/applet/__init__.py
+++ b/software/glasgow/applet/__init__.py
@@ -18,7 +18,7 @@ class GlasgowAppletMeta(ABCMeta):
     def __new__(metacls, clsname, bases, namespace, name=None, **kwargs):
         if name is not None:
             if name in metacls.all_applets:
-                raise NameError(f"Applet {name:r} already exists")
+                raise NameError(f"Applet {name!r} already exists")
             namespace["name"] = name
 
         # Any class that overrides interact() no longer has its superclass' custom REPL, so be


### PR DESCRIPTION
While working on #213, I noticed the following error:

```
venv:$ glasgow run --help
Traceback (most recent call last):
  File "/home/attie/proj_local/glasgow/venv/bin/glasgow", line 11, in <module>
    load_entry_point('glasgow', 'console_scripts', 'glasgow')()
  File "/home/attie/proj_local/glasgow/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 489, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/home/attie/proj_local/glasgow/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2852, in load_entry_point
    return ep.load()
  File "/home/attie/proj_local/glasgow/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2443, in load
    return self.resolve()
  File "/home/attie/proj_local/glasgow/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2449, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/home/attie/proj_local/glasgow/glasgow/software/glasgow/cli.py", line 29, in <module>
    from .applet import all, external
  File "/home/attie/proj_local/glasgow/glasgow/software/glasgow/applet/external.py", line 6, in <module>
    entry_point.load()
  File "/home/attie/proj_local/glasgow/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2443, in load
    return self.resolve()
  File "/home/attie/proj_local/glasgow/venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2449, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/home/attie/proj_local/glasgow/glasgow/examples/out-of-tree-applet/glasgow_oot/__init__.py", line 1, in <module>
    from .uart import CustomUARTApplet
  File "/home/attie/proj_local/glasgow/glasgow/examples/out-of-tree-applet/glasgow_oot/uart.py", line 4, in <module>
    class CustomUARTApplet(UARTApplet, name="uart"):
  File "/home/attie/proj_local/glasgow/glasgow/software/glasgow/applet/__init__.py", line 21, in __new__
    raise NameError(f"Applet {name:r} already exists")
ValueError: Unknown format code 'r' for object of type 'str'
```

I suspect that `{name!r}` was intended instead of `{name:r}`?