### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/venv/
 *.vcd
 *.gtkw
 *.log


### PR DESCRIPTION
Add the venv directory to the ignore set so that python environments won't show up as uncommitted files.

This is an updated patch by @ChuckM from PR #316 