### PR TITLE
README: use `python3` to run the macOS setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Obtain the source code:
 Install the dependencies and the scripts for the current user:
 
     cd software
-    python setup.py develop
+    python3 setup.py develop
 
 The scripts will be installed in `/usr/local/bin`, which should already be in your `PATH`.
 


### PR DESCRIPTION
Switch to the python3 alias so we don't hit the system Python which is a version 2.

https://github.com/GlasgowEmbedded/glasgow/issues/279#issue-817072119