### PR TITLE
Python 3.12 is released, 3.13-dev is the next development snapshot

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,12 +20,15 @@ jobs:
         allow-failure:
         - false
         include:
-          - os-version: ubuntu-latest
-            python-version: '3.12-dev'
-            allow-failure: true
           - os-version: ubuntu-20.04
             python-version: '3.9.5' # shipped with 20.04 LTS
             allow-failure: false
+          - os-version: ubuntu-latest
+            python-version: '3.12'
+            allow-failure: true
+          - os-version: ubuntu-latest
+            python-version: '3.13-dev'
+            allow-failure: true
     continue-on-error: '${{ matrix.allow-failure }}'
     runs-on: ${{ matrix.os-version }}
     name: 'test-software (${{ matrix.python-version }})'


### PR DESCRIPTION
aiohttp still doesn't work on 3.12, but that's mostly out of our hands.