### PR TITLE
Switch CI from Travis to GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,53 @@
+on:
+  push:
+    branches: master
+  pull_request: {}
+
+name: CI
+jobs:
+
+  test-software:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: ['3.7', '3.8', '3.9']
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install git+https://github.com/nmigen/nmigen.git
+      - name: Install software
+        run: python -m pip install -e ./software[toolchain]
+      - name: Run tests
+        working-directory: ./software
+        env:
+          YOSYS: yowasp-yosys
+          NEXTPNR_ICE40: yowasp-nextpnr-ice40
+          ICEPACK: yowasp-icepack
+        run: python -W ignore::DeprecationWarning test.py -v
+
+  build-firmware:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install sdcc
+      - name: Build libfx2
+        working-directory: ./vendor/libfx2/firmware
+        run: make
+      - name: Build firmware
+        working-directory: ./firmware
+        run: make

--- a/software/setup.py
+++ b/software/setup.py
@@ -38,6 +38,7 @@ setup(
         "toolchain": [
             "nmigen-yosys",
             "yowasp-yosys",
+            "yowasp-nextpnr-ice40-5k",
             "yowasp-nextpnr-ice40-8k",
         ],
     },


### PR DESCRIPTION
This is a first pass at using GHA instead of Travis for CI. It should perform the same actions as Travis currently does.

Currently this doesn't perform any caching; we could cache both the pip downloads for YoWASP and the built WASM objects fairly easily if that's desirable. This doesn't remove the Travis CI file either.