### PR TITLE
applet.video.ws2818_output: add support for LEDs other than RGB

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
 # Catherine owns everything that's not owned by someone else.
 *       @whitequark
 /software/glasgow/applet/video/hub75_output/  @attie
+/software/glasgow/applet/video/ws2812_output/ @attie


### PR DESCRIPTION
This sits on top of #224, and adds the ability to give other pixel formats.

I've backed down from the more complex options, and have opted for a simple lambda function that constructs the final pixel shape, paired with `-f`, e.g:

- `-f RGB-BRG`
- `-f RGB-xBRG` - for use with RGBW LEDs, with the White blanked to zero
- `-f RGBW-WBRG`

```python
pixel_formats = {
    # in-out      in size  out size  format_func
    'RGB-BRG':   (   3,        3,    lambda r,g,b:   Cat(b,r,g)   ),
    'RGB-xBRG':  (   3,        4,    lambda r,g,b:   Cat(Const(0, unsigned(8)),b,r,g) ),
    'RGBW-WBRG': (   4,        4,    lambda r,g,b,w: Cat(w,b,r,g) ),
}
```

```python
p = self.pix_format_func(*pix, self.out_fifo.r_data)
m.d.sync += word.eq(Cat(word[pix_out_bpp:], p))
```