### PR TITLE
Migrate from appdirs to platformdirs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,6 @@ jobs:
       - name: Set up PDM
         uses: pdm-project/setup-pdm@v3
         with:
-          version: head # for --strategy direct_minimal_versions
           python-version: ${{ matrix.python-version }}
       - name: Generate lockfile
         working-directory: ./software

--- a/software/glasgow/target/hardware.py
+++ b/software/glasgow/target/hardware.py
@@ -5,7 +5,7 @@ import tempfile
 import shutil
 import logging
 import hashlib
-import appdirs
+import platformdirs
 import pathlib
 from amaranth import *
 from amaranth.build import ResourceError
@@ -153,8 +153,8 @@ class GlasgowBuildPlan:
         return bitstream
 
     def get_bitstream(self, *, debug=False):
-        cache_path = appdirs.user_cache_dir("GlasgowEmbedded", appauthor=False)
-        cache_filename = pathlib.Path(cache_path) / "bitstreams" / self.bitstream_id.hex()
+        cache_path = platformdirs.user_cache_path("GlasgowEmbedded", appauthor=False)
+        cache_filename = cache_path / "bitstreams" / self.bitstream_id.hex()
         cache_exists = False
         if cache_filename.exists():
             with cache_filename.open("rb") as cache_file:

--- a/software/pdm.min.lock
+++ b/software/pdm.min.lock
@@ -5,7 +5,7 @@
 groups = ["default", "builtin-toolchain", "http"]
 strategy = ["cross_platform", "direct_minimal_versions"]
 lock_version = "4.4"
-content_hash = "sha256:d424d8501f58db7a76e39083ce4f514dfbad48d09441e736c60393017ebfe3b2"
+content_hash = "sha256:bc9ebd4b2871a95616a4d1636d8193f4f60c42f3ae404100b93493581febf071"
 
 [[package]]
 name = "aiohttp"
@@ -120,15 +120,6 @@ dependencies = [
 ]
 files = [
     {file = "amaranth_yosys-0.10.0.0.post56-py3-none-any.whl", hash = "sha256:dd11d50ab248a88574c9fcb44f41ea00415bb9b827e0a26929bbcede61073da3"},
-]
-
-[[package]]
-name = "appdirs"
-version = "1.4.2"
-summary = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-files = [
-    {file = "appdirs-1.4.2-py2.py3-none-any.whl", hash = "sha256:a53330b9d53b66aba1e26907dea2958982ebad92735f9faf3897b73c909a20c1"},
-    {file = "appdirs-1.4.2.tar.gz", hash = "sha256:e2de7ae2b3be52542b711eacf4221683f1d2f7706a5550cb2c562ee4ba93ee74"},
 ]
 
 [[package]]
@@ -457,6 +448,16 @@ files = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "3.0.0"
+requires_python = ">=3.7"
+summary = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+files = [
+    {file = "platformdirs-3.0.0-py3-none-any.whl", hash = "sha256:b1d5eb14f221506f50d6604a561f4c5786d9e80355219694a1b244bcd96f4567"},
+    {file = "platformdirs-3.0.0.tar.gz", hash = "sha256:8a1228abb1ef82d788f74139988b137e78692984ec7b08eaa6c65f1723af28f9"},
+]
+
+[[package]]
 name = "pyvcd"
 version = "0.2.3"
 requires_python = ">= 3.6"
@@ -478,16 +479,16 @@ files = [
 
 [[package]]
 name = "wasmtime"
-version = "11.0.0"
-requires_python = ">=3.6"
+version = "14.0.0"
+requires_python = ">=3.8"
 summary = "A WebAssembly runtime powered by Wasmtime"
 files = [
-    {file = "wasmtime-11.0.0-py3-none-any.whl", hash = "sha256:db16541c58b35d548847771c52865ed503eb42a7c6cf8a48c40210697498a527"},
-    {file = "wasmtime-11.0.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:c752b6e0e900e9e78892c342b5a17478d60191a275a100240cf41438c4a7fb03"},
-    {file = "wasmtime-11.0.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:17cfca43797409be2764656affaf20906fd5ae9e1690a0431f6c06e8ef008fae"},
-    {file = "wasmtime-11.0.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:7668c6f3fc61e169fa74f89398e0347403a6f8d008d10d136c66cabf89586d1e"},
-    {file = "wasmtime-11.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:bcd8e3c155dc076706b9577516299a8a5772f1a99f1acce3befe47b4510f9ed9"},
-    {file = "wasmtime-11.0.0-py3-none-win_amd64.whl", hash = "sha256:df6fdd5da8b7826f575d78ddd7388102099ee635321de58f9bc847adcf3f8f2f"},
+    {file = "wasmtime-14.0.0-py3-none-any.whl", hash = "sha256:708f3399d54b4304aa59c55351e06698c8d18073a70f3299eebe07e3987a7353"},
+    {file = "wasmtime-14.0.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:13a63d99c8f53526ec8ca061a223b9499ec7cf991e3946f6fcf002a807beb079"},
+    {file = "wasmtime-14.0.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3e1cb2a78ddce2040aa908690462deecab04924021f75de94b6ee32d0a907bc4"},
+    {file = "wasmtime-14.0.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:236a9f3fb04b29bb9e553de814f2b748f2087f3fdfa99ce552f637ddedcc2a59"},
+    {file = "wasmtime-14.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:ec9a7fcd01ba4b04ee8f4c9d169dcf0f0fe67aa7ff8d032629cd8a08caf30c51"},
+    {file = "wasmtime-14.0.0-py3-none-win_amd64.whl", hash = "sha256:2f3a3589b6ede7c96e5d1cd45f65f88d154ccc9e9ddb34f75b49ce6db5ab6497"},
 ]
 
 [[package]]
@@ -561,15 +562,15 @@ files = [
 
 [[package]]
 name = "yowasp-runtime"
-version = "1.30"
-requires_python = "~=3.7"
+version = "1.42"
+requires_python = "~=3.8"
 summary = "Common runtime for YoWASP packages"
 dependencies = [
-    "appdirs~=1.4",
-    "wasmtime<12,>=1.0",
+    "platformdirs~=3.0",
+    "wasmtime<15,>=1.0",
 ]
 files = [
-    {file = "yowasp_runtime-1.30-py3-none-any.whl", hash = "sha256:cb4f357f90e19b1f604335a436468987c7f3d0e824101446b722678d7430ecd2"},
+    {file = "yowasp_runtime-1.42-py3-none-any.whl", hash = "sha256:d3897a3639a0178c8a63c8427762f6cd6dd0c11b26f534f2e602fbc177082f6d"},
 ]
 
 [[package]]

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -31,9 +31,9 @@ dependencies = [
   # `packaging` is used in the plugin system, `support.plugin`. It uses CalVer: the major version
   # is the two last digits of the year and the minor version is the release within that year.
   "packaging>=23.0",
-  # `appdirs` is used in the bitstream builder to use platform-appropriate cache directories.
+  # `platformdirs` is used in the bitstream builder to use platform-appropriate cache directories.
   # It uses SemVer.
-  "appdirs>=1.4.2,<2",
+  "platformdirs>=3.0.0,<4",
   # `fx2` is effectively maintained together with Glasgow. It uses SemVer, and keeps backward
   # compatibility within the 0.x release series.
   "fx2>=0.11,<1",
@@ -55,7 +55,7 @@ builtin-toolchain = [
   "amaranth-yosys",
   # `yowasp-runtime` is a dependency of other toolchain components, and it is constrained here to
   # the lowest that has features required for isolated builds.
-  "yowasp-runtime>=1.30",
+  "yowasp-runtime>=1.42",
   # Most versions of Yosys and nextpnr work; the minimum versions listed here are known good.
   "yowasp-yosys>=0.31.0.13",
   "yowasp-nextpnr-ice40>=0.1",


### PR DESCRIPTION
platformdirs is a friendly, maintained fork of appdirs (which stopped development after ~2020) - This should be 100% compatible for the used method.

I'm not exactly sure about the PDM lock file, getting rid of appdirs there might be dependent on https://github.com/YoWASP/runtime/pull/2 ?!?