### PR TITLE
init kicad-exports to run on all 'wip-revC[0-9]' branches

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+*.csv filter=bom_csv
+*.html filter=bom_html
+*.gbr filter=gerber
+*.gbrjob filter=gbrjob
+*.xml filter=xml
+*.kicad_pcb filter=kicad_pcb_f
+*.net filter=net_filter

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,20 @@
+[filter "bom_csv"]
+	clean = sed -E 's/^BoM Date:.*$/BoM Date:Date/'
+	smudge = sed -E \"s/BoM Date:Date/BoM Date:,`date +\\\"%a %d %b %Y %X %:::z\\\"`/\"
+[filter "bom_html"]
+	clean = sed -E 's/^<tr><td>BoM Date<\\/td><td>.*$/<tr><td>BoM Date<\\/td><td>Date<\\/td><\\/tr>/'
+	smudge = sed -E \"s/<tr><td>BoM Date<\\/td><td>Date<\\/td><\\/tr>/<tr><td>BoM Date<\\/td><td>`date +\\\"%a %d %b %Y %X %:::z\\\"`<\\/td><\\/tr>/\"
+[filter "gerber"]
+	clean = sed -E -e 's/^%TF.CreationDate,.*$/%TF.CreationDate,Date%/' -e 's/^G04 Created by KiCad.*$/G04 Created by KiCad*/'
+	smudge = sed -E \"s/%TF.CreationDate,Date%/%TF.CreationDate,`date +%Y-%m-%dT%H:%M:%S%:z`/\"
+[filter "gbrjob"]
+	clean = sed -E 's/\"CreationDate\":.*/\"CreationDate\":  \"Date\"/'
+	smudge = sed -E \"s/\\\"CreationDate\\\":  \\\"Date\\\"/\\\"CreationDate\\\":  \\\"`date +%Y-%m-%dT%H:%M:%S%:z`\\\"/\"
+[filter "xml"]
+	clean = sed -E -e 's/^        <date>.*<\\/date>/        <date>Date2<\\/date>/' -e 's/^    <date>.*<\\/date>/    <date>Date1<\\/date>/'
+	smudge = sed -E -e \"s/<date>Date1<\\/date>/<date>`date +\\\"%a %d %b %Y %X %:::z\\\"`<\\/date>/\" -e \"s/<date>Date2<\\/date>/<date>`date +\\\"%Y-%m-%d\\\"`<\\/date>/\"
+[filter "kicad_pcb_f"]
+	clean = sed -E 's/\\(host pcbnew ([[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+).*/\\(host pcbnew \\1\\)/'
+[filter "net_filter"]
+	clean = sed -E -e 's/\\(date \\\".*\\\"\\)/\\(date \\\"Date\\\"\\)/'
+	smudge = sed -E -e \"s/\\(date \\\"Date\\\"\\)/\\(date \\\"`date +\\\"%a %d %b %Y %X %:::z\\\"`\\\"\\)/\"

--- a/.github/workflows/kicad-exports.yaml
+++ b/.github/workflows/kicad-exports.yaml
@@ -1,0 +1,42 @@
+name: kicad-export
+
+on:
+# run only on push/pull_request on branches matching "wip-revC[0-9]" AND if KiCad files changed
+  push:
+    branch: 'wip-revC[0-9]'
+    paths:
+    - '**.sch'
+    - '**.kicad_pcb'
+  pull_request:
+    branch: 'wip-revC[0-9]'
+    paths:
+    - '**.sch'
+    - '**.kicad_pcb'
+    
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+    - name: get current BRANCH and REVISION
+      run: |
+        BRANCH=`git branch --show-current`
+        echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+        echo "REVISION=${BRANCH:4}" >> $GITHUB_ENV
+    - uses: nerdyscout/kicad-exports@v2.2
+      with:
+        config: hardware/boards/config.kibot.yaml
+        board: hardware/boards/glasgow/glasgow.kicad_pcb
+        schema: hardware/boards/glasgow/glasgow.sch
+        dir: hardware/boards/glasgow/${{ env.REVISION }}
+    - uses: github-actions-x/commit@v2.7
+      if: ${{ success() }}
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        name: 'GitHub Actions'
+        email: 'actions@github.com'
+        commit-message: ${{ github.workflow }}
+        files: hardware/boards/glasgow/${{ env.REVISION }}/*

--- a/hardware/boards/config.kibot.yaml
+++ b/hardware/boards/config.kibot.yaml
@@ -1,0 +1,382 @@
+kibot:
+  version: 1
+    
+preflight:
+  update_xml: true
+  run_drc: true
+  run_erc: true
+  check_zone_fills: true
+  ignore_unconnected: false
+  filters:
+    - filter: 'Courtyards overlap'
+      error: '45'
+      regex: 'Courtyards overlap'
+    - filter: 'Track too close to pad'
+      error: '4'
+      regex: 'Pad'
+  
+#global:
+  #  output: '%f-%i.%x'
+  
+outputs:
+  
+# BOM
+  - name: 'https://github.com/openscopeproject/InteractiveHtmlBom'
+    comment: 'ibom.html'
+    type: 'ibom'
+    dir: 'docs/bom'
+    options:
+      blacklist: ''
+      blacklist_empty_val: false
+      board_rotation: 0
+      bom_view: 'left-right'
+#      checkboxes: 'Sourced,Placed'
+      dark_mode: false
+#      dnf_filter: ''
+#      dnp_field: ''
+      extra_fields: 'MPN,variant'
+      hide_pads: false
+      hide_silkscreen: false
+      highlight_pin1: true
+      include_nets: true
+      include_tracks: true
+      layer_view: 'FB'
+#      name_format: 'ibom'
+#      netlist_file: ''
+      no_blacklist_virtual: false
+      no_redraw_on_drag: false
+      normalize_field_case: true
+#      output: '%f-%i%v.%x'
+      show_fabrication: false
+      sort_order: 'C,R,L,D,U,Y,X,F,SW,A,~,HS,CNN,J,P,NT,MH'
+#      variant: ''
+#      variant_field: ''
+#      variants_blacklist: ''
+#      variants_whitelist: ''
+
+  - name: 'https://github.com/SchrodingersGat/KiBoM'
+    comment: 'bom.html'
+    type: 'kibom'
+    dir: 'docs/bom'
+    options:
+      conf:
+        component_aliases: [['r', 'r_small', 'res', 'resistor'], ['l', 'l_small', 'inductor'], ['c', 'c_small', 'cap', 'capacitor'], ['sw', 'switch'], ['zener', 'zenersmall'], ['d', 'diode', 'd_small']]
+        datasheet_as_link: 'Datasheet'
+        digikey_link: ''
+#        exclude_any:
+#          - column: References
+#            regex: '^TP[0-9]*'
+#          - column: References
+#            regex: '^FID'
+#          - column: Part
+#            regex: 'mount.*hole'
+#          - column: Part
+#            regex: 'solder.*bridge'
+#          - column: Part
+#            regex: 'test.*point'
+#          - column: Footprint
+#            regex: 'test.*point'
+#          - column: Footprint
+#            regex: 'mount.*hole'
+#          - column: Footprint
+#            regex: 'fiducial'
+#          - column: References
+#            regex: 'LOGO'
+        fit_field: 'Variant'
+        group_connectors: true
+        group_fields: ['Part', 'Part Lib', 'Value', 'Footprint', 'Footprint Lib']
+        hide_headers: false
+        hide_pcb_info: false
+        html_generate_dnf: true
+        ignore_dnf: true
+        merge_blank_fields: true
+        number_rows: true
+        test_regex: true
+        use_alt: false
+      format: 'HTML'
+#      number: 1
+#      output: '%f-%i%v.%x'
+#      separator: ','
+#      variant: ''
+
+#  - name: 'https://github.com/SchrodingersGat/KiBoM'
+#    comment: 'bom.xlsx'
+#    type: 'kibom'
+#    dir: 'docs/bom'
+#    options:
+#      conf:
+#        component_aliases: [['r', 'r_small', 'res', 'resistor'], ['l', 'l_small', 'inductor'], ['c', 'c_small', 'cap', 'capacitor'], ['sw', 'switch'], ['zener', 'zenersmall'], ['d', 'diode', 'd_small']]
+#        datasheet_as_link: 'Datasheet'
+#        digikey_link: ''
+#        exclude_any:
+#          - column: References
+#            regex: '^TP[0-9]*'
+#          - column: References
+#            regex: '^FID'
+#          - column: Part
+#            regex: 'mount.*hole'
+#          - column: Part
+#            regex: 'solder.*bridge'
+#          - column: Part
+#            regex: 'test.*point'
+#          - column: Footprint
+#            regex: 'test.*point'
+#          - column: Footprint
+#            regex: 'mount.*hole'
+#          - column: Footprint
+#            regex: 'fiducial'
+#          - column: References
+#            regex: 'LOGO'
+#        fit_field: 'Variant'
+#        group_connectors: true
+#        group_fields: ['Part', 'Part Lib', 'Value', 'Footprint', 'Footprint Lib']
+#        hide_headers: false
+#        hide_pcb_info: false
+#        html_generate_dnf: true
+#        ignore_dnf: true
+#        merge_blank_fields: true
+#        number_rows: true
+#        test_regex: true
+#        use_alt: false
+#      format: 'XLSX'
+#      number: 1
+#      output: '%f-%i%v.%x'
+#      separator: ';'
+#      variant: ''
+
+# DOCS
+  - name: 'print schema'
+    comment: "Print schematic (PDF)"
+    type: pdf_sch_print
+    dir: docs
+#    options:
+#      dnf_filter: [string|list(string)=''] Name of the filter to mark components as not fitted. A short-cut to use for simple cases where a variant is an overkill.
+#      output: [string='%f-%i%v.%x'] filename for the output PDF (%i=schematic %x=pdf). Affected by global options.
+#      variant: [string=''] Board variant to apply. Not fitted components are crossed.
+
+  - name: 'print schema'
+    comment: "Print schematic (SVG)"
+    type: svg_sch_print
+    dir: docs/img
+#    options:
+#      dnf_filter: [string|list(string)=''] Name of the filter to mark components as not fitted. A short-cut to use for simple cases where a variant is an overkill.
+#      output: [string='%f-%i%v.%x'] filename for the output SVG (%i=schematic %x=svg). Affected by global options.
+#      variant: [string=''] Board variant to apply. Not fitted components are crossed.
+
+  - name: 'print board mechanics'
+    comment: "Print board (PDF)"
+    type: pdf_pcb_print
+    layers:
+      - Dwgs.User
+      - Edge.Cuts
+      - F.CrtYd
+    dir: docs
+    options:
+#      dnf_filter: [string|list(string)=''] Name of the filter to mark components as not fitted. A short-cut to use for simple cases where a variant is an overkill.
+      drill_marks: full #[string='full'] what to use to indicate the drill places, can be none, small or full (for real scale).
+#      mirror: [boolean=false] print mirrored (X axis inverted). ONLY for KiCad 6.
+#      monochrome: [boolean=false] print in black and white.
+      output: '%f-mechanic.%x' #[string='%f-%i%v.%x'] filename for the output PDF (%i=layers, %x=pdf). Affected by global options.
+#      output_name: Alias for output.
+      plot_sheet_reference: true # [boolean=true] include the title-block.
+#      scaling: [number=1.0] scale factor (0 means autoscaling).
+#      separated: [boolean=false] print layers in separated pages.
+#      variant: [string=''] Board variant to apply.
+
+  - name: 'print board documentation'
+    comment: "Print board (PDF)"
+    type: pdf_pcb_print
+    layers: 
+      - Edge.Cuts
+      - Cmts.User
+      - F.Fab
+    dir: docs
+    options:
+#      dnf_filter: [string|list(string)=''] Name of the filter to mark components as not fitted. A short-cut to use for simple cases where a variant is an overkill.
+#      drill_marks: true #[string='full'] what to use to indicate the drill places, can be none, small or full (for real scale).
+#      mirror: [boolean=false] print mirrored (X axis inverted). ONLY for KiCad 6.
+#      monochrome: [boolean=false] print in black and white.
+      output: '%f-documentation.%x' #[string='%f-%i%v.%x'] filename for the output PDF (%i=layers, %x=pdf). Affected by global options.
+#      output_name: Alias for output.
+      plot_sheet_reference: true # [boolean=true] include the title-block.
+#      scaling: [number=1.0] scale factor (0 means autoscaling).
+#      separated: [boolean=false] print layers in separated pages.
+#      variant: [string=''] Board variant to apply.
+
+# GERBERS
+  - name: "https://en.wikipedia.org/wiki/Gerber_format"
+    comment: 'gerbers'
+    type: 'gerber'
+    dir: 'gerbers'
+    options:
+      create_gerber_job_file: false
+      dnf_filter: ''
+      exclude_edge_layer: true
+      exclude_pads_from_silkscreen: false
+      force_plot_invisible_refs_vals: false
+#      gerber_job_file: '%f-%i%v.%x'
+      gerber_precision: 4.6
+      line_width: 0.1
+#      output: '%f-%i%v.%x'
+      plot_footprint_refs: true
+      plot_footprint_values: true
+      plot_sheet_reference: false
+      subtract_mask_from_silk: false
+      tent_vias: true
+      use_aux_axis_as_origin: true
+      use_gerber_net_attributes: true
+      use_gerber_x2_attributes: true
+      use_protel_extensions: false
+#      variant: ''
+    layers: all
+
+  - name: 'https://en.wikipedia.org/wiki/Gerber_format'
+    comment: 'drill'
+    type: gerb_drill
+    dir: 'gerbers'
+    options:
+#      map:
+#        output: ''
+#        type: 'gerber'
+#      output: '%f-%i%v.%x'
+#      report:
+#        filename: '%i.%x'
+      use_aux_axis_as_origin: true
+
+  - name: 'https://en.wikipedia.org/wiki/Gerber_format'
+    comment: 'drill excellon'
+    type: "excellon"
+    dir: 'gerbers'
+    options:
+#      map:
+#        output: '%f-%i%v.%x'
+#        type: 'gerber'
+      metric_units: true
+      minimal_header: false
+      mirror_y_axis: false
+#      output: '%f-%i%v.%x'
+      pth_and_npth_single_file: false
+#      report:
+#        filename: '%i.%x'
+      use_aux_axis_as_origin: true
+
+
+  # This output is what you get from the 'File/Fabrication output/Footprint poistion (.pos) file' menu in pcbnew.
+  - name: 'link'
+    comment: '*_pos.csv'
+    type: 'position'
+    dir: 'gerbers'
+    options:
+      # [string|list(string)=''] Name of the filter to mark components as not fitted.
+      # A short-cut to use for simple cases where a variant is an overkill
+      dnf_filter: ''
+      # [string='ASCII'] [ASCII,CSV] format for the position file
+      format: 'CSV'
+      # [boolean=true] only include the surface mount components
+      only_smd: true
+      # [string='%f-%i%v.%x'] output file name (%i='top_pos'|'bottom_pos'|'both_pos', %x='pos'|'csv'). Affected by global options
+      output: '%f-%i%v.%x'
+      # [boolean=true] generate two separated files, one for the top and another for the bottom
+      separate_files_for_front_and_back: false
+      # [string='millimeters'] [millimeters,inches] units used for the positions
+      units: 'millimeters'
+      # [string=''] Board variant to apply
+      variant: ''
+
+# PLOT
+  - name: 'https://github.com/yaqwsx/PcbDraw'
+    comment: 'default green svg top'
+    type: 'pcbdraw'
+    dir: 'docs/img'
+    options:
+      bottom: false
+      mirror: true
+      dnf_filter: ''
+      dpi: 300
+      format: 'svg'
+#      highlight: []
+#      libs: ['/usr/share/pcbdraw/footprints/KiCAD-base']
+      libs: []
+      mirror: false
+      no_drillholes: false
+#      output: '%f-%i%v.%x'
+#      placeholder: false
+#      remap:
+#      show_components: none
+      style: '/usr/share/pcbdraw/styles/jlcpcb-green-enig.json'
+#      variant: ''
+#      vcuts: false
+#      warnings: 'none'
+
+  - name: 'https://github.com/yaqwsx/PcbDraw'
+    comment: 'default green svg bottom'
+    type: 'pcbdraw'
+    dir: 'docs/img'
+    options:
+      bottom: true
+      mirror: false
+      dnf_filter: ''
+      dpi: 300
+      format: 'svg'
+#      highlight: []
+#      libs: ['/usr/share/pcbdraw/footprints/KiCAD-base']
+      libs: []
+      no_drillholes: false
+#      output: '%f-%i%v.%x'
+#      placeholder: false
+#      remap:
+#      show_components: none
+      style: '/usr/share/pcbdraw/styles/jlcpcb-green-enig.json'
+#      variant: ''
+#      vcuts: false
+#      warnings: 'none'
+
+# MODEL
+  - name: 'https://www.freecadweb.org/'
+    comment: '3D step model'
+    type: 'step'
+    dir: 'cad'
+    options:
+#      dnf_filter: ''
+      metric_units: true
+      min_distance: -1
+      no_virtual: false
+      origin: 'grid'
+      output: '%f.%x'
+#      variant: ''
+
+# BOM 
+  - name: 'https://octopart.com/'
+    comment: 'bom.csv - octopart'
+    type: 'kibom'
+    dir: 'docs/bom'
+    options:
+      conf:
+        columns:
+          - Description
+          - Part
+          - References
+          - Value
+          - field: Quantity Per PCB
+            name: Qty
+#          - field: MPN
+#            name: Part Number
+        component_aliases: [['r', 'r_small', 'res', 'resistor'], ['l', 'l_small', 'inductor'], ['c', 'c_small', 'cap', 'capacitor'], ['sw', 'switch'], ['zener', 'zenersmall'], ['d', 'diode', 'd_small']]
+        datasheet_as_link: ''
+        digikey_link: ''
+        fit_field: 'Variant'
+        group_connectors: true
+        group_fields: ['']
+        hide_headers: false
+        hide_pcb_info: true
+        html_generate_dnf: true
+        ignore_dnf: true
+        merge_blank_fields: false
+        number_rows: false
+        test_regex: true
+        use_alt: false
+      format: 'CSV'
+#      number: 1
+      output: '%f-%i%v_octopart.%x'
+      separator: ';'
+#      variant: ''

--- a/hardware/boards/glasgow/revC2/README.md
+++ b/hardware/boards/glasgow/revC2/README.md
@@ -1,0 +1,28 @@
+# Glasgow revC1
+
+Repo for kicad schematic, board and gerber files. This project is in development and is not ready for release.
+
+## Schematic
+[![Schematic page1](docs/img/glasgow-schematic.svg)](docs/glasgow-schematic.pdf)
+[![Schematic page2](docs/img/io_banks-IO_Banks.svg)](docs/glasgow-schematic.pdf)
+[![Schematic page3](docs/img/io_buffer-IO_Banks-IO_Buffer_A.svg)](docs/glasgow-schematic.pdf)
+[![Schematic page4](docs/img/io_buffer-IO_Banks-IO_Buffer_B.svg)](docs/glasgow-schematic.pdf)
+
+# Documentation
+- [documentation](docs/glasgow-documentation.pdf)
+- [mechanic](docs/glasgow-mechanic.pdf)
+
+## Plots
+[![top](docs/img/glasgow-top.svg)](docs/img/glasgow-top.svg)
+[![bottom](docs/img/glasgow-bottom.svg)](docs/img/glasgow-bottom.svg)
+
+## BOM
+- [ibom](https://htmlpreview.github.io/?https://github.com/nerdyscout/Glasgow/blob/wip-revC2/hardware/boards/glasgow/revC2/docs/bom/glasgow-ibom.html)
+- [csv](docs/bom/glasgow-bom_octopart.csv)
+- [kibom](https://htmlpreview.github.io/?https://github.com/nerdyscout/Glasgow/blob/wip-revC2/hardware/boards/glasgow/revC2/docs/bom/glasgow-bom.html)
+
+## Gerbers
+can be found [here](gerbers/) including [glasgow-both_pos.csv](gerbers/glasgow-both_pos.csv) for the pick and place machiene.
+
+## Model
+[3D Step model](cad/glasgow.step)

--- a/hardware/boards/glasgow/revC2/kibot_errors.filter
+++ b/hardware/boards/glasgow/revC2/kibot_errors.filter
@@ -1,0 +1,4 @@
+# Courtyards overlap
+45,Courtyards overlap
+# Track too close to pad
+4,Pad


### PR DESCRIPTION
hi everyone!

after merging this pull request, whenever changes are made on the glasgow.sch or glasgow.kicad_pcb, a CI script will run to generate several files. This happens only on branches matching `wip-revC[0-9]` and if ERC+DRC are passed. The output will be written to `hardware/boards/glasgow/revC[0-9]`.
Please take a look [here](https://github.com/nerdyscout/Glasgow/tree/wip-revC2/hardware/boards/glasgow/revC2) about which files are generated. (schematic.pdf, schematic.svg, gerbers, bom, plots, 3d-model)

You might want to generate only specific files and not all of them. Please see the [config.kibot.yaml](https://github.com/nerdyscout/Glasgow/blob/kicad-exports/hardware/boards/config.kibot.yaml) about dis/enabling various output formats. There is also a huge set of options to configure the output.
Currently the [kicad-exports.yaml](https://github.com/nerdyscout/Glasgow/blob/kicad-exports/.github/workflows/kicad-exports.yaml) is set up to commit all generated files back to Github. With all kinds of [Github Actions](https://github.com/marketplace?type=actions) these could also be stored somewhere else.

I put this on draft for discussion which files to generate/commit/upload somewhere else.