### PR TITLE
Do not fill terminal with noise when a device is surprise disconnected

### DIFF
--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -681,6 +681,10 @@ async def _main():
                 task.cancel()
             await asyncio.wait(tasks, return_when=asyncio.ALL_COMPLETED)
 
+            # If the applet task has raised an exception, retrieve it here in case any of the await
+            # statements above will fail; if we don't, asyncio will unnecessarily complain.
+            applet_task.exception()
+
             if do_trace:
                 await device.write_register(target.analyzer.addr_done, 1)
                 await analyzer_task

--- a/software/glasgow/device/hardware.py
+++ b/software/glasgow/device/hardware.py
@@ -254,23 +254,29 @@ class GlasgowHardwareDevice:
             elif status == usb1.TRANSFER_STALL:
                 result_future.set_exception(usb1.USBErrorPipe())
             elif status == usb1.TRANSFER_NO_DEVICE:
-                result_future.set_exception(GlasgowDeviceError("device lost"))
+                result_future.set_exception(GlasgowDeviceError("device disconnected"))
             else:
                 result_future.set_exception(GlasgowDeviceError(
                     "transfer error: {}".format(usb1.libusb1.libusb_transfer_status(status))))
 
+        def handle_usb_error(func):
+            try:
+                func()
+            except usb1.USBErrorNoDevice:
+                raise GlasgowDeviceError("device disconnected") from None
+
         loop = asyncio.get_event_loop()
         transfer.setCallback(lambda transfer: loop.call_soon_threadsafe(usb_callback, transfer))
-        transfer.submit()
+        handle_usb_error(lambda: transfer.submit())
         try:
             return await result_future
-        except asyncio.CancelledError:
-            try:
-                transfer.cancel()
-                await cancel_future
-            except usb1.USBErrorNotFound:
-                pass # already finished, one way or another
-            raise
+        finally:
+            if result_future.cancelled():
+                try:
+                    handle_usb_error(lambda: transfer.cancel())
+                    await cancel_future
+                except usb1.USBErrorNotFound:
+                    pass # already finished, one way or another
 
     async def control_read(self, request_type, request, value, index, length):
         logger.trace("USB: CONTROL IN type=%#04x request=%#04x "

--- a/software/glasgow/support/task_queue.py
+++ b/software/glasgow/support/task_queue.py
@@ -82,12 +82,12 @@ class TaskQueue:
         await self.poll()
 
     def __bool__(self):
-        """Check whether there are any pending tasks in the queue."""
-        return bool(self._live)
+        """Check whether there are any tasks in the queue."""
+        return bool(self._live) or bool(self._done)
 
     def __len__(self):
-        """Count pending tasks in the queue."""
-        return len(self._live)
+        """Count tasks in the queue."""
+        return len(self._live) + len(self._done)
 
     @property
     def total_wait_time(self):


### PR DESCRIPTION
"Surprise disconnected" means disconnecting a device while it is being used by an applet, script, or REPL; whether there are ongoing transfers or not.

After this commit, in general, only one message should be printed:

```
E: g.cli: device disconnected
```

However, applet logic will often not handle cancellation or USB transfer errors, so certain individual applets may still print more noise.

This has been one of the more irritating papercuts, especially as all that noise will make recovering from an accidentally unplugged device all that more annoying, and it's confusing to people who have not seen the error before too.

See individual commit messages for details of implementation, which is _nightmarish_.

Fixes #386.