### PR TITLE
Use proper `amaranth[builtin-yosys]` dependency

### DIFF
--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -18,7 +18,7 @@ requires-python = "~=3.8"
 
 dependencies = [
   "appdirs~=1.4",
-  "amaranth @ git+https://github.com/amaranth-lang/amaranth.git",
+  "amaranth[builtin-yosys] @ git+https://github.com/amaranth-lang/amaranth.git",
   "fx2>=0.11",
   "libusb1>=1.8.1",
   "aiohttp~=3.8",
@@ -28,7 +28,6 @@ dependencies = [
 
 [project.optional-dependencies]
 builtin-toolchain = [
-  "amaranth-yosys", # use amaranth[builtin-yosys] when tooling stops breaking
   "yowasp-runtime>=1.30",
   "yowasp-yosys>=0.31.0.13",
   "yowasp-nextpnr-ice40>=0.1",


### PR DESCRIPTION
PDM 2.8.1 has fixed the bug that prevented its use before.