### PR TITLE
device.hardware: print causes of `set_voltage()` failure

### DIFF
--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -495,7 +495,7 @@ async def _main():
                     await device.set_alert_tolerance(args.ports, args.voltage,
                                                      args.tolerance / 100)
 
-            print("Port\tVio\tVlimit\tVsense\tMonitor")
+            print("Port\tVio\tVlimit\tVsense\tVsense(range)")
             alerts = await device.poll_alert()
             for port in args.ports:
                 vio    = await device.get_voltage(port)


### PR DESCRIPTION
For example:

    $ glasgow voltage
    Port    Vio     Vlimit  Vsense  Monitor
    A       0.0     5.5     0.0     0.0-5.5
    B       0.0     3.3     0.0     0.0-5.5
    $ glasgow voltage AB 5
    E: g.cli: cannot set I/O port(s) AB voltage to 5.0 V (port B voltage limit is set to 3.3 V)

It is easy to miss the value in the Vlimit column. The display of causes of the error avoids a source of frustration, and ensures that voltage limit caused errors do not mislead the operator into thinking that their device is faulty.