### PR TITLE
add InfluxDB2DataLogger (cli name influxdb2) to log into an InfluxDB 2.x

### DIFF
--- a/software/glasgow/support/data_logger.py
+++ b/software/glasgow/support/data_logger.py
@@ -248,6 +248,12 @@ class InfluxDB2DataLogger(DataLogger, name="influxdb2"):
             "endpoint", metavar="ENDPOINT", type=str,
             help="write to endpoint URL //ENDPOINT/api/v2/write")
         parser.add_argument(
+            "org", metavar="ORGANIZATION", type=str,
+            help="Organization")
+        parser.add_argument(
+            "bucket", metavar="BUCKET", type=str,
+            help="Bucket")
+        parser.add_argument(
             "measurement", metavar="SERIES", type=str,
             help="write to measurement SERIES")
         def tag(arg):
@@ -269,12 +275,6 @@ class InfluxDB2DataLogger(DataLogger, name="influxdb2"):
         parser.add_argument(
             "--token", metavar="TOKEN", type=str, required=True,
             help="Auth token")
-        parser.add_argument(
-            "--org", metavar="ORGANIZATION", type=str, required=True,
-            help="Organization")
-        parser.add_argument(
-            "--bucket", metavar="BUCKET", type=str, required=True,
-            help="Bucket")
 
     async def setup(self, args):
         url = yarl.URL(args.endpoint)

--- a/software/glasgow/support/data_logger.py
+++ b/software/glasgow/support/data_logger.py
@@ -267,13 +267,13 @@ class InfluxDB2DataLogger(DataLogger, name="influxdb2"):
             "--batch-size", metavar="BATCH-SIZE", type=int, default=1,
             help="submit data in groups of BATCH-SIZE points")
         parser.add_argument(
-            "--token", metavar="TOKEN", type=str,
+            "--token", metavar="TOKEN", type=str, required=True,
             help="Auth token")
         parser.add_argument(
-            "--org", metavar="ORGANIZATION", type=str,
+            "--org", metavar="ORGANIZATION", type=str, required=True,
             help="Organization")
         parser.add_argument(
-            "--bucket", metavar="BUCKET", type=str,
+            "--bucket", metavar="BUCKET", type=str, required=True,
             help="Bucket")
 
     async def setup(self, args):

--- a/software/glasgow/support/data_logger.py
+++ b/software/glasgow/support/data_logger.py
@@ -249,10 +249,10 @@ class InfluxDB2DataLogger(DataLogger, name="influxdb2"):
             help="write to endpoint URL //ENDPOINT/api/v2/write")
         parser.add_argument(
             "org", metavar="ORGANIZATION", type=str,
-            help="Organization")
+            help="write to Organization ORGANIZATION (can be either the name or the id)")
         parser.add_argument(
             "bucket", metavar="BUCKET", type=str,
-            help="Bucket")
+            help="write to bucket BUCKET")
         parser.add_argument(
             "measurement", metavar="SERIES", type=str,
             help="write to measurement SERIES")
@@ -274,7 +274,7 @@ class InfluxDB2DataLogger(DataLogger, name="influxdb2"):
             help="submit data in groups of BATCH-SIZE points")
         parser.add_argument(
             "--token", metavar="TOKEN", type=str, required=True,
-            help="Auth token")
+            help="set the Token to use for Authentication")
 
     async def setup(self, args):
         url = yarl.URL(args.endpoint)


### PR DESCRIPTION
This adds a new logger named ``influxdb2``.

At first I wanted to expand the existing ``influxdb`` logger, but there are a few differences between 1.x and 2.x:

* 1.x takes a ``db`` parameter
* 2.x takes ``org`` and ``bucket``
* 2.x does not support a parameter ``retention-policy`` on write, instead the retention period is configured statically on the bucket
* 2.x requires authentication with a Token

The token could have been added as an optional parameter, but the discrepancy between the single positional parameter ``db`` and the two parameters ``org`` / ``bucket`` would have been awkward.


I've tested this against a local influxdb running in docker (``docker run --rm -it --name influxdb -p 8086:8086 quay.io/influxdb/influxdb:v2.0.2``) and against the cloud version.

The invocation to log it into the cloud would look like this:

```
glasgow run sensor-scd30 log influxdb2 -p s --token "####### <endpoint> <org> <bucket> <measure>
```

Endpoint depends on the backend, for example ``https://eu-central-1-1.aws.cloud2.influxdata.com``

``org`` can either be the Organization name or id. It can be copied from the UI url.




This is my first PR against glasgow, and I don't do much python, so any feedback is welcome.