### PR TITLE
applet.interface.uart: fix `tty` subcommand on Windows

### DIFF
--- a/software/glasgow/applet/interface/uart/__init__.py
+++ b/software/glasgow/applet/interface/uart/__init__.py
@@ -314,7 +314,7 @@ class UARTApplet(GlasgowApplet, name="uart"):
         in_fileno  = sys.stdin.fileno()
         out_fileno = sys.stdout.fileno()
 
-        if os.isatty(in_fileno):
+        if os.isatty(in_fileno) and os.name != "nt":
             import atexit, termios
 
             old_stdin_attrs = termios.tcgetattr(sys.stdin)


### PR DESCRIPTION
This PR fixes a crash when running the `uart tty` subcommand on Windows. It does not allow sending `^C` like on *nix, but at least the command is usable at all.