### PR TITLE
target: cache bitstreams

### DIFF
--- a/software/glasgow/applet/__init__.py
+++ b/software/glasgow/applet/__init__.py
@@ -231,7 +231,7 @@ class GlasgowAppletTestCase(unittest.TestCase):
             raise AssertionError("argument parsing failed") from None
         self.applet.build(target, parsed_args)
 
-        target.build_plan().execute()
+        target.build_plan().get_bitstream()
 
     def _prepare_applet_args(self, args, access_args, interact=False):
         parser = argparse.ArgumentParser()

--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -244,8 +244,8 @@ def get_argparser():
 
         g_run_bitstream = parser.add_mutually_exclusive_group()
         g_run_bitstream.add_argument(
-            "--rebuild", default=False, action="store_true",
-            help="(advanced) rebuild bitstream even if an identical one is already loaded")
+            "--reload", default=False, action="store_true",
+            help="(advanced) reload bitstream even if an identical one is already loaded")
         g_run_bitstream.add_argument(
             "--prebuilt", default=False, action="store_true",
             help="(advanced) load prebuilt applet bitstream from ./<applet-name.bin>")
@@ -524,7 +524,7 @@ async def _main():
                 with bitstream_file:
                     await device.download_prebuilt(plan, bitstream_file)
             else:
-                await device.download_target(plan, rebuild=args.rebuild)
+                await device.download_target(plan, reload=args.reload)
 
             do_trace = hasattr(args, "trace") and args.trace
             if do_trace:
@@ -695,18 +695,18 @@ async def _main():
                     glasgow_config.bitstream_size = len(new_bitstream)
                     glasgow_config.bitstream_id   = new_bitstream_id
             elif args.applet:
-                logger.info("building bitstream for applet %s", args.applet)
+                logger.info("generating bitstream for applet %s", args.applet)
                 target, applet = _applet(device.revision, args)
                 plan = target.build_plan()
                 new_bitstream_id = plan.bitstream_id
-                new_bitstream    = plan.execute()
+                new_bitstream    = plan.get_bitstream()
 
                 # We always build and reflash the bitstream in case the one currently
                 # in EEPROM is corrupted. If we only compared the ID, there would be
                 # no easy way to recover from that case. There's also no point in
                 # storing the bitstream hash (as opposed to Verilog hash) in the ID,
                 # as building the bitstream takes much longer than flashing it.
-                logger.info("built bitstream ID %s", new_bitstream_id.hex())
+                logger.info("generated bitstream ID %s", new_bitstream_id.hex())
                 glasgow_config.bitstream_size = len(new_bitstream)
                 glasgow_config.bitstream_id   = new_bitstream_id
 
@@ -761,17 +761,17 @@ async def _main():
             target, applet = _applet(args.rev, args)
             plan = target.build_plan()
             if args.type in ("il", "rtlil"):
-                logger.info("building RTLIL for applet %r", args.applet)
+                logger.info("generating RTLIL for applet %r", args.applet)
                 with open(args.filename or args.applet + ".il", "wt") as f:
                     f.write(plan.rtlil)
             if args.type in ("zip", "archive"):
-                logger.info("building archive for applet %r", args.applet)
+                logger.info("generating archive for applet %r", args.applet)
                 plan.archive(args.filename or args.applet + ".zip")
             if args.type in ("bin", "bitstream"):
-                logger.info("building bitstream for applet %r", args.applet)
+                logger.info("generating bitstream for applet %r", args.applet)
                 with open(args.filename or args.applet + ".bin", "wb") as f:
                     f.write(plan.bitstream_id)
-                    f.write(plan.execute())
+                    f.write(plan.get_bitstream())
 
         if args.action == "test":
             logger.info("testing applet %r", args.applet)

--- a/software/glasgow/device/hardware.py
+++ b/software/glasgow/device/hardware.py
@@ -419,12 +419,12 @@ class GlasgowHardwareDevice:
         except usb1.USBErrorPipe:
             raise GlasgowDeviceError("FPGA configuration failed")
 
-    async def download_target(self, plan, *, rebuild=False):
-        if await self.bitstream_id() == plan.bitstream_id and not rebuild:
+    async def download_target(self, plan, *, reload=False):
+        if await self.bitstream_id() == plan.bitstream_id and not reload:
             logger.info("device already has bitstream ID %s", plan.bitstream_id.hex())
             return
-        logger.info("building bitstream ID %s", plan.bitstream_id.hex())
-        await self.download_bitstream(plan.execute(), plan.bitstream_id)
+        logger.info("generating bitstream ID %s", plan.bitstream_id.hex())
+        await self.download_bitstream(plan.get_bitstream(), plan.bitstream_id)
 
     async def download_prebuilt(self, plan, bitstream_file):
         bitstream_file_id = bitstream_file.read(16)

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 requires-python = "~=3.8"
 
 dependencies = [
+  "appdirs~=1.4",
   "amaranth @ git+https://github.com/amaranth-lang/amaranth.git",
   "fx2>=0.11",
   "libusb1>=1.8.1",


### PR DESCRIPTION
This is a major usability improvement for two use cases:
* routine and recommended use of the reset button on revC2+, which is otherwise excruciatingly slow;
* frequent switching between multiple specific applet configurations, useful as a workaround for the lack of multiple applet support.

This commit should make most uses of `run --prebuilt` obsolete.

Fixes #43 (again).

Depends on #353.