### PR TITLE
cli: add platform, architecture, and OS version to `--version` output

### DIFF
--- a/docs/manual/src/contribute.rst
+++ b/docs/manual/src/contribute.rst
@@ -15,9 +15,7 @@ Bug reports are always welcome! If you are experiencing an issue with your devic
 
 For a timely resolution of your issues involving the Glasgow software, include the following information when `reporting a bug on GitHub <issues_>`__:
 
-* Your operating system, including its version (e.g.: "Debian Linux bookworm" or "Windows 10 update 22H2");
-
-* The version of the Glasgow software stack (as printed by ``glasgow --version``);
+* The version of the Glasgow software stack and environment components (as printed by ``glasgow --version``);
 
 * The complete debug information produced by the command you are running (as printed by ``glasgow -vvv [command...]``).
 

--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import ast
+import platform
 import logging
 import argparse
 import textwrap
@@ -71,15 +72,30 @@ class TextHelpFormatter(argparse.HelpFormatter):
         return re.sub(r"((?!\n\n)(?!\n\s+(?:\*|\$|\d+\.)).)+(\n*)?", filler, text, flags=re.S)
 
 
+def version_info():
+    glasgow_version = __version__
+    python_version = '.'.join(map(str, sys.version_info[:3]))
+    python_implementation = platform.python_implementation()
+    python_platform = platform.platform()
+    freedesktop_os_name = ""
+    if hasattr(platform, "freedesktop_os_release"): # TODO(py3.9): present in 3.10+
+        try:
+            freedesktop_os_release = platform.freedesktop_os_release()
+            if "PRETTY_NAME" in freedesktop_os_release:
+                freedesktop_os_name = f" {freedesktop_os_release['PRETTY_NAME']}"
+        except OSError:
+            pass
+    return (
+        f"Glasgow {glasgow_version} "
+        f"({python_implementation} {python_version} on {python_platform}{freedesktop_os_name})"
+    )
+
+
 def create_argparser():
     parser = argparse.ArgumentParser(formatter_class=TextHelpFormatter)
 
-    version = "Glasgow version {version} (Python {python_version})" \
-        .format(python_version=".".join(str(n) for n in sys.version_info[:3]),
-                version=__version__)
-
     parser.add_argument(
-        "-V", "--version", action="version", version=version,
+        "-V", "--version", action="version", version=version_info(),
         help="show version and exit")
     parser.add_argument(
         "-v", "--verbose", default=0, action="count",


### PR DESCRIPTION
Fixes #400.

Output looks like this:

```
$ pdm run glasgow --version
Glasgow 0.1.dev1826+g4fe4acc.d20231004164618 (CPython 3.9.18 on Linux-6.1.0-10-amd64-x86_64-with-glibc2.37)

$ pdm run glasgow --version
Glasgow 0.1.dev1825+gcc2acdc (CPython 3.11.2 on Linux-6.1.0-10-amd64-x86_64-with-glibc2.36 Debian GNU/Linux 12 (bookworm))

% pdm run glasgow --version
Glasgow 0.1.dev1889+gb95a16e (CPython 3.11.5 on macOS-13.4.1-arm64-arm-64bit)

>pdm run glasgow --version
Glasgow 0.1.dev1891+g3833fcb (CPython 3.11.4 on Windows-10-10.0.19045-SP0)
```