### PR TITLE
applet.selftest: fix `leds` mode.

### DIFF
--- a/software/glasgow/applet/internal/selftest/__init__.py
+++ b/software/glasgow/applet/internal/selftest/__init__.py
@@ -42,7 +42,7 @@ class SelfTestSubtarget(Elaboratable):
             self.reg_i_b.eq(Cat(pin.io.i for pin in self.pins_b))
         ]
 
-        m.d.comb += Cat(self.leds).eq(self.reg_leds)
+        m.d.comb += Cat(pin.o for pin in self.leds).eq(self.reg_leds)
 
         return m
 


### PR DESCRIPTION
Fixes the following error:

    TypeError: Object flipped((rec led_0 o)) cannot be converted to an Amaranth value

Tested on revC3-ish.