### PR TITLE
target: locate and examine the FPGA build tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/venv/
 *.vcd
 *.gtkw
 *.log

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 **Important note: if you are looking to assemble boards yourself, use only revC2.**
 
+
 ## ⚠️⚠️⚠️ NEWCOMERS AND CROWDSUPPLY BUYERS: PLEASE READ THIS FIRST ⚠️⚠️⚠️
 
 At the moment the project does not see much activity because the founder and primary maintainer, [Catherine @whitequark](https://github.com/whitequark), has spent several years struggling to survive due to disability, large scale social unrest, and other factors. She has now moved to the UK, got necessary healthcare, and is doing a lot better; the project's pace will pick up soon and more maintainers will be added to the current team of three in close future, but the timing of Crowdsupply orders being shipped doesn't match up to maintainer capacity a little bit.
@@ -14,6 +15,7 @@ Please stay patient and keep in mind that hardware is made by people who have li
 
 If you want to show appreciation or help with Catherine's living costs, she has a personal [Patreon](https://patreon.com/whitequark). These donations will not impact the progress of the project since the limiting factor is health first and time second, but they are very much appreciated.
 
+
 ## What is Glasgow?
 
 Glasgow is a tool for exploring digital interfaces, aimed at embedded developers, reverse engineers, digital archivists, electronics hobbyists, and everyone else who wants to communicate to a wide selection of digital devices with high reliability and minimum hassle. It can be attached to most devices without additional active or passive components, and includes extensive protection from unexpected conditions and operator error.
@@ -21,6 +23,7 @@ Glasgow is a tool for exploring digital interfaces, aimed at embedded developers
 The Glasgow hardware can support many digital interfaces because it uses reconfigurable logic. Instead of only offering a small selection of standard hardware supported interfaces, it uses an FPGA to adapt on the fly to the task at hand without compromising on performance or reliability, even for unusual, custom or obsolete interfaces.
 
 The Glasgow software is a set of building blocks designed to eliminate incidental complexity. Each interface is packaged into a self-contained *applet* that can be used directly from the command line, or reused as a part of a more complex system. Using Glasgow does not require any programming knowledge, although it becomes much more powerful if you know a bit of Python.
+
 
 ## What can I do with Glasgow?
 
@@ -50,11 +53,13 @@ Some of the tasks Glasgow can do well are:
 
 Everything above can be done with only a Glasgow revC board, some wires, and depending on the device under test, external power.
 
+
 ## How does using Glasgow look like?
 
 Watch a typical command-line workflow in this screencast:
 
 [![asciicast](https://asciinema.org/a/i9edqaUBVLLw7mRZCpdxe91Fu.svg)](https://asciinema.org/a/i9edqaUBVLLw7mRZCpdxe91Fu)
+
 
 ## What hardware does Glasgow use?
 
@@ -62,9 +67,11 @@ The Glasgow hardware evolves over time, with each major milestone called a "revi
 
 Glasgow boards use a version in the `revXN` format, where `X` is a revision letter (increased on major design changes) and `N` is a stepping number (increased on any layout or component changes). For example, `revC0` is the first stepping of revision C.
 
+
 ### revA/revB
 
 Revisions A and B have not been produced in significant amounts, contain major design issues, and are therefore mostly of historical interest. Nevertheless, everyone who has one of the revA/revB boards can keep using them—forever.
+
 
 ### revC
 
@@ -73,6 +80,7 @@ Revisions A and B have not been produced in significant amounts, contain major d
 Revision C is the latest revision and is being prepared for mass production. It provides 16 I/O pins with a data rate up to approx. 100 Mbps/pin (50 MHz)\*, independent direction control and independent programmable pull-up/pull-down resistors. The I/O pins are grouped into two I/O ports, each of which can use any voltage from 1.8 V to 5 V, sense and monitor I/O voltage of the device under test, as well as provide up to 150 mA of power. The board uses USB 2 for power, configuration, and communication, achieving up to 336 Mbps (42 MB/s) of sustained combined throughput.
 
 <sub>\* Data rate achievable in practice depends on many factors and will vary greatly with specific interface and applet design. 12 Mbps/pin (6 MHz) can be achieved with minimal development effort; reaching higher data rates requires careful HDL coding and a good understanding of timing analysis.</sub>
+
 
 ## What software does Glasgow use?
 
@@ -84,65 +92,136 @@ Implementing reliable, high-performance USB communication is not trivial—packe
 
 Debugging new applets can be hard, especially if bidirectional buses are involved. Glasgow provides a built-in cycle-accurate logic analyzer that can relate the I/O pin level and direction changes to commands and responses received and sent by the applet. The logic analyzer compresses waveforms and can pause the applet if its buffer is about to overflow.
 
+
 ## How do I use Glasgow?
 
-**If these instructions don't work for you, please file it as a bug, so that the experience can be made more smooth for everyone.**
+A lot of care and effort has been put into making the use of the software stack as seamless as possible. In particular, every dependency where it is possible is shipped via the [Python package index][pypi] (including the USB driver and the FPGA toolchains) to make installation and upgrades as seamless as they can be.
+
+[pypi]: https://pypi.org/
+
+**If these instructions don't work for you, please file it as a bug, so that the experience can be made smoother for everyone.**
+
 
 ### ... with Linux?
 
-You will need git and Python 3.8 (or newer). On a Debian (11 or newer) or Ubuntu (20.04 or newer) system these can be installed with:
+You will need to have git, Python, and pipx installed. To install these on an Ubuntu or Debian system, run:
 
-    apt install --no-install-recommends \
-      git python3 python3-setuptools python3-pip python3-libusb1 python3-aiohttp python3-bitarray
+```shell
+sudo apt install --no-install-recommends git pipx
+pipx ensurepath
+```
 
-    python3 --version
+The `pipx ensurepath` command may prompt you to reopen the terminal window; do so.
 
-You will also need recent versions of Yosys and nextpnr-ice40, which can be installed from the [binary Tabby CAD Suite distribution](https://github.com/YosysHQ/oss-cad-suite-build#installation), or from separate sources ([Yosys](https://github.com/YosysHQ/yosys#installation) and [nextpnr-ice40](https://github.com/YosysHQ/nextpnr#nextpnr-ice40)).
+Navigate to a convenient working directory and download the source code:
 
-Obtain the source code:
-
-    git clone https://github.com/GlasgowEmbedded/glasgow
-    cd glasgow
+```shell
+git clone https://github.com/GlasgowEmbedded/glasgow
+```
 
 Configure your system to allow unprivileged access (for anyone in the `plugdev` group) to the Glasgow hardware:
 
-    sudo cp config/99-glasgow.rules /etc/udev/rules.d
+```shell
+sudo cp glasgow/config/99-glasgow.rules /etc/udev/rules.d
+```
 
-Install the dependencies and the scripts for the current user:
+Install the Glasgow software for the current user:
 
-    cd software
-    pip install --user --editable ./
+```shell
+pipx install -e 'glasgow/software[toolchain]'
+```
 
-The scripts are placed in `$HOME/.local/bin`, so be sure to add that directory to the `PATH` environment variable; after this, you can run `glasgow` from a terminal. Instead of adjusting `PATH` it is also possible to use `python3 -m glasgow.cli`.
+To update the software to its newest revision, navigate to your working directory and run:
 
-To update the source code, do:
+```shell
+git -C glasgow pull
+pipx reinstall glasgow
+```
 
-    cd glasgow
-    git pull
-
-### ... with macOS?
-
-If you haven't already, install [Homebrew](https://brew.sh/). Now:
-
-    brew install python
-    brew tap ktemkin/oss-fpga
-    brew install --HEAD icestorm yosys nextpnr-ice40
-
-Obtain the source code:
-
-    git clone https://github.com/GlasgowEmbedded/glasgow
-    cd glasgow
-
-Install the dependencies and the scripts for the current user:
-
-    cd software
-    python3 setup.py develop
-
-The scripts will be installed in `/usr/local/bin`, which should already be in your `PATH`.
 
 ### ... with Windows?
 
-Although first-class Windows support is an important goal and Glasgow already works on Windows, the installation process is not yet ready.
+You will need to have git, Python, and pipx installed. To install [git][git-win] and [Python][py-win], follow the instructions from their respective pages. To install pipx, run:
+
+[git-win]: https://git-scm.com/download/win
+[py-win]: https://www.python.org/downloads/windows/
+
+```cmd
+py -3 -m pip install --user pipx
+py -3 -m pipx ensurepath
+```
+
+The `py -3 -m pipx ensurepath` command may prompt you to reopen the terminal window; do so.
+
+Navigate to a convenient working directory (it is highly recommended to use a local directory, e.g. `%LOCALAPPDATA%`, since running Glasgow software from a network drive or a roaming profile causes significant slowdown) and download the source code:
+
+```cmd
+git clone https://github.com/GlasgowEmbedded/glasgow
+```
+
+Install the Glasgow software for the current user:
+
+```cmd
+pipx install -e glasgow/software[toolchain]
+```
+
+To update the software to its newest revision, navigate to your working directory and run:
+
+```cmd
+git -C glasgow pull
+pipx reinstall glasgow
+```
+
+
+### ... with macOS?
+
+You will need to have pipx installed. If you haven't already, install [Homebrew](https://brew.sh/). To install pipx, run:
+
+```shell
+brew install pipx
+pipx ensurepath
+```
+
+The `pipx ensurepath` command may prompt you to reopen the terminal window; do so.
+
+Navigate to a convenient working directory and download the source code:
+
+```shell
+git clone https://github.com/GlasgowEmbedded/glasgow
+```
+
+Install the Glasgow software for the current user:
+
+```shell
+pipx install -e 'glasgow/software[toolchain]'
+```
+
+To update the software to its newest revision, navigate to your working directory and run:
+
+```shell
+git -C glasgow pull
+pipx reinstall glasgow
+```
+
+
+### Advanced topic: Using a native FPGA toolchain
+
+The steps above install the [YoWASP][] FPGA toolchain, which is a good low-friction option, especially for people whose primary competence is not in software, since it does not require any additional steps besides those that are already necessary. However, the YoWASP toolchain is noticeably slower than the native one (usually by a factor of less than 2×). The YoWASP toolchain is also not available for all platforms and architectures; notably, 32-bit Raspberry Pi is not covered.
+
+If you already have the required tools (`yosys`, `nextpnr-ice40`, `icepack`) installed or are willing to [install][oss-cad-suite] them, you can update your profile to set the environment variable `GLASGOW_TOOLCHAIN` to `native,builtin`, which prioritizes using the native tools over the YoWASP tools. The default value is `builtin,native`, which causes the native tools to be used only if the YoWASP tools are unusable.
+
+[yowasp]: https://yowasp.org/
+[oss-cad-suite]: https://github.com/YosysHQ/oss-cad-suite-build
+
+
+### Advanced topic: Developing the Glasgow software
+
+The steps above install the Glasgow software using `pipx install -e`, which performs an _editable install_: changes to the downloaded source code modify the behavior of the next invocation of the `glasgow` tool. Changes to `pyproject.toml`, most importantly to the dependencies, are not picked up until `pipx reinstall` is manually run.
+
+If you want to have your global Glasgow installation be independent from the source code check-out, you can omit `-e` in the instructions above. You can use any way of managing virtual environments for your development workflow, but we use and recommend [PDM][].
+
+[pdm]: https://pdm.fming.dev/
+
 
 ## How do I factory flash Glasgow?
 
@@ -151,6 +230,7 @@ Although first-class Windows support is an important goal and Glasgow already wo
 As a prerequisite to factory flashing, follow all steps from the "[How do I use Glasgow?](#how-do-i-use-glasgow)" section.
 
 Any board that is factory flashed must have a blank FX2_MEM EEPROM. If the FX2_MEM EEPROM is not completely erased (all bytes set to `FF`), the factory flashing process may fail.
+
 
 ### ... with Linux?
 
@@ -166,9 +246,11 @@ Plug in the newly assembled device. At this point, `lsusb | grep 04b4:8613` shou
 
 Done! At this point, `lsusb | grep 20b7:9db1` should list one entry.
 
+
 ### ... with Windows?
 
-See [above](#-with-windows).
+The steps are similar to the steps for Linux above, but you will need to use Zadig to bind the WinUSB driver to the device, since this will not happen automatically with a device that hasn't been flashed yet.
+
 
 ## Who made Glasgow?
 
@@ -181,6 +263,7 @@ See [above](#-with-windows).
   * [@Attie](https://github.com/attie) improved and refactored many applets;
   * [@mwkmwkmwk](https://github.com/mwkmwkmwk) did important maintenance work to keep the codebase in good shape;
   * ... and many [other people](https://github.com/GlasgowEmbedded/Glasgow/graphs/contributors).
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ sudo cp glasgow/config/99-glasgow.rules /etc/udev/rules.d
 Install the Glasgow software for the current user:
 
 ```shell
-pipx install -e 'glasgow/software[toolchain]'
+pipx install -e 'glasgow/software[builtin-toolchain]'
 ```
 
 To update the software to its newest revision, navigate to your working directory and run:
@@ -162,7 +162,7 @@ git clone https://github.com/GlasgowEmbedded/glasgow
 Install the Glasgow software for the current user:
 
 ```cmd
-pipx install -e glasgow/software[toolchain]
+pipx install -e glasgow/software[builtin-toolchain]
 ```
 
 To update the software to its newest revision, navigate to your working directory and run:
@@ -193,7 +193,7 @@ git clone https://github.com/GlasgowEmbedded/glasgow
 Install the Glasgow software for the current user:
 
 ```shell
-pipx install -e 'glasgow/software[toolchain]'
+pipx install -e 'glasgow/software[builtin-toolchain]'
 ```
 
 To update the software to its newest revision, navigate to your working directory and run:

--- a/software/.gitignore
+++ b/software/.gitignore
@@ -1,5 +1,11 @@
+# Python
 __pycache__/
-/*.egg-info
-/.eggs
-/build
+*.egg-info
 /dist
+/build
+
+# pdm
+/.pdm-plugins
+/.pdm-python
+/.venv
+/pdm.lock

--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -23,6 +23,7 @@ from .support.logging import *
 from .support.asignal import *
 from .device import GlasgowDeviceError
 from .device.config import GlasgowConfig
+from .target.toolchain import ToolchainNotFound
 from .target.hardware import GlasgowHardwareTarget
 from .gateware import GatewareBuildError
 from .gateware.analyzer import TraceDecoder
@@ -841,9 +842,12 @@ async def _main():
         logger.error(e)
         return 1
 
+    except ToolchainNotFound as e:
+        return 2
+
     except GatewareBuildError as e:
         applet.logger.error(e)
-        return 1
+        return 2
 
     except KeyboardInterrupt:
         logger.warn("interrupted")

--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -845,6 +845,10 @@ async def _main():
         applet.logger.error(e)
         return 1
 
+    except KeyboardInterrupt:
+        logger.warn("interrupted")
+        return 130 # 128 + SIGINT
+
     finally:
         if device is not None:
             device.close()

--- a/software/glasgow/target/toolchain.py
+++ b/software/glasgow/target/toolchain.py
@@ -317,5 +317,5 @@ def find_toolchain(tools=("yosys", "nextpnr-ice40", "icepack")):
             logger.error(f"could not find a usable FPGA toolchain; examined: {examined}")
             logger.error(f"consider reinstalling the package with the 'builtin-toolchain' "
                          f"feature enabled, "
-                         f"e.g.: `pipx install --force -e glasgow/software[toolchain]`")
+                         f"e.g.: `pipx install --force -e glasgow/software[builtin-toolchain]`")
         raise ToolchainNotFound(f"No usable toolchain is available (examined: {', '.join(kinds)})")

--- a/software/glasgow/target/toolchain.py
+++ b/software/glasgow/target/toolchain.py
@@ -1,0 +1,321 @@
+from abc import ABCMeta, abstractmethod
+import os
+import sys
+import hashlib
+import importlib.metadata
+import shutil
+import sysconfig
+import logging
+import subprocess
+import re
+from ..support.lazy import lazy
+
+
+__all__ = ["ToolchainNotFound", "find_toolchain"]
+
+
+logger = logging.getLogger(__name__)
+
+
+class ToolchainNotFound(Exception):
+    pass
+
+
+class Tool(metaclass=ABCMeta):
+    def __init__(self, name):
+        self.name = str(name)
+
+    @property
+    def env_var_name(self):
+        """Name of environment variable used by Amaranth to configure tool location."""
+        # Identical to amaranth._toolchain.tool_env_var.
+        return self.name.upper().replace("-", "_").replace("+", "X")
+
+    @property
+    @abstractmethod
+    def command(self):
+        """Command name for invoking the tool.
+
+        Full path to the executable that can be used to run the tool, or ``None`` if the tool
+        is not available.
+        """
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def available(self):
+        """Tool availability.
+
+        ``True`` if the tool is installed, ``False`` otherwise. Installed binary may still not
+        be runnable, or might be too old to be useful.
+        """
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def version(self):
+        """Tool version number.
+
+        ``None`` if version number could not be determined, or a tool-specific tuple if it could.
+        """
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def identifier(self):
+        """Unique tool identifier.
+
+        Returns an array of 16 bytes that uniquely identifies the behavior of this particular tool
+        in its entirety, but has no other meaning. Typically implemented by hashing the binary and
+        its data files.
+        """
+
+    def __repr__(self):
+        return f"<{self.__class__.__module__}.{self.__class__.__name__} {self.name}>"
+
+
+
+class WasmTool(Tool):
+    PREFIX = "yowasp-"
+
+    @property
+    def python_package(self):
+        if self.name == "yosys" or self.name.startswith("nextpnr-"):
+            return self.PREFIX + self.name
+        if self.name == "icepack":
+            return self.PREFIX + "nextpnr-ice40"
+        if self.name == "ecppack":
+            return self.PREFIX + "nextpnr-ecp5"
+        raise NotImplementedError(f"Python package for tool {self.name} is not known")
+
+    @property
+    def available(self):
+        try:
+            importlib.metadata.metadata(self.python_package)
+            return True
+        except importlib.metadata.PackageNotFoundError:
+            return False
+
+    @property
+    def command(self):
+        if self.available:
+            basename = self.PREFIX + self.name
+            # We cannot assume that the command is on PATH and accessible by its basename. This
+            # will not be true when Glasgow is running from a pipx virtual environment (which isn't
+            # activated when the `glasgow` script is run). Also, our build environment does not
+            # even *have* PATH.
+            return os.path.join(sysconfig.get_path('scripts'), basename)
+
+    @property
+    def version(self):
+        if self.available:
+            # Running Wasm tools for the first time can incur a significant delay, so use
+            # the version from the Python package metadata (which is guaranteed to be the same).
+            # This makes querying the version at least as fast as for the native tools.
+            return (*importlib.metadata.version(self.python_package).split("."),)
+
+    @property
+    def identifier(self):
+        if self.available:
+            hasher = hashlib.blake2s()
+            for file_entry in importlib.metadata.files(self.python_package):
+                if file_entry.hash is None:
+                    continue # RECORD, *.pyc, etc
+                hasher.update(file_entry.hash.value.encode("utf-8"))
+            return hasher.digest()[:16]
+
+
+class SystemTool(Tool):
+    @staticmethod
+    def get_output(args):
+        return subprocess.run(args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            encoding="utf-8").stdout.strip()
+
+    @property
+    def available(self):
+        return self.command is not None
+
+    @property
+    def command(self):
+        return shutil.which(os.environ.get(self.env_var_name, self.name))
+
+    @property
+    def version(self):
+        if self.available:
+            if self.name == "yosys":
+                # Yosys 0.26+50 (git sha1 ef8ed21a2, ccache clang 11.0.1-2 -O0 -fPIC)
+                raw_version = self.get_output([self.command, "--version"])
+                if matches := re.match(r"^Yosys ([^\s]+) \(git sha1 ([0-9a-f]+)", raw_version):
+                    version = matches[1].replace("+", ".").split(".")
+                    return (*version, "g" + matches[2])
+
+            elif self.name.startswith("nextpnr-"):
+                # nextpnr-ice40 -- Nex... ...ce and Route (Version nextpnr-0.2-48-g20e595e2)
+                raw_version = self.get_output([self.command, "--version"])
+                if matches := re.match(r".+?\(Version .+?-(.+)\)$", raw_version):
+                    return (*matches[1].replace("-", ".").split("."),)
+
+            elif self.name == "icepack":
+                # does not have versions; does not have an option to return version
+                return ("0",)
+
+            elif self.name == "ecppack":
+                # Project Trellis ecppack Version 1.3-3-g6845f33
+                raw_version = self.get_output([self.command, "--version"])
+                if matches := re.match(r".+?Version (.+)$", raw_version):
+                    return (*matches[1].replace("-", ".").split("."),)
+
+            else:
+                raise NotImplementedError(f"Cannot extract version from tool {self.name!r}")
+
+    def _iter_data_files(self):
+        def iter_files(start):
+            for root, dirs, files in os.walk(start):
+                for file in files:
+                    yield os.path.join(root, file)
+
+        if self.available:
+            if self.name == "yosys":
+                if yosys_datdir := self.get_output([f"{self.command}-config", "--datdir"]):
+                    return iter_files(yosys_datdir)
+            else:
+                # It is unclear if it is feasible to get at the data files and other dependencies
+                # for nextpnr. However, while it is possible to ship chipdb separately (and Wasm
+                # builds do so), the overwhelming majority of native builds is likely shipping
+                # nxetpnr as a self-contained binary that loads no data.
+                #
+                # Icepack is a self-contained binary. Ecppack is similar to nextpnr.
+                #
+                # This is likely fine.
+                return iter([])
+
+    _identifier_cache = None
+
+    # To the Nix person who replaces this with something more sensible: please message @whitequark
+    @property
+    def identifier(self):
+        if self.available:
+            if self._identifier_cache is None:
+                hasher = hashlib.blake2s()
+                with open(self.command, "rb") as file:
+                    hasher.update(file.read())
+                for data_filename in self._iter_data_files():
+                    with open(data_filename, "rb") as file:
+                        hasher.update(file.read())
+                self._identifier_cache = hasher.digest()[:16]
+            return self._identifier_cache
+
+
+class Toolchain:
+    def __init__(self, tools):
+        self.tools = list(tools)
+
+    @property
+    def available(self):
+        """Toolchain availability.
+
+        ``True`` if every tool is available, ``False`` otherwise.
+        """
+        return all(tool.available for tool in self.tools)
+
+    @property
+    def missing(self):
+        """Tools that are missing from the toolchain.
+
+        An iterator that yields the name of every tool whose version could not be determined,
+        because it is either unavailable or crashes when run.
+        """
+        return (tool.name for tool in self.tools if not tool.available or tool.version is None)
+
+    @property
+    def env_vars(self):
+        """Environment variables to bring the toolchain in scope.
+
+        An environment dictionary that includes entries for every of the tools included in this
+        toolchain, and nothing else.
+
+        Can be passed to :meth:`amaranth.build.run.BuildPlan.execute_local()` as the `env`
+        argument in order to build a bitstream using this toolchain while isolating the build
+        from any environmental impurity.
+        """
+        return {tool.env_var_name: tool.command for tool in self.tools}
+
+    @property
+    def versions(self):
+        """Versions of tools.
+
+        A dictionary that maps names of tools to their versions.
+        """
+        return {tool.name: tool.version for tool in self.tools}
+
+    @property
+    def identifier(self):
+        """Unique toolchain identifier.
+
+        Returns an array of 16 bytes that uniquely identifies this particular collection of tools,
+        but has no other meaning.
+        """
+        hasher = hashlib.blake2s()
+        for tool in self.tools:
+            if not tool.available:
+                return None
+            hasher.update(tool.identifier)
+        return hasher.digest()[:16]
+
+    def __str__(self):
+        return ", ".join(f"{name} {'.'.join(ver or ('(unavailable)',))}"
+                         for name, ver in self.versions.items())
+
+    def __repr__(self):
+        return (f"<{self.__class__.__module__}.{self.__class__.__name__} " +
+                " ".join(f"{tool.command}=={'.'.join(tool.version or ('unavailable',))}"
+                         for tool in self.tools) +
+                f">")
+
+
+def find_toolchain(tools=("yosys", "nextpnr-ice40", "icepack")):
+    """Discover a toolchain.
+
+    Returns a :class:`Toolchain` that includes all of the requested tools chosen according to
+    the ``GLASGOW_TOOLCHAIN`` environment variable, or raises :exn:`ToolchainNotFound` if such
+    toolchain isn't available within the constraints.
+    """
+    env_var_name = "GLASGOW_TOOLCHAIN"
+    available_toolchains = {
+        "builtin": Toolchain(map(WasmTool,   tools)),
+        "system":  Toolchain(map(SystemTool, tools)),
+    }
+
+    kinds = os.environ.get(env_var_name, ",".join(available_toolchains.keys())).split(",")
+    for kind in kinds:
+        if kind not in available_toolchains:
+            logger.error(f"the {env_var_name} environment variable contains "
+                         f"an unrecognized toolchain kind {kind!r}, available: "
+                         f"{', '.join(available_toolchains)}")
+            raise ToolchainNotFound(f"Unknown toolchain kind {kind!r} in {env_var_name}")
+
+    selected_toolchains = {kind: available_toolchains[kind] for kind in kinds}
+    for kind, toolchain in selected_toolchains.items():
+        if toolchain.available:
+            logger.debug(f"using toolchain {kind!r} ({toolchain})")
+            for tool in toolchain.tools:
+                logger.trace(f"tool {tool.name!r} is invoked as {tool.command!r}")
+            logger.trace(f"toolchain ID is %s", lazy(lambda: toolchain.identifier.hex()))
+            for tool in toolchain.tools:
+                logger.trace(f"tool ID of {tool.name!r} is %s", lazy(lambda: tool.identifier.hex()))
+            return toolchain
+
+    else:
+        examined = ", ".join(f"{kind} (missing {', '.join(selected_toolchains[kind].missing)})"
+                             for kind in kinds)
+        if env_var_name in os.environ:
+            logger.error(f"could not find a usable FPGA toolchain; "
+                         f"examined (according to {env_var_name}): {examined}")
+        else:
+            logger.error(f"could not find a usable FPGA toolchain; examined: {examined}")
+            logger.error(f"consider reinstalling the package with the 'builtin-toolchain' "
+                         f"feature enabled, "
+                         f"e.g.: `pipx install --force -e glasgow/software[toolchain]`")
+        raise ToolchainNotFound(f"No usable toolchain is available (examined: {', '.join(kinds)})")

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-toolchain = [
+builtin-toolchain = [
   "amaranth-yosys", # use amaranth[builtin-yosys] when tooling stops breaking
   "yowasp-runtime>=1.30",
   "yowasp-yosys>=0.31.0.13",

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -32,8 +32,9 @@ dependencies = [
 
 [project.optional-dependencies]
 toolchain = [
-  "amaranth-yosys",
-  "yowasp-yosys>=0.11",
+  "amaranth-yosys", # use amaranth[builtin-yosys] when tooling stops breaking
+  "yowasp-runtime>=1.30",
+  "yowasp-yosys>=0.31.0.13",
   "yowasp-nextpnr-ice40>=0.1",
 ]
 


### PR DESCRIPTION
This commit adds a mechanism to Glasgow similar to the existing `AMARANTH_USE_YOSYS` mechanism that selects a Yosys binary to run. It introduces the concept of a toolchain (a collection of tools that come from a single source; currently, either the system binaries or the co-installed YoWASP packages). The toolchain is used as a whole, i.e. system and YoWASP packages cannot be mixed since this has a high probability of being a mistake. Any missing components required for operation are reported.

To select the toolchain, a new `GLASGOW_TOOLCHAIN` environment variable is introduced. It can be set to `builtin`, `system`, or a comma separated list where earlier entry has priority.

The default is `builtin,system` to make YoWASP packages take priority since when installed with pipx or pdm, these packages are guaranteed to provide a consistent experience.

Experienced users can globally set `GLASGOW_TOOLCHAIN` to be `system` or `system,builtin`, which will improve bitstream build performance.

The digest of the tool versions is included in the bitstream ID, meaning the applets will be rebuilt if the toolchain is upgraded.

The `target.toolchain` code includes support for `nextpnr-ecp5` and `ecppack` that are not currently used. We're likely to use them in the future so it doesn't hurt to have them here.

This commit also updates the installation instructions, which are now almost entirely aligned for all OSes, and do not require anything besides git, Python, and pipx.