### PR TITLE
software: use PDM to manage dependencies on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,14 @@ jobs:
       - name: Install dependencies
         working-directory: ./software
         run: pdm install -G :all
+      - name: Preserve caches
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/wasmtime
+            ~/.cache/YoWASP
+            ~/.cache/GlasgowEmbedded
+          key: ${{ runner.os }}
       - name: Run tests
         working-directory: ./software
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,19 +31,18 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install PDM
+        run: curl -sSL https://pdm.fming.dev/dev/install-pdm.py | python -
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip setuptools wheel
-          python -m pip install git+https://github.com/amaranth-lang/amaranth.git
-      - name: Install software
-        run: python -m pip install -e ./software[toolchain]
+        working-directory: ./software
+        run: pdm install -G :all
       - name: Run tests
         working-directory: ./software
         env:
           YOSYS: yowasp-yosys
           NEXTPNR_ICE40: yowasp-nextpnr-ice40
           ICEPACK: yowasp-icepack
-        run: python test.py -v
+        run: pdm run test
 
   build-firmware:
     runs-on: ubuntu-20.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,11 +24,11 @@ jobs:
     name: 'test-software (${{ matrix.python-version }})'
     steps:
       - name: Check out source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install PDM
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Install dependencies

--- a/software/glasgow/applet/__init__.py
+++ b/software/glasgow/applet/__init__.py
@@ -113,7 +113,7 @@ from ..target.simulation import *
 from ..target.hardware import *
 from ..device.simulation import *
 from ..device.hardware import *
-from ..platform.all import GlasgowPlatformRevAB
+from ..target.toolchain import find_toolchain
 
 
 __all__ += ["GlasgowAppletTestCase", "synthesis_test", "applet_simulation_test",
@@ -297,7 +297,7 @@ class GlasgowAppletTestCase(unittest.TestCase):
 
 
 def synthesis_test(case):
-    synthesis_available = GlasgowPlatformRevAB().has_required_tools()
+    synthesis_available = find_toolchain(quiet=True) is not None
     return unittest.skipUnless(synthesis_available, "synthesis not available")(case)
 
 

--- a/software/glasgow/target/toolchain.py
+++ b/software/glasgow/target/toolchain.py
@@ -275,7 +275,7 @@ class Toolchain:
                 f">")
 
 
-def find_toolchain(tools=("yosys", "nextpnr-ice40", "icepack")):
+def find_toolchain(tools=("yosys", "nextpnr-ice40", "icepack"), *, quiet=False):
     """Discover a toolchain.
 
     Returns a :class:`Toolchain` that includes all of the requested tools chosen according to
@@ -291,6 +291,8 @@ def find_toolchain(tools=("yosys", "nextpnr-ice40", "icepack")):
     kinds = os.environ.get(env_var_name, ",".join(available_toolchains.keys())).split(",")
     for kind in kinds:
         if kind not in available_toolchains:
+            if quiet:
+                return
             logger.error(f"the {env_var_name} environment variable contains "
                          f"an unrecognized toolchain kind {kind!r}, available: "
                          f"{', '.join(available_toolchains)}")
@@ -308,6 +310,8 @@ def find_toolchain(tools=("yosys", "nextpnr-ice40", "icepack")):
             return toolchain
 
     else:
+        if quiet:
+            return
         examined = ", ".join(f"{kind} (missing {', '.join(selected_toolchains[kind].missing)})"
                              for kind in kinds)
         if env_var_name in os.environ:

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -1,7 +1,3 @@
-[build-system]
-requires = ["setuptools>=67.0", "setuptools_scm[toml]>=6.2"]
-build-backend = "setuptools.build_meta"
-
 [project]
 dynamic = ["version"]
 
@@ -47,9 +43,23 @@ glasgow = "glasgow.cli:main"
 "Source Code" = "https://github.com/GlasgowEmebedded/Glasgow"
 "Bug Tracker" = "https://github.com/GlasgowEmebedded/Glasgow/issues"
 
+# Build system configuration
+
+[build-system]
+requires = ["setuptools>=67.0", "setuptools_scm[toml]>=6.2"]
+build-backend = "setuptools.build_meta"
+
 [tool.setuptools.package-data]
 "glasgow.device" = ["firmware.ihex"]
 
 [tool.setuptools_scm]
 root = ".."
 local_scheme = "node-and-timestamp"
+
+# Development workflow configuration
+
+[tool.pdm.dev-dependencies]
+test = ["setuptools"]
+
+[tool.pdm.scripts]
+test = {cmd = "test.py -v"}


### PR DESCRIPTION
At the moment (since commit 36769e73) synthesis tests are not running on CI because a request to install nonexistent optional dependency group is silently ignored by pip.

Pip is not really suited for this workflow, so use PDM instead, and also set up the `pdm run test` alias since the test runner is liable to change in the future.