### PR TITLE
applet.interface.uart: add commentary about the autobaud and its limitations

### DIFF
--- a/software/glasgow/applet/interface/uart/__init__.py
+++ b/software/glasgow/applet/interface/uart/__init__.py
@@ -22,6 +22,13 @@ class UARTAutoBaud(Elaboratable):
     algorithm will not correctly lock onto this sequence. In fact, it would determine the baud rate
     that is 5× slower than the actual one.)
 
+    When running on an ASCII stream, approximately 82% of the printable characters will allow this
+    algorithm to produce a valid baud rate (17 characters do not have a single bit-time)... an
+    extended series of the characters listed below may cause issues when combined with framing or
+    parity errors (e.g: due to glitches).
+
+        01389<?`acgpqsxy|
+
     This algorithm works by training on a fixed-length sequence of pulses, choosing the length
     of the shortest one as the bit time. After the sequence ends, it retrains again from scratch,
     discarding the previous estimate.
@@ -130,6 +137,10 @@ class UARTApplet(GlasgowApplet, name="uart"):
     Transmit and receive data via UART.
 
     Any baud rate is supported. Only 8n1 mode is supported.
+
+    NOTE: The automatic baud rate algorithm requires a burst of data, and will lock on to the
+    shortest bit-times present in the stream... updates only occur on frame or parity errors, and
+    and random data will help.
     """
 
     __pins = ("rx", "tx")


### PR DESCRIPTION
Make the autobaud limitations more visible and expand details in `UARTAutoBaud`'s docstring.

Supersedes #260.