### PR TITLE
target.hardware: whitelist `HOME` on Linux

### DIFF
--- a/software/glasgow/target/hardware.py
+++ b/software/glasgow/target/hardware.py
@@ -135,11 +135,17 @@ class GlasgowBuildPlan:
         if build_dir is None:
             build_dir = tempfile.mkdtemp(prefix="glasgow_")
         try:
-            environ = self.toolchain.env_vars
-            if os.name == 'nt':
+            env_whitelist = []
+
+            if os.name == "posix":
+                env_whitelist.append("HOME")
+            elif os.name == "nt":
                 # PROCESSOR_ARCHITECTURE: required for YoWASP (used by wasmtime)
-                for var in ("PROCESSOR_ARCHITECTURE",):
-                    environ[var] = os.environ[var]
+                env_whitelist.append("PROCESSOR_ARCHITECTURE")
+
+            environ = self.toolchain.env_vars
+            environ.update({ k:v for k,v in os.environ.items() if k in env_whitelist })
+
             products  = self.lower.execute_local(build_dir, env=environ)
             bitstream = products.get("top.bin")
         except:


### PR DESCRIPTION
This resovles errors when nextpnr-ice40 tries to create directories in the rootfs (follow on from #384)

See: https://github.com/YosysHQ/oss-cad-suite-build/issues/75