### PR TITLE
Migrate to the PDM-Backend build backend

### DIFF
--- a/software/.gitignore
+++ b/software/.gitignore
@@ -1,11 +1,11 @@
 # Python
+*.pyc
 __pycache__/
-*.egg-info
 /dist
-/build
 
 # pdm
 /.pdm-plugins
 /.pdm-python
+/.pdm-build
 /.venv*
 /pdm.lock

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -1,3 +1,6 @@
+[tool.pdm.version]
+source = "scm"
+
 [project]
 dynamic = ["version"]
 
@@ -108,15 +111,8 @@ radio-nrf24l1 = "glasgow.applet.radio.nrf24l01:RadioNRF24L01Applet"
 # Build system configuration
 
 [build-system]
-requires = ["setuptools>=67.0", "setuptools_scm[toml]>=6.2"]
-build-backend = "setuptools.build_meta"
-
-[tool.setuptools.package-data]
-"glasgow.device" = ["firmware.ihex"]
-
-[tool.setuptools_scm]
-root = ".."
-local_scheme = "node-and-timestamp"
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
 
 # Development workflow configuration
 

--- a/software/setup.py
+++ b/software/setup.py
@@ -1,4 +1,0 @@
-from setuptools import setup
-
-
-setup()


### PR DESCRIPTION
This provides us with the same functionality as setuptools with none of the legacy complexity and issues.

It also means that we use the same vendor for our package management and package build system, reducing the fragmentation in our dependency tree. (We went from three independent code suppliers to one.)