### PR TITLE
CI: unignore DeprecationWarning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
           YOSYS: yowasp-yosys
           NEXTPNR_ICE40: yowasp-nextpnr-ice40
           ICEPACK: yowasp-icepack
-        run: python -W ignore::DeprecationWarning test.py -v
+        run: python test.py -v
 
   build-firmware:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
With the move away from amaranth.compat almost complete, the tests are now free from deprecation warnings.