### PR TITLE
Resolve some issues with the UART applet's auto-baud detection.

### DIFF
--- a/software/glasgow/applet/interface/uart/__init__.py
+++ b/software/glasgow/applet/interface/uart/__init__.py
@@ -260,7 +260,11 @@ class UARTApplet(GlasgowApplet, name="uart"):
                 self.logger.warning("%d frame or parity errors detected", delta)
 
             new_bit_cyc = await device.read_register(self.__addr_bit_cyc, width=4)
-            if new_bit_cyc != cur_bit_cyc:
+
+            cur_bit_cyc_lo = cur_bit_cyc * 0.95
+            cur_bit_cyc_hi = cur_bit_cyc * 1.05
+
+            if new_bit_cyc < cur_bit_cyc_lo or new_bit_cyc > cur_bit_cyc_hi:
                 self.logger.info("switched to %d baud",
                                  self.__sys_clk_freq // (new_bit_cyc + 1))
             cur_bit_cyc = new_bit_cyc

--- a/software/glasgow/applet/interface/uart/__init__.py
+++ b/software/glasgow/applet/interface/uart/__init__.py
@@ -101,7 +101,7 @@ class UARTSubtarget(Elaboratable):
 
         m.d.comb += uart.bit_cyc.eq(self.bit_cyc)
         with m.If(self.use_auto):
-            with m.If((uart.rx_ferr | uart.rx_perr) & (self.auto_cyc != ~0)):
+            with m.If(self.auto_cyc != ~0):
                 m.d.sync += self.bit_cyc.eq(self.auto_cyc)
         with m.Else():
             m.d.sync += self.bit_cyc.eq(self.manual_cyc)


### PR DESCRIPTION
When receiving a single frame that is at a faster baudrate than is currently configured, it is possible that you won't see a frame or
parity error, especially if no parity is selected. This is because the line idles high, which looks identical to a stop bit.

Even if you have parity enabled, there is a non-zero chance you'll see the high line state, and consider it to be a "valid" parity bit, when in fact it is the idle state.

When receiving a stream of frames in quick succession, there is a higher probability that you will look for a stop bit in the next frame, and will thus see a frame error (or parity error).

This PR also addresses the resulting extra / unwanted announcements to minor adjustments of the baudrate, as well as a mistake in the nMigen update of the UART gateware.