### PR TITLE
manual: index: add opengraph and twitter metadata

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,7 +135,17 @@ jobs:
             <link rel="canonical" href="latest/">
             <script>location="latest/"</script>
             <meta http-equiv="refresh" content="0; url=latest/">
-            <meta name="robots" content="noindex">
+            <meta content="Glasgow Interface Explorer" name="og:title" />
+            <meta content="website" name="og:type" />
+            <meta content="https://glasgow-embedded.org/" name="og:url" />
+            <meta content="A highly capable and extremely flexible open source multitool for digital electronics" name="og:description" />
+            <meta content="https://www.crowdsupply.com/img/f9a9/glasgow-revc2_jpg_open-graph.jpg" name="og:image" />
+            <meta content="A Glasgow Interface Explorer PCB, without a case" name="og:image:alt" />
+            <meta content="Glasgow Interface Explorer" name="twitter:title" />
+            <meta content="summary_large_image" name="twitter:card" />
+            <meta content="A highly capable and extremely flexible open source multitool for digital electronics" name="twitter:description" />
+            <meta content="https://www.crowdsupply.com/img/f9a9/glasgow-revc2_jpg_project-main.jpg" name="twitter:image" />
+            <meta content="A Glasgow Interface Explorer PCB, without a case" name="twitter:image:alt" />
             <h1>Redirecting&hellip;</h1>
             <a href="latest/">Click here if you are not redirected.</a>
           </html>

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,5 +153,5 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@releases/v4
         with:
           folder: pages/
-          clean: true
+          clean: ${{ github.repository == 'GlasgowEmbedded/glasgow' && github.event.ref == 'refs/heads/main' }}
           single-commit: true

--- a/docs/manual/src/index.rst
+++ b/docs/manual/src/index.rst
@@ -1,3 +1,24 @@
+..
+    These meta tags only affect direct fetches of https://glasgow-embedded.org/latest/.
+    The landing page at https://glasgow-embedded.org/ is created in the GitHub Actions workflow and
+    must be maintained manually (by copying these tags from the HTML source, probably).
+
+.. meta::
+
+    :og:title: Glasgow Interface Explorer
+    :og:type: website
+    :og:url: https://glasgow-embedded.org/
+    :og:description: A highly capable and extremely flexible open source multitool for digital electronics
+    :og:image: https://www.crowdsupply.com/img/f9a9/glasgow-revc2_jpg_open-graph.jpg
+    :og:image:alt: A Glasgow Interface Explorer PCB, without a case
+
+    :twitter:title: Glasgow Interface Explorer
+    :twitter:card: summary_large_image
+    :twitter:description: A highly capable and extremely flexible open source multitool for digital electronics
+    :twitter:image: https://www.crowdsupply.com/img/f9a9/glasgow-revc2_jpg_project-main.jpg
+    :twitter:image:alt: A Glasgow Interface Explorer PCB, without a case
+
+
 Glasgow Interface Explorer manual
 ---------------------------------
 


### PR DESCRIPTION
It is unclear whether services will follow the meta redirect on the landing /index.html page, but it seems the answer is "probably not". Be safe and add the metadata both on /index.html and /latest/index.html, for good measure.

Fixes #401.