### PR TITLE
doc: add details about libusb bug

### DIFF
--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -1,0 +1,7 @@
+Known Issues
+============
+
+Device Not Found
+----------------
+
+If Glasgow is connected to the system, appears in ``dmesg`` and ``/sys/bus/usb/...``, but is not listed when using ``glasgow list`` or ``lsusb``, you may have run into a bug in libusb v1.0.24, see `libusb#825 <https://github.com/libusb/libusb/issues/825>`_.


### PR DESCRIPTION
Add details about libusb bug that may prevent glasgow from being seen by `lsusb` and `glasgow list`.