### PR TITLE
cli: add support for passing command-line arguments to the REPL and script environments

### DIFF
--- a/examples/script_args.py
+++ b/examples/script_args.py
@@ -1,0 +1,8 @@
+import argparse
+
+parser = argparse.ArgumentParser('script_args.py')
+parser.add_argument('-m', '--my-arg', default=0, type=int)
+
+my_args = parser.parse_args(args.script_args)
+
+print(my_args)

--- a/software/glasgow/applet/__init__.py
+++ b/software/glasgow/applet/__init__.py
@@ -74,7 +74,7 @@ class GlasgowApplet(metaclass=ABCMeta):
 
     async def repl(self, device, args, iface):
         self.logger.info("dropping to REPL; use 'help(iface)' to see available APIs")
-        await AsyncInteractiveConsole(locals={"device":device, "iface":iface},
+        await AsyncInteractiveConsole(locals={"device":device, "iface":iface, "args":args},
             run_callback=device.demultiplexer.flush).interact()
 
 


### PR DESCRIPTION
As discussed in `#glasgow`, it would be nice to make command line arguments available to the REPL and script environments (especially the latter).

This patch adds support for this, with a small example script.