### PR TITLE
Add --allow_urls option to audio-yamaha-opx applet

### DIFF
--- a/software/glasgow/applet/audio/yamaha_opx/__init__.py
+++ b/software/glasgow/applet/audio/yamaha_opx/__init__.py
@@ -814,18 +814,21 @@ class YamahaVGMStreamPlayer(VGMStreamPlayer):
 
 
 class YamahaOPxWebInterface:
-    def __init__(self, logger, opx_iface, set_voltage):
+    def __init__(self, logger, opx_iface, set_voltage, allow_urls):
         self._logger    = logger
         self._opx_iface = opx_iface
         self._lock      = asyncio.Lock()
 
         self._set_voltage = set_voltage
+        self._allow_urls = allow_urls
 
     async def serve_index(self, request):
         with open(os.path.join(os.path.dirname(__file__), "index.html")) as f:
             index_html = f.read()
             index_html = index_html.replace("{{chip}}", self._opx_iface.chips[-1])
             index_html = index_html.replace("{{compat}}", ", ".join(self._opx_iface.chips))
+            index_html = index_html.replace("{{url_display}}",
+                                            "block" if self._allow_urls else "none")
             return aiohttp.web.Response(text=index_html, content_type="text/html")
 
     async def serve_vgm(self, request):
@@ -840,6 +843,11 @@ class YamahaOPxWebInterface:
         elif vgm_msg.type == aiohttp.WSMsgType.TEXT:
             self._logger.info("web: URL %s submitted by %s",
                               vgm_msg.data, request.remote)
+
+            if not self._allow_urls:
+                self._logger.warning("Received URL submission when disabled")
+                await sock.close(code=405, message="URL submissions not allowed")
+                return sock
 
             async with aiohttp.ClientSession() as client_sess:
                 async with client_sess.get(vgm_msg.data) as client_resp:
@@ -1162,6 +1170,9 @@ class AudioYamahaOPxApplet(GlasgowApplet):
         p_web = p_operation.add_parser(
             "web", help="expose Yamaha hardware via a web interface")
         p_web.add_argument(
+            "--allow-urls", action='store_true',
+            help="allow users to specify a URL to play a VGM/VGZ file from (use with caution)")
+        p_web.add_argument(
             "endpoint", metavar="ENDPOINT", type=str, default="localhost:8080",
             help="listen for requests on ENDPOINT (default: %(default)s)")
 
@@ -1215,7 +1226,7 @@ class AudioYamahaOPxApplet(GlasgowApplet):
         if args.operation == "web":
             async def set_voltage(voltage):
                 await device.set_voltage(args.port_spec, voltage)
-            web_iface = YamahaOPxWebInterface(self.logger, opx_iface, set_voltage=set_voltage)
+            web_iface = YamahaOPxWebInterface(self.logger, opx_iface, set_voltage, args.allow_urls)
             await web_iface.serve(args.endpoint)
 
         if args.operation == "run":

--- a/software/glasgow/applet/audio/yamaha_opx/index.html
+++ b/software/glasgow/applet/audio/yamaha_opx/index.html
@@ -9,7 +9,7 @@
   <p>Connected synthesizer: {{chip}}. Playback support for: {{compat}}.</p>
   <p><b>Glitching</b>: undervolt to <input type="number" min="1.65" max="5.50" value="5.00" step="0.01" id="voltage"></p>
   <p>Upload a <a href="https://vgmrips.net/packs/chips">VGM/VGZ file</a>: <input type="file" id="vgmFile" accept=".vgm,.vgz"></p>
-  <p>... or provide an URL for it: <input type="url" id="vgmUrl" size="50"></p>
+  <p style="display: {{url_display}};">... or provide an URL for it: <input type="url" id="vgmUrl" size="50"></p>
   <p>Control: <input type="button" id="play" value="Play"> <input type="button" id="replay" value="Replay" disabled> <input type="checkbox" id="loop"> <label for="loop">Loop</label> <input type="button" id="exportFull" value="Export full" disabled> <input type="button" id="exportLoop" value="Export loop" disabled></p>
   <p>Status: <span id="chipStatus">no chip</span>, <span id="pcmStatus">no format</span>, <span id="netStatus">idle</span>, <span id="playStatus">stopped</span>.</p>
   <p id="errorPane" style="color:red; display:none">Error: <span id="error"></span></p>


### PR DESCRIPTION
The `audio-yamaha-opx` applet potentially allows remote users to make GET requests to arbitrary URLs. This may have security implications (e.g., accessing internal IP addresses, or accessing prohibited URLs). This patch disables this feature by default, but allows users to opt back in by passing the `--allow_urls` flag to the `audio-yamaha-opx` applet.