### PR TITLE
Gracefully handle plugin load errors

### DIFF
--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -19,7 +19,7 @@ from fx2.format import input_data, diff_data
 from . import __version__
 from .support.logging import *
 from .support.asignal import *
-from .support.plugin import PluginRequirementsUnmet
+from .support.plugin import PluginRequirementsUnmet, PluginLoadError
 from .device import GlasgowDeviceError
 from .device.config import GlasgowConfig
 from .target.toolchain import ToolchainNotFound
@@ -138,7 +138,7 @@ def get_argparser():
         subparsers = add_subparsers(parser, dest="applet", metavar="APPLET", required=required)
 
         for handle, metadata in GlasgowAppletMetadata.all().items():
-            if not metadata.available:
+            if not metadata.loadable:
                 # fantastically cursed
                 p_applet = subparsers.add_parser(
                     handle, help=metadata.synopsis, description=metadata.description,
@@ -904,7 +904,7 @@ async def _main():
         return 2
 
     # Environment-related errors
-    except PluginRequirementsUnmet as e:
+    except (PluginRequirementsUnmet, PluginLoadError) as e:
         logger.error(e)
         print(e.metadata.description)
         return 3


### PR DESCRIPTION
This most notably improves the case where stale entry points metadata refers to a nonexistent applet (e.g. because it was removed, or because the applet was developed in a different branch of an editable install), which before this commit entirely breaks the CLI. This commit catches load errors and displays a nice error message in the UI.

This commit also improves help text for plugins with unmet requirements.