### PR TITLE
Port crcmod to crc

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Debugging new applets can be hard, especially if bidirectional buses are involve
 You will need git and Python 3.7 (or a newer version, in which case replace `3.7` with that version below). On a Debian or Ubuntu system these can be installed with:
 
     apt-get install --no-install-recommends git python3.7 python3-setuptools \
-      python3-libusb1 python3-aiohttp python3-bitarray python3-crcmod
+      python3-libusb1 python3-aiohttp python3-bitarray
 
 You will also need Yosys and nextpnr-ice40, both from the master branch. Follow the setup instructions for [Yosys](https://github.com/yosysHQ/yosys/#setup) and [nextpnr](https://github.com/YosysHQ/nextpnr/#nextpnr-ice40).
 

--- a/software/glasgow/applet/memory/floppy/__init__.py
+++ b/software/glasgow/applet/memory/floppy/__init__.py
@@ -302,7 +302,7 @@ import argparse
 import struct
 import random
 import itertools
-import crcmod
+import crc
 import math
 from amaranth.compat import *
 from amaranth.compat.genlib.cdc import MultiReg
@@ -988,7 +988,7 @@ class MemoryFloppyAppletTool(GlasgowAppletTool, applet=MemoryFloppyApplet):
             size, cylinder, head = struct.unpack(">LBB", header)
             yield cylinder, head, file.read(size)
 
-    crc_mfm = staticmethod(crcmod.mkCrcFun(0x11021, initCrc=0xffff, rev=False))
+    crc_mfm = staticmethod(crc.Calculator(crc.Configuration(width=16, polynomial=0x11021, init_value=0xffff)).checksum)
 
     def iter_mfm_sectors(self, symbstream, *, verbose=False, ignore_data_crc=False):
         state   = "IDLE"

--- a/software/glasgow/applet/sensor/scd30/__init__.py
+++ b/software/glasgow/applet/sensor/scd30/__init__.py
@@ -8,7 +8,7 @@ import asyncio
 import aiohttp
 import yarl
 import struct
-import crcmod
+import crc
 
 from ....support.logging import dump_hex
 from ....support.data_logger import DataLogger
@@ -47,7 +47,7 @@ class SCD30I2CInterface:
     def _log(self, message, *args):
         self._logger.log(self._level, "SCD30: " + message, *args)
 
-    _crc = staticmethod(crcmod.mkCrcFun(0x131, initCrc=0xff, rev=False))
+    _crc = staticmethod(crc.Calculator(crc.Configuration(width=8,polynomial=0x131,init_value=0xff)).checksum)
 
     async def _read_raw(self, addr, length=0):
         assert length % 2 == 0

--- a/software/glasgow/applet/sensor/sen5x/__init__.py
+++ b/software/glasgow/applet/sensor/sen5x/__init__.py
@@ -6,7 +6,7 @@ import argparse
 import logging
 import asyncio
 import struct
-import crcmod
+import crc
 
 from ....support.logging import dump_hex
 from ....support.data_logger import DataLogger
@@ -42,7 +42,7 @@ class SEN5xI2CInterface:
     def _log(self, message, *args):
         self._logger.log(self._level, "SEN5x: " + message, *args)
 
-    _crc = staticmethod(crcmod.mkCrcFun(0x131, initCrc=0xff, rev=False))
+    _crc = staticmethod(crc.Calculator(crc.Configuration(width=8,polynomial=0x131,init_value=0xff)).checksum)
 
     async def _read_raw(self, addr, length=0, delay_seconds=None):
         assert length % 2 == 0

--- a/software/glasgow/arch/nrf24l/__init__.py
+++ b/software/glasgow/arch/nrf24l/__init__.py
@@ -1,6 +1,3 @@
-import crcmod
-
-
 __all__ = ["crc8_nrf24l", "crc16_nrf24l"]
 
 

--- a/software/glasgow/protocol/onfi.py
+++ b/software/glasgow/protocol/onfi.py
@@ -2,7 +2,7 @@
 # Accession: G00030
 
 import struct
-import crcmod
+import crc
 
 from ..support.bitstruct import *
 
@@ -14,7 +14,7 @@ class ONFIParameterError(Exception):
     pass
 
 
-_crc_onfi = crcmod.mkCrcFun(0x18005, initCrc=0x4f4e, rev=False)
+_crc_onfi = staticmethod(crc.Calculator(crc.Configuration(width=16, polynomial=0x18005, init_value=0x4f4e)).checksum)
 
 
 _ONFI_Revision = bitstruct("ONFI_Revision", 16, [

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "aiohttp~=3.8",
   "pyvcd",
   "bitarray",
-  "crcmod",
+  "crc",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This is a continuation / re-PR of PR #310.
Ports crcmod to crc as requested in issue #309.

**Tested this way:**
testdata=b"\x12\x23\x34\x56\xaa\xbb\xcc\xdd"
import crc
import crcmod
crc_mfm_new = staticmethod(crc.Calculator(crc.Configuration(width=16, polynomial=0x11021, init_value=0xffff)).checksum)
crc_mfm = staticmethod(crcmod.mkCrcFun(0x11021, initCrc=0xffff, rev=False))
print("Bad crc") if crc_mfm_new(testdata)!=crc_mfm(testdata) else print("All fine :)")