### PR TITLE
Update SPI signal terms to COPI / CIPO

### DIFF
--- a/software/glasgow/applet/all.py
+++ b/software/glasgow/applet/all.py
@@ -3,7 +3,7 @@ from .internal.benchmark import BenchmarkApplet
 
 from .interface.analyzer import AnalyzerApplet
 from .interface.uart import UARTApplet
-from .interface.spi_master import SPIMasterApplet
+from .interface.spi_controller import SPIControllerApplet
 from .interface.i2c_initiator import I2CInitiatorApplet
 from .interface.i2c_target import I2CTargetApplet
 from .interface.jtag_pinout import JTAGPinoutApplet

--- a/software/glasgow/applet/interface/spi_controller/__init__.py
+++ b/software/glasgow/applet/interface/spi_controller/__init__.py
@@ -328,7 +328,7 @@ class SPIControllerApplet(GlasgowApplet, name="spi-controller"):
             in_fifo=iface.get_in_fifo(auto_flush=False),
             period_cyc=self.derive_clock(input_hz=target.sys_clk_freq,
                                          output_hz=args.frequency * 1000,
-                                         clock_name="master",
+                                         clock_name="sck",
                                          # 2 cyc MultiReg delay from SCK to CIPO requires a 4 cyc
                                          # period with current implementation of SERDES
                                          min_cyc=4),

--- a/software/glasgow/applet/program/ice40_sram/__init__.py
+++ b/software/glasgow/applet/program/ice40_sram/__init__.py
@@ -3,7 +3,7 @@ import asyncio
 import logging
 from nmigen.compat import *
 
-from ...interface.spi_master import SPIMasterApplet
+from ...interface.spi_controller import SPIControllerApplet
 from ... import *
 
 
@@ -43,7 +43,7 @@ class ProgramICE40SRAMInterface:
         await self.lower.write([0] * 16)
 
 
-class ProgramICE40SRAMApplet(SPIMasterApplet, name="program-ice40-sram"):
+class ProgramICE40SRAMApplet(SPIControllerApplet, name="program-ice40-sram"):
     logger = logging.getLogger(__name__)
     help = "program SRAM of iCE40 FPGAs"
     description = """
@@ -55,13 +55,13 @@ class ProgramICE40SRAMApplet(SPIMasterApplet, name="program-ice40-sram"):
         super().add_build_arguments(parser, access, omit_pins=True)
 
         access.add_pin_argument(parser, "sck",   required=True)
-        access.add_pin_argument(parser, "ss",    required=True)
-        access.add_pin_argument(parser, "mosi",  required=True)
+        access.add_pin_argument(parser, "cs",    required=True)
+        access.add_pin_argument(parser, "copi",  required=True)
         access.add_pin_argument(parser, "reset", required=True)
         access.add_pin_argument(parser, "done")
 
     def build(self, target, args):
-        subtarget = super().build(target, args, pins=("sck", "ss", "mosi"))
+        subtarget = super().build(target, args, pins=("sck", "cs", "copi"))
 
         reset_t = self.mux_interface.get_pin(args.pin_reset)
         dut_reset, self.__addr_dut_reset = target.registers.add_rw(1)
@@ -113,5 +113,5 @@ class ProgramICE40SRAMAppletTestCase(GlasgowAppletTestCase, applet=ProgramICE40S
     @synthesis_test
     def test_build(self):
         self.assertBuilds(args=["--pin-reset", "0", "--pin-done", "1",
-                                "--pin-sck",   "2", "--pin-ss",   "3",
-                                "--pin-mosi",  "4"])
+                                "--pin-sck",   "2", "--pin-cs",   "3",
+                                "--pin-copi",  "4"])


### PR DESCRIPTION
As discussed in `#glasgow`, this patch should update the SPI signal terms to COPI / CIPO / CS.

The old terms will no longer be obeyed, and flags such as `--pin-copi` must be used from now on.

I believe I've resolved all references to the old terms, but if there are other places (perhaps implicit) that I've missed please let me know.

Happy to squash into one commit if that would be preferred.