### PR TITLE
applet: avoid UnusedElaboratable warning spam in hardware testcases

### DIFF
--- a/software/glasgow/applet/__init__.py
+++ b/software/glasgow/applet/__init__.py
@@ -1,6 +1,7 @@
 import re
 import argparse
 from abc import ABCMeta, abstractmethod
+from amaranth import *
 
 from ..support.arepl import *
 from ..gateware.clockgen import *
@@ -288,6 +289,9 @@ class GlasgowAppletTestCase(unittest.TestCase):
     async def run_hardware_applet(self, mode):
         if mode == "record":
             await self.device.download_target(self.target.build_plan())
+        else:
+            # avoid UnusedElaboratable warning
+            Fragment.get(self.target, None)
 
         return await self.applet.run(self.device, self._parsed_args)
 


### PR DESCRIPTION
The hardware tests using `applet_hardware_test` work by constructing the whole applet (including the gateware), then discarding the gateware and connecting the applet software to a mock interface. This results in a lot of `UnusedElaboratable` warnings in CI logs, making them effectively unusable.

This patch performs a dummy elaboration of the hierarchy to mark all involved elaboratables as used.