### PR TITLE
if old API level is found, tell user to run glasgow flash

### DIFF
--- a/software/glasgow/device/hardware.py
+++ b/software/glasgow/device/hardware.py
@@ -121,7 +121,7 @@ class GlasgowHardwareDevice:
                     device_api_level = 0x00
                 if device_api_level != CUR_API_LEVEL:
                     logger.info("found rev%s device with API level %d "
-                                "(supported API level is %d)",
+                                "(supported API level is %d, run 'glasgow flash' to update your device)",
                                 revision, device_api_level, CUR_API_LEVEL)
                 else:
                     handle.close()


### PR DESCRIPTION
If a device with an old API level is connected, nudge the user to update it.

see https://github.com/GlasgowEmbedded/glasgow/issues/241, https://github.com/GlasgowEmbedded/glasgow/issues/239

apparently both attie and me saw the message and just ignored it, because hey, everything worked.