### PR TITLE
factory: allow --force mode to find already flashed devices

### DIFF
--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -793,7 +793,14 @@ async def _main():
                 return 1
 
         if args.action == "factory":
-            device = GlasgowHardwareDevice(args.serial, _factory_rev=args.factory_rev)
+            try:
+                device = GlasgowHardwareDevice(args.serial, _factory_rev=args.factory_rev)
+            except GlasgowDeviceError as e:
+                if args.force and str(e) == "device not found":
+                    # device could already have a revision flashed, search again and accept flashed ones
+                    device = GlasgowHardwareDevice(args.serial, _factory_rev=None)
+                else:
+                    raise
 
             logger.info("reading device configuration")
             header = await device.read_eeprom("fx2", 0, 8 + 4 + GlasgowConfig.size)

--- a/software/glasgow/device/hardware.py
+++ b/software/glasgow/device/hardware.py
@@ -78,9 +78,13 @@ class GlasgowHardwareDevice:
                     if (vendor_id, product_id) != (VID_QIHW, PID_GLASGOW):
                         continue
                     revision = GlasgowConfig.decode_revision(device_id & 0xFF)
+                    logger.debug("found rev%s device on bus %03i device %03i", 
+                                 revision, device.getBusNumber(), device.getDeviceAddress())
                 else:
                     if (vendor_id, product_id) != (VID_CYPRESS, PID_FX2):
                         continue
+                    logger.debug("found device with FX2 bare vid+pid on bus %03i device %03i", 
+                                 device.getBusNumber(), device.getDeviceAddress())
                     revision = _factory_rev
 
                 handle = device.open()


### PR DESCRIPTION
Without this change, the call to GlasgowHardwareDevice._enumerate_devices() would only return devices which do not have a revision set yet. This defeats the purpose of the --force flag to allow reflashing them.

Also improve debug logging in GlasgowHardwareDevice._enumerate_devices(). I needed this to find the problem and I think it could help in similar situations.
