### PR TITLE
revC3: Added aluminium case outline with tolerance.

### DIFF
--- a/hardware/boards/glasgow/glasgow.kicad_pcb
+++ b/hardware/boards/glasgow/glasgow.kicad_pcb
@@ -29,6 +29,8 @@
     (47 "F.CrtYd" user "F.Courtyard")
     (48 "B.Fab" user)
     (49 "F.Fab" user)
+    (50 "User.1" user "User.bot-case-outline")
+    (51 "User.2" user "User.top-case-outline")
   )
 
   (setup
@@ -24125,6 +24127,394 @@
     (stroke (width 0.2) (type solid)) (layer "B.Fab") (tstamp d7a9edd9-cb60-43c6-9586-da775d1c154c))
   (gr_line (start 101.4 89.1) (end 101.4 101.9)
     (stroke (width 0.2) (type solid)) (layer "B.Fab") (tstamp e55c957b-014b-4f3d-a42d-34d786a236d4))
+  (gr_arc (start 76.729647 118.091667) (mid 77.230858 117.168077) (end 78.215109 116.8)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 0286dc95-8417-4150-87aa-504a56f7f0fc))
+  (gr_line (start 126 69) (end 54 69)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 0d817c2c-d13a-4a6c-92e5-a11fa265616e))
+  (gr_line (start 71.084891 116.8) (end 61.57 116.8)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 12c39b52-cc56-4edb-a74f-9cb9624bf4d2))
+  (gr_arc (start 59.354005 77.903226) (mid 59.441321 79.950382) (end 57.681556 81)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 13ad483b-60ce-44c3-80de-e0ffa7af0acb))
+  (gr_line (start 61.57 73.8) (end 101.784891 73.8)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 1895f10c-f7bc-4242-9d8c-4ef0fc0cc7f8))
+  (gr_arc (start 102.87423 72.852778) (mid 105.35 70.7) (end 107.82577 72.852778)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 1966a20f-337e-4d00-a204-104b3d1b467a))
+  (gr_line (start 49.6 75) (end 49.6 116)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 1c9af1a5-2565-45e3-b2bf-25649d63cb48))
+  (gr_arc (start 54 120.4) (mid 50.88873 119.11127) (end 49.6 116)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 1ea1cc88-3b81-4daa-84d4-8f0066a3e6b0))
+  (gr_line (start 118.43 117.2) (end 78.215109 117.2)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 220f9ec9-98b0-4d7b-8fd2-1912773bd28b))
+  (gr_line (start 118.43 116.8) (end 78.215109 116.8)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 23c62e17-ca12-44e4-8d02-32b50a68cf0f))
+  (gr_arc (start 51.4 83) (mid 51.868629 81.868629) (end 53 81.4)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 24dcab4c-16d9-475d-a760-9ffc4e19893d))
+  (gr_line (start 127 109.6) (end 122.318444 109.6)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 25aa8b8f-d9f2-4ad9-8bc7-bc21e0a7a2fd))
+  (gr_circle (center 126 75) (end 127.2645 75)
+    (stroke (width 0.01) (type solid)) (fill none) (layer "User.1") (tstamp 2af2f0f4-dda3-4008-8ac0-a712452fc597))
+  (gr_line (start 132 116) (end 132 75)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 31a8f541-96a9-4848-863a-c23348c4ef7c))
+  (gr_arc (start 130.4 116) (mid 129.11127 119.11127) (end 126 120.4)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 34668f55-5deb-4ff0-834d-e4e88775e851))
+  (gr_arc (start 48 75) (mid 49.757359 70.757359) (end 54 69)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 3e58b5d2-3ca3-4023-ba33-305ec597e8ab))
+  (gr_line (start 54 122) (end 126 122)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 3f9bc911-26ec-43a5-8215-742ff1c1b1f4))
+  (gr_line (start 128.6 83) (end 128.6 108)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 456155b5-09af-42de-bdd9-aee04f588a9b))
+  (gr_arc (start 71.084891 117.2) (mid 71.806675 117.469923) (end 72.17423 118.147222)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 481c4ec0-f82e-48af-bbe7-7e6412f3a06e))
+  (gr_arc (start 120.311505 113.316129) (mid 120.409736 115.619179) (end 118.43 116.8)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 4a3a0d14-1969-43b3-9470-ceab6f753c1f))
+  (gr_arc (start 51 83) (mid 51.585786 81.585786) (end 53 81)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 4b1180bf-f407-4234-b87f-367b50b3090c))
+  (gr_line (start 61.57 74.2) (end 101.784891 74.2)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 4d677f66-c774-43f8-91e5-7c593cb50c14))
+  (gr_line (start 57.681556 110) (end 53 110)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 4dae7431-eaf2-4218-9b21-04eb4ca512f9))
+  (gr_arc (start 59.354005 77.903226) (mid 59.238311 75.190744) (end 61.57 73.8)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 571adf0d-b86a-4cd0-9108-eec08560a90a))
+  (gr_line (start 122.318444 81.4) (end 127 81.4)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 5a1e6eca-23bc-4cb5-95a6-958575b4bb01))
+  (gr_arc (start 108.915109 74.2) (mid 107.930858 73.831923) (end 107.429647 72.908333)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 61cca196-bc44-4313-b4b5-7531e86f1642))
+  (gr_arc (start 59.688495 77.683871) (mid 59.793274 80.140458) (end 57.681556 81.4)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 65e06bec-5337-45d2-b444-a9d45ddcb2fd))
+  (gr_arc (start 108.915109 73.8) (mid 108.193325 73.530077) (end 107.82577 72.852778)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 6d5eedc1-a618-4fc3-9e1d-d36249996fac))
+  (gr_arc (start 132 116) (mid 130.242641 120.242641) (end 126 122)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 6d64593d-fe9a-404b-8964-1b3fce2190a9))
+  (gr_line (start 108.915109 73.8) (end 118.43 73.8)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 724a93fe-422d-4b94-a769-33364448cc0e))
+  (gr_arc (start 61.57 117.2) (mid 59.238311 115.809256) (end 59.354005 113.096774)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 72d686a6-f9d8-4f4c-9c07-5e17f557d29c))
+  (gr_arc (start 129 108) (mid 128.414214 109.414214) (end 127 110)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 7436fc93-d435-47b7-97b6-5b5479a29b56))
+  (gr_line (start 130.4 116) (end 130.4 75)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 7b4acfd5-f37a-4efd-90d1-adf010172b80))
+  (gr_line (start 51 108) (end 51 83)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 7d3bbf56-78b4-4b97-b483-a5e0e267b147))
+  (gr_line (start 126 70.6) (end 54 70.6)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 87ce3564-1d69-46b4-8708-e2879e6a26a9))
+  (gr_arc (start 103.270353 72.908333) (mid 102.769142 73.831923) (end 101.784891 74.2)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 8811c9c9-f4fd-4202-b101-42401903087c))
+  (gr_line (start 53 81.4) (end 57.681556 81.4)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 8b2697cc-03b4-4137-834d-d1d636035aae))
+  (gr_line (start 54 120.4) (end 126 120.4)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 8c4812e7-2851-434d-ba16-4b98074ef882))
+  (gr_arc (start 118.43 73.8) (mid 120.761689 75.190744) (end 120.645995 77.903226)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 8e77173a-13b3-42d4-b838-aff5a90ec080))
+  (gr_arc (start 71.084891 116.8) (mid 72.069142 117.168077) (end 72.570353 118.091667)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 8f4247c1-d59a-4f06-b3e7-9766a9acefb5))
+  (gr_arc (start 57.681556 110) (mid 59.441321 111.049618) (end 59.354005 113.096774)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 98fb9826-c9d8-450b-9abb-f98afd297e8e))
+  (gr_arc (start 126 69) (mid 130.242641 70.757359) (end 132 75)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp 99d1d74f-4ed7-425f-8fb6-e7f302f6fa81))
+  (gr_line (start 122.318444 81) (end 127 81)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp a05c54fb-968f-4edf-80dc-5c4c46ab4757))
+  (gr_arc (start 103.270353 72.908333) (mid 105.35 71.1) (end 107.429647 72.908333)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp a46ee5e0-33f5-4089-bb09-9c3f3687fc1e))
+  (gr_arc (start 120.645995 113.096774) (mid 120.558679 111.049618) (end 122.318444 110)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp a5a28b15-be69-493a-9935-6f76e8e66df2))
+  (gr_arc (start 76.729647 118.091667) (mid 74.65 119.9) (end 72.570353 118.091667)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp aa0cab07-fc99-485f-ba1f-dcff7ece8646))
+  (gr_arc (start 77.12577 118.147222) (mid 74.65 120.3) (end 72.17423 118.147222)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp adb83766-2012-45bf-915c-691aa91066ba))
+  (gr_arc (start 128.6 108) (mid 128.131371 109.131371) (end 127 109.6)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp af6da678-ef05-4e54-8c0d-7c5bccb81727))
+  (gr_arc (start 77.12577 118.147222) (mid 77.493325 117.469923) (end 78.215109 117.2)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp b82d7fd0-769b-4769-8f2e-153070488f92))
+  (gr_arc (start 53 109.6) (mid 51.868629 109.131371) (end 51.4 108)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp b9a4925f-c903-4942-96bf-daaa02f026a6))
+  (gr_circle (center 54 75) (end 55.2645 75)
+    (stroke (width 0.01) (type solid)) (fill none) (layer "User.1") (tstamp b9c898ee-8584-4942-9ef7-6c79b60d5ef5))
+  (gr_circle (center 54 116) (end 55.2645 116)
+    (stroke (width 0.01) (type solid)) (fill none) (layer "User.1") (tstamp ba2132bd-1343-479c-9e2c-902b8d30d240))
+  (gr_arc (start 61.57 116.8) (mid 59.590264 115.61918) (end 59.688495 113.316129)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp bb22ce4e-b386-427f-a636-adf71349d72e))
+  (gr_arc (start 59.688495 77.683871) (mid 59.590264 75.380821) (end 61.57 74.2)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp bd7f6d8d-6c9a-4757-8452-70ec55c7fcc9))
+  (gr_arc (start 118.43 74.2) (mid 120.409736 75.38082) (end 120.311505 77.683871)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp c3878947-6c74-43ff-b80a-0f6b11cc443a))
+  (gr_line (start 108.915109 74.2) (end 118.43 74.2)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp c3dd3c96-df6c-4e92-a5ce-ffbf5ec8e9af))
+  (gr_line (start 127 110) (end 122.318444 110)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp c49ba654-9f39-4bca-9d86-4c01df406c86))
+  (gr_line (start 53 81) (end 57.681556 81)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp c6b8eb31-bd48-4c43-bfc5-002fb6559830))
+  (gr_arc (start 54 122) (mid 49.757359 120.242641) (end 48 116)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp c7f7ec1c-c7c8-472f-b96d-13ec77f62b70))
+  (gr_line (start 71.084891 117.2) (end 61.57 117.2)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp c94c80de-52a6-4ec6-8c50-4664362214bb))
+  (gr_arc (start 122.318444 81.4) (mid 120.206726 80.140458) (end 120.311505 77.683871)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp d3ff2b9e-8630-4dc9-b662-32fd2ca857e6))
+  (gr_arc (start 126 70.6) (mid 129.11127 71.88873) (end 130.4 75)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp d6807fcb-4131-411d-862e-f880615ea0a5))
+  (gr_circle (center 126 116) (end 127.2645 116)
+    (stroke (width 0.01) (type solid)) (fill none) (layer "User.1") (tstamp d6ffe4a9-b6fc-4bc9-84b6-0c32920db9df))
+  (gr_arc (start 53 110) (mid 51.585786 109.414214) (end 51 108)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp d8c22d37-2c95-4827-87da-910df4261dcc))
+  (gr_line (start 48 75) (end 48 116)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp db976dfb-22b3-4e93-82a2-5635aa8e1373))
+  (gr_arc (start 57.681556 109.6) (mid 59.793274 110.859542) (end 59.688495 113.316129)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp dbb8b175-7b41-4419-82b2-0dea98f2db52))
+  (gr_arc (start 127 81) (mid 128.414214 81.585786) (end 129 83)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp de3c32e5-5fec-4d74-a492-2025dfca757f))
+  (gr_arc (start 120.645995 113.096774) (mid 120.761689 115.809256) (end 118.43 117.2)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp dfc1cd81-81c0-48fd-ac6e-6026711c6329))
+  (gr_line (start 51.4 108) (end 51.4 83)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp e77d5e63-dd14-4d97-bccf-54ee9c426604))
+  (gr_line (start 129 83) (end 129 108)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp ea27b106-77ae-4c8e-a457-2f000a59bf1d))
+  (gr_arc (start 102.87423 72.852778) (mid 102.506675 73.530077) (end 101.784891 73.8)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp eecf70ff-0151-40b2-932a-313edf2d3206))
+  (gr_arc (start 120.311505 113.316129) (mid 120.206726 110.859542) (end 122.318444 109.6)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp effb698f-d772-432d-8a8e-d950b11e6da5))
+  (gr_arc (start 49.6 75) (mid 50.88873 71.88873) (end 54 70.6)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp f8af8d76-c143-4687-bc9c-ec322e646020))
+  (gr_arc (start 122.318444 81) (mid 120.558679 79.950382) (end 120.645995 77.903226)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp fbc2b66e-1e10-40ef-a122-47be35c41ebd))
+  (gr_line (start 57.681556 109.6) (end 53 109.6)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp fd3d34f8-3edb-402a-b192-2423bec527a2))
+  (gr_arc (start 127 81.4) (mid 128.131371 81.868629) (end 128.6 83)
+    (stroke (width 0.01) (type solid)) (layer "User.1") (tstamp fe22d50c-bda6-4dbe-87ed-777e3ae44abd))
+  (gr_line (start 126 69) (end 54 69)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 00242d58-e772-4e92-b902-20b5c2823f97))
+  (gr_line (start 126.5 112) (end 122.93 112)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 0126765d-987b-47f3-a225-5e56dc1819cc))
+  (gr_line (start 120.93 72.625) (end 120.93 76.6)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 0133c162-af3a-47b7-8bd4-38eef59f1424))
+  (gr_arc (start 54.7 80.910387) (mid 55.011807 79.838008) (end 55.85 79.1)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 01d8fda4-8918-418c-9902-8f78dc138f4a))
+  (gr_line (start 70.031242 119.085) (end 59 119.085)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 0495a9fa-bc61-4867-b248-a47a9f7b7876))
+  (gr_line (start 73.6 122.4) (end 73.6 119.98)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 04c96fa0-2987-4458-97d5-789c54dc0cca))
+  (gr_arc (start 70.031242 119.085) (mid 70.765053 119.232442) (end 71.385002 119.651833)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 04e24fbc-5432-4fd4-8e33-c50bd03962c4))
+  (gr_line (start 119.93 119.375) (end 88.07 119.375)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 0637cc9f-1c95-4898-a8ec-57847f3ed9a1))
+  (gr_arc (start 72.168758 119.98) (mid 71.743924 119.894633) (end 71.385002 119.651833)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 0aa36502-78a9-4e9d-8ac3-c45977d53ef2))
+  (gr_line (start 80.26 120.999999) (end 80.26 112.165736)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 0aa3789c-ed6c-438e-b3a1-ab912cb2e5b5))
+  (gr_line (start 57 117.485) (end 57 113.710387)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 0d5403b2-3cfe-42c4-9a5e-aa78ee5f9fb1))
+  (gr_line (start 87.47 118.375) (end 87.47 112.165736)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 0da05805-6861-423e-98be-5bcfbf36e391))
+  (gr_arc (start 132 116) (mid 130.242641 120.242641) (end 126 122)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 11616c82-abc4-4e29-a299-9ba6a2948132))
+  (gr_line (start 55.1 89) (end 55.1 80.910387)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 12d3a05c-f815-432c-99c4-4f167e1f9efe))
+  (gr_line (start 59 72.025) (end 119.93 72.025)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 154d2267-2a92-4d4d-be89-fcf9cbecb5bf))
+  (gr_arc (start 77.8 118.88) (mid 77.477817 119.657817) (end 76.7 119.98)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 18762295-ea1f-479a-87e2-4cda66184fbc))
+  (gr_line (start 53.08 100.38) (end 48 100.38)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 1a24bc4b-09e9-4927-a316-407da5ecb7f1))
+  (gr_arc (start 119.93 72.025) (mid 120.354264 72.200736) (end 120.53 72.625)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 1c27dba5-83a1-4eee-8279-5a4ed0eed7e4))
+  (gr_line (start 54.7 110.089613) (end 54.7 102)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 1dc1142a-979d-4c42-89df-93da6eab42b8))
+  (gr_line (start 122.93 79) (end 126.5 79)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 1dcbfad9-0667-4a47-ba1e-13ff93926721))
+  (gr_line (start 75.7 119.98) (end 75.7 122.4)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 20b2a041-b076-4b9a-be7c-291e615849ad))
+  (gr_arc (start 88.07 118.975) (mid 87.645736 118.799264) (end 87.47 118.375)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 218b14d3-a42c-4362-af00-60f8b5cf127c))
+  (gr_line (start 57.4 117.485) (end 57.4 113.710387)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 28fd6501-b1d4-4222-9c3e-33b0efdcbba9))
+  (gr_line (start 122.93 78.6) (end 126.5 78.6)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 29d8f68f-7597-4825-ba14-8f35ebd3e1b5))
+  (gr_arc (start 126 69) (mid 130.242641 70.757359) (end 132 75)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 2ba39466-d940-4df7-b98c-272a80cc889a))
+  (gr_arc (start 78.2 112.165736) (mid 78.394761 111.695487) (end 78.865 111.500736)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 2f5752e7-06cc-4961-bc93-f16f46440ace))
+  (gr_line (start 76.7 119.98) (end 75.7 119.98)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 3883105b-3501-4644-9e43-342f1dafef6b))
+  (gr_line (start 128.1 80.6) (end 128.1 110.4)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 4169ef77-1642-4dc2-97d3-61b1a92e5cfa))
+  (gr_line (start 86.74 122) (end 126 122)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 43f837c5-3df6-4293-81cf-68f17a490060))
+  (gr_line (start 126.5 112.4) (end 122.93 112.4)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 47201999-f4bf-4262-adcc-da66c1995dba))
+  (gr_line (start 75.7 122.4) (end 78.859999 122.4)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 4785e968-5634-42fe-b5a8-7e96ca067988))
+  (gr_arc (start 55.85 111.9) (mid 56.688199 112.638005) (end 57 113.710387)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 49420061-a561-45ef-973e-5af5be443f34))
+  (gr_arc (start 132.4 116) (mid 130.525483 120.525483) (end 126 122.4)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 4a359150-54bc-4456-875a-7d37fc4e3172))
+  (gr_arc (start 53.08 99.98) (mid 54.508356 100.571644) (end 55.1 102)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 4b66e61a-fe77-4eb5-8d87-0971906261aa))
+  (gr_arc (start 126.5 79) (mid 127.631371 79.468629) (end 128.1 80.6)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 4e519a8d-d60c-45d8-b191-7642fb446bc6))
+  (gr_arc (start 79.195 111.100736) (mid 79.948056 111.412669) (end 80.26 112.165736)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 4f4117a6-15bd-4c66-8a36-d25876f32c8f))
+  (gr_arc (start 80.26 120.999999) (mid 79.849949 121.989949) (end 78.859999 122.4)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 555842db-9e0f-4dca-891a-71c6d895bc47))
+  (gr_line (start 57 77.289613) (end 57 73.625)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 56242ca6-00ab-458e-a1cd-341f4dfee9e7))
+  (gr_line (start 120.93 114.4) (end 120.93 118.375)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 58bac623-f7cf-4c06-b6e8-35c013cec1de))
+  (gr_arc (start 120.93 118.375) (mid 120.637107 119.082107) (end 119.93 119.375)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 593714b0-8d96-43ca-b8c5-fa5b9f8d0b6b))
+  (gr_arc (start 86.74 122.4) (mid 85.750051 121.989949) (end 85.34 121)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 5d93f524-911c-43d1-8f67-561edc6cdcf9))
+  (gr_arc (start 70.031242 119.485) (mid 70.610564 119.601404) (end 71.1 119.9325)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 6208a5c0-5be1-4ee4-b9fa-2c5aaf80ed62))
+  (gr_arc (start 48 75) (mid 49.757359 70.757359) (end 54 69)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 62766bfb-31ab-4dce-b9ec-41818299166b))
+  (gr_line (start 76.1 120.38) (end 76.1 122)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 63141cd1-5714-494d-bc30-7303f430163f))
+  (gr_arc (start 79.86 120.999999) (mid 79.567107 121.707107) (end 78.859999 122)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 647f9741-78b2-4a4a-959d-e90f71ab325f))
+  (gr_arc (start 85.74 112.165736) (mid 86.405 111.500736) (end 87.07 112.165736)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 699fdf64-e18a-4e48-8bbd-fcbc9a44a80e))
+  (gr_circle (center 54 116) (end 55.75 116)
+    (stroke (width 0.01) (type solid)) (fill none) (layer "User.2") (tstamp 6b2dd3f9-11bf-4182-909b-3baa619b9283))
+  (gr_arc (start 55.85 111.9) (mid 55.011801 111.161995) (end 54.7 110.089613)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 6c9e03a1-0653-4bcb-bf88-8ddff0506da5))
+  (gr_line (start 47.6 91.03) (end 53.07 91.03)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 7092d363-dd7b-4dce-b573-c39fd439bc5c))
+  (gr_line (start 53.08 99.98) (end 47.6 99.98)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 73c172bd-8dbc-4572-8506-5a9dccc4d7d9))
+  (gr_line (start 47.6 99.98) (end 47.6 116)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 747051c9-1660-4725-8d60-1e65e00b63a3))
+  (gr_line (start 48 100.38) (end 48 116)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 7494e041-13fb-4d1e-b4b4-76dd8190a34e))
+  (gr_line (start 57.4 77.289613) (end 57.4 73.625)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 769ef32d-005e-4fd3-9111-80515d014fab))
+  (gr_arc (start 120.93 114.4) (mid 121.515786 112.985786) (end 122.93 112.4)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 77c4d812-f7e2-40e6-866b-0ffff1367be4))
+  (gr_line (start 85.74 112.165736) (end 85.74 121)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 78eb9b74-85b6-4a2e-b085-d4c0e5dbaa28))
+  (gr_arc (start 122.93 78.6) (mid 121.515786 78.014214) (end 120.93 76.6)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 7b080d4b-a284-4a23-a952-f99e5757914b))
+  (gr_arc (start 55.1 89) (mid 54.505427 90.435427) (end 53.07 91.03)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 7da6f068-06bf-4875-abc3-3e9758ff3cac))
+  (gr_arc (start 122.93 79) (mid 121.232944 78.297056) (end 120.53 76.6)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 7f0a9efd-6652-427e-861b-ee7b55698c33))
+  (gr_circle (center 126 75) (end 127.75 75)
+    (stroke (width 0.01) (type solid)) (fill none) (layer "User.2") (tstamp 7fabe2f9-e574-40c6-9082-c993d70e880c))
+  (gr_arc (start 86.74 122) (mid 86.032893 121.707107) (end 85.74 121)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 81fda36a-0535-41a7-8c40-aafdb40d478d))
+  (gr_arc (start 128.1 110.4) (mid 127.631371 111.531371) (end 126.5 112)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 821f8943-5d93-4172-8dc2-e3c8d2d36fe6))
+  (gr_line (start 55.1 110.089613) (end 55.1 102)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 87dc08d9-2669-4eea-96a0-e370138a6933))
+  (gr_arc (start 59 119.485) (mid 57.585786 118.899214) (end 57 117.485)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 88edbafa-67fe-4155-a751-33cf6c39ec4d))
+  (gr_line (start 78.2 112.165736) (end 78.2 118.88)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 8a8caab4-cdcb-4a8a-9eff-d5200c5a43d9))
+  (gr_line (start 128.5 80.6) (end 128.5 110.4)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 8e94b478-17a1-4cb9-9b14-592e2337d86e))
+  (gr_arc (start 55.1 80.910387) (mid 55.349446 80.052484) (end 56.02 79.462077)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 905f70d8-8222-4f53-a807-aae1aaff718d))
+  (gr_arc (start 57 77.289613) (mid 56.688193 78.361992) (end 55.85 79.1)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 90ace7ff-490b-427a-b178-10169f1d0658))
+  (gr_arc (start 126.5 78.6) (mid 127.914214 79.185786) (end 128.5 80.6)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 95ee5ba2-4e98-4cce-8538-e5a644068e96))
+  (gr_line (start 85.34 112.165736) (end 85.34 121)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 99352fa1-b0c4-4c86-b92d-fc3e2665be27))
+  (gr_line (start 126 68.6) (end 54 68.6)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 9aa62924-8544-48ca-af4d-517f95570d5c))
+  (gr_line (start 79.195 111.100736) (end 78.865 111.100736)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 9c31a310-40db-46d5-8d07-aed14564330e))
+  (gr_line (start 119.93 118.975) (end 88.07 118.975)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 9c68dd91-27b3-4758-8dd9-64719f53acc8))
+  (gr_line (start 120.53 114.4) (end 120.53 118.375)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 9ceea44d-000d-4381-bcd4-cd34bfe86bf1))
+  (gr_arc (start 78.2 118.88) (mid 77.76066 119.94066) (end 76.7 120.38)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 9da7a185-2db4-4ff2-a486-98c7e8d33fe7))
+  (gr_arc (start 119.93 71.625) (mid 120.637107 71.917893) (end 120.93 72.625)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp 9eecfbc4-2951-4584-9b4b-165b8e2144a1))
+  (gr_arc (start 85.34 112.165736) (mid 86.405 111.100736) (end 87.47 112.165736)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp a40f1857-f21f-4e7f-97da-0e64d9ed9e41))
+  (gr_arc (start 72.168758 120.38) (mid 71.589436 120.263596) (end 71.1 119.9325)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp a53e1fb4-4e50-4595-981e-46cdd2a8ac0e))
+  (gr_line (start 77.8 112.165736) (end 77.8 118.88)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp a67ef4ee-e36b-4de4-ad65-a3f38bc30369))
+  (gr_arc (start 53.08 100.38) (mid 54.225513 100.854487) (end 54.7 102)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp a819a1ec-c126-4b17-92e4-e645d0d00eac))
+  (gr_arc (start 77.8 112.165736) (mid 78.111919 111.412644) (end 78.865 111.100736)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp a907865a-3ede-4326-9050-da4ceaba2c5d))
+  (gr_arc (start 54.7 89) (mid 54.222584 90.152584) (end 53.07 90.63)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp abb77112-0d24-43a8-ae34-fc43411fb83b))
+  (gr_circle (center 126 116) (end 127.75 116)
+    (stroke (width 0.01) (type solid)) (fill none) (layer "User.2") (tstamp ac6c781b-3248-43b1-8f69-f4233d34ae5c))
+  (gr_line (start 48 75) (end 48 90.63)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp b29fa949-22c2-40d5-9761-61f37a4df66d))
+  (gr_line (start 76.7 120.38) (end 76.1 120.38)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp b7a4c96e-9a79-43af-b1fc-317dfd91d5d4))
+  (gr_line (start 79.86 120.999999) (end 79.86 112.165736)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp bbd13cc1-3c9e-4228-90ae-b274841f5bc9))
+  (gr_arc (start 79.195 111.500736) (mid 79.665213 111.695512) (end 79.86 112.165736)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp bc514d20-eb72-4fcb-b706-4c3bd977b258))
+  (gr_arc (start 57.4 73.625) (mid 57.868629 72.493629) (end 59 72.025)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp c0882d97-60f7-4bb4-be60-ffc9afc2daf8))
+  (gr_arc (start 47.6 75) (mid 49.474517 70.474517) (end 54 68.6)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp c0caa370-2813-4a38-938a-1fa294dcfb86))
+  (gr_line (start 79.195 111.500736) (end 78.865 111.500736)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp c5903aaf-2ba6-4736-95e9-6db6be39de1d))
+  (gr_line (start 54.7 89) (end 54.7 80.910387)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp c60aec90-396e-418c-9618-a588f615857c))
+  (gr_line (start 86.74 122.4) (end 126 122.4)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp c7972341-9ffb-49b5-b8d4-c0c183e5396e))
+  (gr_line (start 48 90.63) (end 53.07 90.63)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp c9920a24-5b5a-4fd6-8d6d-68ea2b412147))
+  (gr_circle (center 54 75) (end 55.75 75)
+    (stroke (width 0.01) (type solid)) (fill none) (layer "User.2") (tstamp cdc7b829-71f3-4b6b-9f0b-f06ee9ea2e6a))
+  (gr_line (start 70.031242 119.485) (end 59 119.485)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp cfb540c8-c00f-4934-9680-def7a8db8e20))
+  (gr_line (start 47.6 75) (end 47.6 91.03)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp d021ac64-9809-4dc5-91a5-26e6cf03c49d))
+  (gr_line (start 132 116) (end 132 75)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp d0344fdf-ad2b-4987-845e-f527573cf23d))
+  (gr_line (start 73.6 119.98) (end 72.168758 119.98)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp d2bd07e2-56be-4829-b9bc-b98dc2a8da34))
+  (gr_line (start 120.53 72.625) (end 120.53 76.6)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp d5345bfe-2d96-444f-a266-310218cabc2e))
+  (gr_arc (start 59 119.085) (mid 57.868629 118.616371) (end 57.4 117.485)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp d60f6874-b45f-4669-b941-91d0588ef802))
+  (gr_arc (start 57 73.625) (mid 57.585786 72.210786) (end 59 71.625)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp d71ec0c9-88d9-482e-b38e-d92ccaac872b))
+  (gr_arc (start 56.02 111.537923) (mid 57.025838 112.423529) (end 57.4 113.710387)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp d72b0813-e0e7-4e3d-94e4-4c67eb886a92))
+  (gr_line (start 73.2 122) (end 73.2 120.38)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp d839a8e6-544f-4496-bb8a-6e03869bedc0))
+  (gr_line (start 73.2 120.38) (end 72.168758 120.38)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp dbeb24e0-215c-4fc8-b35a-d1db0621f368))
+  (gr_line (start 87.07 118.375) (end 87.07 112.165736)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp dd2c5b0d-5fac-404e-a643-44795c42a42d))
+  (gr_line (start 59 71.625) (end 119.93 71.625)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp dd4b8a44-a685-4bca-a9d9-973339a44b88))
+  (gr_arc (start 56.02 111.537923) (mid 55.349439 110.947519) (end 55.1 110.089613)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp df8b9572-3d45-4bc8-b838-faa90afd48da))
+  (gr_arc (start 120.53 114.4) (mid 121.232944 112.702944) (end 122.93 112)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp e43796d7-c5a0-4071-b00c-e0920e5f7a53))
+  (gr_line (start 54 122) (end 73.2 122)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp e4c97bf4-21c3-4cc4-97e7-b41d33fce7d2))
+  (gr_arc (start 120.53 118.375) (mid 120.354264 118.799264) (end 119.93 118.975)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp e55834b2-e7fc-44d5-84aa-cc410954fc0a))
+  (gr_arc (start 88.07 119.375) (mid 87.362893 119.082107) (end 87.07 118.375)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp e84e4485-195d-45e9-a286-ba964885ff0f))
+  (gr_arc (start 54 122) (mid 49.757359 120.242641) (end 48 116)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp ea123408-dcb4-47d3-8229-9929b1206557))
+  (gr_arc (start 128.5 110.4) (mid 127.914214 111.814214) (end 126.5 112.4)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp ebf8f755-a514-4009-a9f1-77aa807da995))
+  (gr_line (start 76.1 122) (end 78.859999 122)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp ef04ad5b-b9cf-4399-89e3-9ebd5b16a712))
+  (gr_line (start 54 122.4) (end 73.6 122.4)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp f1e60cab-fde1-46fb-aebf-1ccbb662e625))
+  (gr_line (start 132.4 116) (end 132.4 75)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp f41563db-f8ca-4853-82e0-7890cc842bc1))
+  (gr_arc (start 126 68.6) (mid 130.525483 70.474517) (end 132.4 75)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp f70ce9ed-e10a-4434-87b2-2cb3aadc5147))
+  (gr_arc (start 57.4 77.289613) (mid 57.025832 78.576468) (end 56.02 79.462077)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp f7fb8b5d-00b9-4129-875f-2ce4844eb931))
+  (gr_arc (start 54 122.4) (mid 49.474517 120.525483) (end 47.6 116)
+    (stroke (width 0.01) (type solid)) (layer "User.2") (tstamp fcfab889-44b0-4cf9-a850-a33baf3e5050))
   (gr_text "5V" (at 80.5 116.05) (layer "B.SilkS") (tstamp 00000000-0000-0000-0000-00005ca3bc42)
     (effects (font (size 1.2 1.2) (thickness 0.16)) (justify left mirror))
   )
@@ -65431,6 +65821,208 @@
         (xy 61.670953 107.2)
         (xy 72.274 107.2)
       )
+    )
+  )
+  (group "" (id ec80925a-95ca-4f3f-b690-77efdd14d02d)
+    (members
+      0286dc95-8417-4150-87aa-504a56f7f0fc
+      0d817c2c-d13a-4a6c-92e5-a11fa265616e
+      12c39b52-cc56-4edb-a74f-9cb9624bf4d2
+      13ad483b-60ce-44c3-80de-e0ffa7af0acb
+      1895f10c-f7bc-4242-9d8c-4ef0fc0cc7f8
+      1966a20f-337e-4d00-a204-104b3d1b467a
+      1c9af1a5-2565-45e3-b2bf-25649d63cb48
+      1ea1cc88-3b81-4daa-84d4-8f0066a3e6b0
+      220f9ec9-98b0-4d7b-8fd2-1912773bd28b
+      23c62e17-ca12-44e4-8d02-32b50a68cf0f
+      24dcab4c-16d9-475d-a760-9ffc4e19893d
+      25aa8b8f-d9f2-4ad9-8bc7-bc21e0a7a2fd
+      2af2f0f4-dda3-4008-8ac0-a712452fc597
+      31a8f541-96a9-4848-863a-c23348c4ef7c
+      34668f55-5deb-4ff0-834d-e4e88775e851
+      3e58b5d2-3ca3-4023-ba33-305ec597e8ab
+      3f9bc911-26ec-43a5-8215-742ff1c1b1f4
+      456155b5-09af-42de-bdd9-aee04f588a9b
+      481c4ec0-f82e-48af-bbe7-7e6412f3a06e
+      4a3a0d14-1969-43b3-9470-ceab6f753c1f
+      4b1180bf-f407-4234-b87f-367b50b3090c
+      4d677f66-c774-43f8-91e5-7c593cb50c14
+      4dae7431-eaf2-4218-9b21-04eb4ca512f9
+      571adf0d-b86a-4cd0-9108-eec08560a90a
+      5a1e6eca-23bc-4cb5-95a6-958575b4bb01
+      61cca196-bc44-4313-b4b5-7531e86f1642
+      65e06bec-5337-45d2-b444-a9d45ddcb2fd
+      6d5eedc1-a618-4fc3-9e1d-d36249996fac
+      6d64593d-fe9a-404b-8964-1b3fce2190a9
+      724a93fe-422d-4b94-a769-33364448cc0e
+      72d686a6-f9d8-4f4c-9c07-5e17f557d29c
+      7436fc93-d435-47b7-97b6-5b5479a29b56
+      7b4acfd5-f37a-4efd-90d1-adf010172b80
+      7d3bbf56-78b4-4b97-b483-a5e0e267b147
+      87ce3564-1d69-46b4-8708-e2879e6a26a9
+      8811c9c9-f4fd-4202-b101-42401903087c
+      8b2697cc-03b4-4137-834d-d1d636035aae
+      8c4812e7-2851-434d-ba16-4b98074ef882
+      8e77173a-13b3-42d4-b838-aff5a90ec080
+      8f4247c1-d59a-4f06-b3e7-9766a9acefb5
+      98fb9826-c9d8-450b-9abb-f98afd297e8e
+      99d1d74f-4ed7-425f-8fb6-e7f302f6fa81
+      a05c54fb-968f-4edf-80dc-5c4c46ab4757
+      a46ee5e0-33f5-4089-bb09-9c3f3687fc1e
+      a5a28b15-be69-493a-9935-6f76e8e66df2
+      aa0cab07-fc99-485f-ba1f-dcff7ece8646
+      adb83766-2012-45bf-915c-691aa91066ba
+      af6da678-ef05-4e54-8c0d-7c5bccb81727
+      b82d7fd0-769b-4769-8f2e-153070488f92
+      b9a4925f-c903-4942-96bf-daaa02f026a6
+      b9c898ee-8584-4942-9ef7-6c79b60d5ef5
+      ba2132bd-1343-479c-9e2c-902b8d30d240
+      bb22ce4e-b386-427f-a636-adf71349d72e
+      bd7f6d8d-6c9a-4757-8452-70ec55c7fcc9
+      c3878947-6c74-43ff-b80a-0f6b11cc443a
+      c3dd3c96-df6c-4e92-a5ce-ffbf5ec8e9af
+      c49ba654-9f39-4bca-9d86-4c01df406c86
+      c6b8eb31-bd48-4c43-bfc5-002fb6559830
+      c7f7ec1c-c7c8-472f-b96d-13ec77f62b70
+      c94c80de-52a6-4ec6-8c50-4664362214bb
+      d3ff2b9e-8630-4dc9-b662-32fd2ca857e6
+      d6807fcb-4131-411d-862e-f880615ea0a5
+      d6ffe4a9-b6fc-4bc9-84b6-0c32920db9df
+      d8c22d37-2c95-4827-87da-910df4261dcc
+      db976dfb-22b3-4e93-82a2-5635aa8e1373
+      dbb8b175-7b41-4419-82b2-0dea98f2db52
+      de3c32e5-5fec-4d74-a492-2025dfca757f
+      dfc1cd81-81c0-48fd-ac6e-6026711c6329
+      e77d5e63-dd14-4d97-bccf-54ee9c426604
+      ea27b106-77ae-4c8e-a457-2f000a59bf1d
+      eecf70ff-0151-40b2-932a-313edf2d3206
+      effb698f-d772-432d-8a8e-d950b11e6da5
+      f8af8d76-c143-4687-bc9c-ec322e646020
+      fbc2b66e-1e10-40ef-a122-47be35c41ebd
+      fd3d34f8-3edb-402a-b192-2423bec527a2
+      fe22d50c-bda6-4dbe-87ed-777e3ae44abd
+    )
+  )
+  (group "" (id bca68876-f2ae-4914-9122-10b0de5eb183)
+    (members
+      00242d58-e772-4e92-b902-20b5c2823f97
+      0126765d-987b-47f3-a225-5e56dc1819cc
+      0133c162-af3a-47b7-8bd4-38eef59f1424
+      01d8fda4-8918-418c-9902-8f78dc138f4a
+      0495a9fa-bc61-4867-b248-a47a9f7b7876
+      04c96fa0-2987-4458-97d5-789c54dc0cca
+      04e24fbc-5432-4fd4-8e33-c50bd03962c4
+      0637cc9f-1c95-4898-a8ec-57847f3ed9a1
+      0aa36502-78a9-4e9d-8ac3-c45977d53ef2
+      0aa3789c-ed6c-438e-b3a1-ab912cb2e5b5
+      0d5403b2-3cfe-42c4-9a5e-aa78ee5f9fb1
+      0da05805-6861-423e-98be-5bcfbf36e391
+      11616c82-abc4-4e29-a299-9ba6a2948132
+      12d3a05c-f815-432c-99c4-4f167e1f9efe
+      154d2267-2a92-4d4d-be89-fcf9cbecb5bf
+      18762295-ea1f-479a-87e2-4cda66184fbc
+      1a24bc4b-09e9-4927-a316-407da5ecb7f1
+      1c27dba5-83a1-4eee-8279-5a4ed0eed7e4
+      1dc1142a-979d-4c42-89df-93da6eab42b8
+      1dcbfad9-0667-4a47-ba1e-13ff93926721
+      20b2a041-b076-4b9a-be7c-291e615849ad
+      218b14d3-a42c-4362-af00-60f8b5cf127c
+      28fd6501-b1d4-4222-9c3e-33b0efdcbba9
+      29d8f68f-7597-4825-ba14-8f35ebd3e1b5
+      2ba39466-d940-4df7-b98c-272a80cc889a
+      2f5752e7-06cc-4961-bc93-f16f46440ace
+      3883105b-3501-4644-9e43-342f1dafef6b
+      4169ef77-1642-4dc2-97d3-61b1a92e5cfa
+      43f837c5-3df6-4293-81cf-68f17a490060
+      47201999-f4bf-4262-adcc-da66c1995dba
+      4785e968-5634-42fe-b5a8-7e96ca067988
+      49420061-a561-45ef-973e-5af5be443f34
+      4a359150-54bc-4456-875a-7d37fc4e3172
+      4b66e61a-fe77-4eb5-8d87-0971906261aa
+      4e519a8d-d60c-45d8-b191-7642fb446bc6
+      4f4117a6-15bd-4c66-8a36-d25876f32c8f
+      555842db-9e0f-4dca-891a-71c6d895bc47
+      56242ca6-00ab-458e-a1cd-341f4dfee9e7
+      58bac623-f7cf-4c06-b6e8-35c013cec1de
+      593714b0-8d96-43ca-b8c5-fa5b9f8d0b6b
+      5d93f524-911c-43d1-8f67-561edc6cdcf9
+      6208a5c0-5be1-4ee4-b9fa-2c5aaf80ed62
+      62766bfb-31ab-4dce-b9ec-41818299166b
+      63141cd1-5714-494d-bc30-7303f430163f
+      647f9741-78b2-4a4a-959d-e90f71ab325f
+      699fdf64-e18a-4e48-8bbd-fcbc9a44a80e
+      6b2dd3f9-11bf-4182-909b-3baa619b9283
+      6c9e03a1-0653-4bcb-bf88-8ddff0506da5
+      7092d363-dd7b-4dce-b573-c39fd439bc5c
+      73c172bd-8dbc-4572-8506-5a9dccc4d7d9
+      747051c9-1660-4725-8d60-1e65e00b63a3
+      7494e041-13fb-4d1e-b4b4-76dd8190a34e
+      769ef32d-005e-4fd3-9111-80515d014fab
+      77c4d812-f7e2-40e6-866b-0ffff1367be4
+      78eb9b74-85b6-4a2e-b085-d4c0e5dbaa28
+      7b080d4b-a284-4a23-a952-f99e5757914b
+      7da6f068-06bf-4875-abc3-3e9758ff3cac
+      7f0a9efd-6652-427e-861b-ee7b55698c33
+      7fabe2f9-e574-40c6-9082-c993d70e880c
+      81fda36a-0535-41a7-8c40-aafdb40d478d
+      821f8943-5d93-4172-8dc2-e3c8d2d36fe6
+      87dc08d9-2669-4eea-96a0-e370138a6933
+      88edbafa-67fe-4155-a751-33cf6c39ec4d
+      8a8caab4-cdcb-4a8a-9eff-d5200c5a43d9
+      8e94b478-17a1-4cb9-9b14-592e2337d86e
+      905f70d8-8222-4f53-a807-aae1aaff718d
+      90ace7ff-490b-427a-b178-10169f1d0658
+      95ee5ba2-4e98-4cce-8538-e5a644068e96
+      99352fa1-b0c4-4c86-b92d-fc3e2665be27
+      9aa62924-8544-48ca-af4d-517f95570d5c
+      9c31a310-40db-46d5-8d07-aed14564330e
+      9c68dd91-27b3-4758-8dd9-64719f53acc8
+      9ceea44d-000d-4381-bcd4-cd34bfe86bf1
+      9da7a185-2db4-4ff2-a486-98c7e8d33fe7
+      9eecfbc4-2951-4584-9b4b-165b8e2144a1
+      a40f1857-f21f-4e7f-97da-0e64d9ed9e41
+      a53e1fb4-4e50-4595-981e-46cdd2a8ac0e
+      a67ef4ee-e36b-4de4-ad65-a3f38bc30369
+      a819a1ec-c126-4b17-92e4-e645d0d00eac
+      a907865a-3ede-4326-9050-da4ceaba2c5d
+      abb77112-0d24-43a8-ae34-fc43411fb83b
+      ac6c781b-3248-43b1-8f69-f4233d34ae5c
+      b29fa949-22c2-40d5-9761-61f37a4df66d
+      b7a4c96e-9a79-43af-b1fc-317dfd91d5d4
+      bbd13cc1-3c9e-4228-90ae-b274841f5bc9
+      bc514d20-eb72-4fcb-b706-4c3bd977b258
+      c0882d97-60f7-4bb4-be60-ffc9afc2daf8
+      c0caa370-2813-4a38-938a-1fa294dcfb86
+      c5903aaf-2ba6-4736-95e9-6db6be39de1d
+      c60aec90-396e-418c-9618-a588f615857c
+      c7972341-9ffb-49b5-b8d4-c0c183e5396e
+      c9920a24-5b5a-4fd6-8d6d-68ea2b412147
+      cdc7b829-71f3-4b6b-9f0b-f06ee9ea2e6a
+      cfb540c8-c00f-4934-9680-def7a8db8e20
+      d021ac64-9809-4dc5-91a5-26e6cf03c49d
+      d0344fdf-ad2b-4987-845e-f527573cf23d
+      d2bd07e2-56be-4829-b9bc-b98dc2a8da34
+      d5345bfe-2d96-444f-a266-310218cabc2e
+      d60f6874-b45f-4669-b941-91d0588ef802
+      d71ec0c9-88d9-482e-b38e-d92ccaac872b
+      d72b0813-e0e7-4e3d-94e4-4c67eb886a92
+      d839a8e6-544f-4496-bb8a-6e03869bedc0
+      dbeb24e0-215c-4fc8-b35a-d1db0621f368
+      dd2c5b0d-5fac-404e-a643-44795c42a42d
+      dd4b8a44-a685-4bca-a9d9-973339a44b88
+      df8b9572-3d45-4bc8-b838-faa90afd48da
+      e43796d7-c5a0-4071-b00c-e0920e5f7a53
+      e4c97bf4-21c3-4cc4-97e7-b41d33fce7d2
+      e55834b2-e7fc-44d5-84aa-cc410954fc0a
+      e84e4485-195d-45e9-a286-ba964885ff0f
+      ea123408-dcb4-47d3-8229-9929b1206557
+      ebf8f755-a514-4009-a9f1-77aa807da995
+      ef04ad5b-b9cf-4399-89e3-9ebd5b16a712
+      f1e60cab-fde1-46fb-aebf-1ccbb662e625
+      f41563db-f8ca-4853-82e0-7890cc842bc1
+      f70ce9ed-e10a-4434-87b2-2cb3aadc5147
+      f7fb8b5d-00b9-4129-875f-2ce4844eb931
+      fcfab889-44b0-4cf9-a850-a33baf3e5050
     )
   )
 )


### PR DESCRIPTION
Due to potential shorts users might experience we need to have a reference of where the case can overlap with the circuits on the PCB. The outlines are added to the optional user.1 and user.2 layers.

The case to board tolerance is 0.4mm. The lines are doubled to represent the maximum overlap extents.

