### PR TITLE
software: move from `TSTriple` to `Pin`, simplify `Pads`

### DIFF
--- a/software/glasgow/access/__init__.py
+++ b/software/glasgow/access/__init__.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from amaranth import *
-from amaranth.compat.fhdl.specials import TSTriple
+from amaranth.lib.io import Pin
 
 from ..gateware.pads import Pads
 
@@ -69,7 +69,7 @@ class AccessMultiplexerInterface(Elaboratable, metaclass=ABCMeta):
         pass
 
     def get_pins(self, pins, name=None):
-        triple = TSTriple(len(pins), name=name)
+        triple = Pin(width=len(pins), dir='io')
         for n, pin in enumerate(pins):
             self.build_pin_tristate(pin, triple.oe, triple.o[n], triple.i[n])
 

--- a/software/glasgow/gateware/pads.py
+++ b/software/glasgow/gateware/pads.py
@@ -1,6 +1,5 @@
 from amaranth import *
 from amaranth.lib.io import Pin
-from amaranth.compat.fhdl.specials import TSTriple
 
 
 __all__ = ['Pads']
@@ -13,11 +12,10 @@ class Pads(Elaboratable):
     Provides a common interface to device pads, wrapping either a Migen platform request,
     or a Glasgow I/O port slice.
 
-    Construct a pad adapter providing signals, records, or tristate triples; name may
-    be specified explicitly with keyword arguments. For each signal, record field, or
-    triple with name ``n``, the pad adapter will have an attribute ``n_t`` containing
-    a tristate triple. ``None`` may also be provided, and is ignored; no attribute
-    is added to the adapter.
+    Construct a pad adapter providing pins; name may
+    be specified explicitly with keyword arguments. For each
+    pin with name ``n``, the pad adapter will have an attribute ``n_t`` containing
+    a ``Pin``.
 
     For example, if a Migen platform file contains the definitions ::
 
@@ -30,123 +28,19 @@ class Pads(Elaboratable):
         ]
 
     then a pad adapter constructed as ``Pads(platform.request("i2c"))`` will have
-    attributes ``scl_t`` and ``sda_t`` containing tristate triples for their respective
+    attributes ``scl_t`` and ``sda_t`` containing ``Pin`` objects for their respective
     pins.
-
-    If a Glasgow applet contains the code ::
-
-        port = target.get_port(args.port)
-        pads = Pads(tx=port[args.pin_tx], rx=port[args.pin_rx])
-        target.submodules += pads
-
-    then the pad adapter ``pads`` will have attributes ``tx_t`` and ``rx_t`` containing
-    tristate triples for their respective pins; since Glasgow I/O ports return tristate
-    triples when slicing, the results of slicing are unchanged.
     """
-    def __init__(self, *args, **kwargs):
-        self._tristates = []
-        for (i, elem) in enumerate(args):
-            self._add_elem(elem, index=i)
-        for name, elem in kwargs.items():
-            self._add_elem(elem, name)
+    def __init__(self, **kwargs):
+        for name, pin in kwargs.items():
+            assert isinstance(pin, Pin)
 
-    def _add_elem(self, elem, name=None, index=None):
-        if elem is None:
-            return
-        elif isinstance(elem, Record):
-            for field in elem.layout:
-                if name is None:
-                    field_name = field[0]
-                else:
-                    field_name = "{}_{}".format(name, field[0])
-                self._add_elem(getattr(elem, field[0]), field_name)
-            return
-        elif isinstance(elem, Signal):
-            triple = TSTriple()
-            self._tristates.append(triple.get_tristate(elem))
-            if name is None:
-                name = elem.name
-        elif isinstance(elem, (Pin, TSTriple)):
-            triple = elem
-        else:
-            assert False
+            pin_name = "{}_t".format(name)
+            if hasattr(self, pin_name):
+                raise ValueError("Cannot add {!r} as attribute {}; attribute already exists")
 
-        if name is None and index is None:
-            raise ValueError("Name must be provided for {!r}".format(elem))
-        elif name is None:
-            raise ValueError("Name must be provided for {!r} (argument {})"
-                             .format(elem, index + 1))
-
-        triple_name = "{}_t".format(name)
-        if hasattr(self, triple_name):
-            raise ValueError("Cannot add {!r} as attribute {}; attribute already exists")
-
-        setattr(self, triple_name, triple)
+            setattr(self, pin_name, pin)
 
     def elaborate(self, platform):
         m = Module()
-        m.submodules += self._tristates
         return m
-
-# -------------------------------------------------------------------------------------------------
-
-import unittest
-
-
-class PadsTestCase(unittest.TestCase):
-    def assertIsTriple(self, obj):
-        self.assertIsInstance(obj, TSTriple)
-
-    def assertHasTristate(self, frag, sig):
-        for tristate in frag._tristates:
-            if tristate.target is sig:
-                return
-        self.fail("No tristate for {!r} in {!r}".format(sig, frag))
-
-    def test_none(self):
-        pads = Pads(x=None)
-
-        self.assertFalse(hasattr(pads, "x_t"))
-
-    def test_signal(self):
-        sig  = Signal()
-        pads = Pads(sig)
-
-        self.assertIsTriple(pads.sig_t)
-        self.assertHasTristate(pads, sig)
-
-    def test_signal_named(self):
-        sig  = Signal()
-        pads = Pads(rx=sig)
-
-        self.assertIsTriple(pads.rx_t)
-        self.assertHasTristate(pads, sig)
-
-    def test_triple(self):
-        tri  = TSTriple()
-        pads = Pads(sig=tri)
-
-        self.assertIsTriple(pads.sig_t)
-        self.assertEqual(pads.sig_t, tri)
-
-    def test_triple_unnamed(self):
-        tri  = TSTriple()
-        self.assertRaises(ValueError, Pads, tri)
-
-    def test_record(self):
-        rec  = Record([("rx", 1), ("tx", 1)])
-        pads = Pads(rec)
-
-        self.assertIsTriple(pads.rx_t)
-        self.assertHasTristate(pads, rec.rx)
-        self.assertIsTriple(pads.tx_t)
-        self.assertHasTristate(pads, rec.tx)
-
-    def test_record_named(self):
-        rec  = Record([("rx", 1), ("tx", 1)])
-        pads = Pads(uart=rec)
-
-        self.assertIsTriple(pads.uart_rx_t)
-        self.assertHasTristate(pads, rec.rx)
-        self.assertIsTriple(pads.uart_tx_t)
-        self.assertHasTristate(pads, rec.tx)

--- a/software/glasgow/target/hardware.py
+++ b/software/glasgow/target/hardware.py
@@ -7,7 +7,6 @@ import logging
 from amaranth import *
 from amaranth.build import ResourceError
 
-from ..gateware.pads import Pads
 from ..gateware.i2c import I2CTarget
 from ..gateware.registers import I2CRegisters
 from ..gateware.fx2_crossbar import FX2Crossbar


### PR DESCRIPTION
This removes the last dependency on `amaranth.compat`, finishing the migration.

Depends on amaranth-lang/amaranth#833 .