### PR TITLE
manual: make the call-to-action announcement green

### DIFF
--- a/docs/manual/src/conf.py
+++ b/docs/manual/src/conf.py
@@ -44,6 +44,14 @@ html_theme_options = {
 }
 if is_production:
     html_theme_options.update({
+        "light_css_variables": {
+            "color-announcement-background": "#56bf62",
+            "color-announcement-text": "#094a05",
+        },
+        "dark_css_variables": {
+            "color-announcement-background": "#1c4808",
+            "color-announcement-text": "#64cc69",
+        },
         "announcement":
             "The Early Bird units are being shipped by Mouser! "
             "<a href='https://crowdsupply.com/1bitsquared/glasgow'>Pre-Order yours now</a>"


### PR DESCRIPTION
This bothered me for a while.

(It's not visible in the docs built from the PR--you'll have to check out locally.)