### PR TITLE
firmware: include git revision in product string

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ name: CI
 jobs:
 
   test-software:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version:
@@ -54,7 +54,7 @@ jobs:
         run: pdm run test
 
   build-firmware:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out source code
         uses: actions/checkout@v3

--- a/firmware/.gitignore
+++ b/firmware/.gitignore
@@ -1,2 +1,3 @@
 /build
 *.ihex
+version.h

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -13,3 +13,18 @@ CFLAGS    = -DSYNCDELAYLEN=16 -DCONF_SIZE=$(CONF_SIZE)
 
 LIBFX2    = ../vendor/libfx2/firmware/library
 include $(LIBFX2)/fx2rules.mk
+
+# Make executes makefiles in two stages: first it builds a dependency graph and determines freshness, and then it
+# starts to actually build the targets. By the time it starts to build, any updates to the freshness of files on
+# disk will be ignored; therefore we need to build the `version.h` target during the first stage. In practical
+# terms this is accomplished by building it as a part of an immediate assignment.
+#
+# Yes, this is awful. I am so proud of it =^_^=
+GIT_REV_SHORT   = $(shell git log -1 --abbrev=8 --pretty=%h HEAD .)
+ifneq ($(shell git diff-index --exit-code HEAD -- .),)
+GIT_TREE_DIRTY  = .dirty
+endif
+VERSION_H_RULE := $(shell \
+	echo "#define GIT_REVISION \"$(GIT_REV_SHORT)$(GIT_TREE_DIRTY)\"" >.version.h && \
+	if ! diff -q .version.h version.h 2>/dev/null ; then mv .version.h version.h; else rm -f .version.h; fi \
+)

--- a/firmware/main.c
+++ b/firmware/main.c
@@ -8,6 +8,7 @@
 #include <fx2eeprom.h>
 #include <usbmicrosoft.h>
 #include "glasgow.h"
+#include "version.h"
 
 // bcdDevice is a 16-bit number where the high byte indicates the API revision and the low byte
 // indicates the hardware revision. If the firmware is not flashed (only the FX2 header is present)
@@ -145,7 +146,7 @@ usb_configuration_set_c usb_configs[] = {
 
 usb_ascii_string_c usb_strings[] = {
   [0] = "whitequark research\0\0\0\0", // 23 characters
-  [1] = "Glasgow Interface Explorer",
+  [1] = "Glasgow Interface Explorer (git " GIT_REVISION ")",
   [2] = "XX-XXXXXXXXXXXXXXXX",
   // Configurations
   [3] = "Pipe P at {2x512B EP2OUT/EP6IN}, Q at {2x512B EP4OUT/EP8IN}",


### PR DESCRIPTION
In the issue #382, @VioletEternity pointed out that it is not currently possible to find out which git commit a firmware was built.

This commit introduces the embedding of the hash of the commit containing the last modification to the `firmware/` (git) tree in the product string that is visible in the device properties, for example on Linux it can be retrieved like this:

```
$ lsusb -d 20b7:9db1 -v | grep iProduct
  iProduct                2 Glasgow Interface Explorer (git 52734ce9)
```

Because a commit cannot include its own hash (without a successful preimage attack on SHA1), the commit that is updating the built-in firmware in the `software/glasgow/device/firmware.ihex` file needs to be separate from the commit that updates the firmware code. Because the version is recorded for the latest change of the `firmware/` tree, which is not modified in the second commit, it stays consistent afterwards.