### PR TITLE
applet.audio.yamaha_opx: fix listening on IPv6 endpoints

### DIFF
--- a/software/glasgow/applet/audio/yamaha_opx/__init__.py
+++ b/software/glasgow/applet/audio/yamaha_opx/__init__.py
@@ -147,6 +147,7 @@ import io
 from amaranth import *
 from amaranth.lib import data
 from amaranth.lib.cdc import FFSynchronizer
+from urllib.parse import urlparse
 
 from ....gateware.pads import *
 from ....gateware.clockgen import *
@@ -1014,7 +1015,8 @@ class YamahaOPxWebInterface:
         runner = aiohttp.web.AppRunner(app,
             access_log_format='%a(%{X-Forwarded-For}i) "%r" %s "%{Referer}i" "%{User-Agent}i"')
         await runner.setup()
-        site = aiohttp.web.TCPSite(runner, *endpoint.split(":", 1))
+        parsed_endpoint = urlparse(f"//{endpoint}")
+        site = aiohttp.web.TCPSite(runner, parsed_endpoint.hostname, parsed_endpoint.port)
         await site.start()
         await asyncio.Future()
 


### PR DESCRIPTION
This resolves an issue where you can't specify an IPv6 endpoint like '[2602:fce8:101:69:d886:936e:f259:3927]:3128'