### PR TITLE
pyproject: setuptools~=67.0 → setuptools>=67.0

### DIFF
--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools~=67.0", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=67.0", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
The latter is overly strict and breaks installation with PDM (which is more principled than our other PEP517 build backends).