### PR TITLE
Add type annotations to all public methods in `support.bits`

### DIFF
--- a/software/glasgow/support/bits.py
+++ b/software/glasgow/support/bits.py
@@ -103,7 +103,7 @@ class _bits_base(Sequence):
 
     def __new__(cls, value=0, length=None):
         """Creates a new bits instance.  The valid arguments for ``value`` are:
-        
+
         - another bits or bitarray instance (``length`` must not be provided)
         - int (``length`` may be provided or not, see ``from_int``)
         - str (``length`` must not be provided, see ``from_str``)
@@ -157,7 +157,7 @@ class _bits_base(Sequence):
                 # byte-aligned reverse fastpath
                 res = object.__new__(self.__class__)
                 bstart = start // 8
-                bstop = None if stop == -1 else stop // 8 
+                bstop = None if stop == -1 else stop // 8
                 res._bytes = self._bytes[bstart:bstop:-1].translate(_byterev_lut)
                 res._len = start - stop
                 return res
@@ -305,7 +305,7 @@ class _bits_base(Sequence):
         """Returns the start index of the first occurence of a given bit string within this
         bit string. If the ``needle`` is an ``str`` or an iterator, it is first converted
         to ``bits``. If ``needle`` is an integer, it must hava a value of 0 or 1, and is
-        converted to single-bit ``bits``. If ``start`` and ``end`` are given, only start positions in 
+        converted to single-bit ``bits``. If ``start`` and ``end`` are given, only start positions in
         ``range(start, end)`` are checked. If no occurence is found, the result is ``-1``."""
         if isinstance(needle, (str, Iterable)):
             needle = bits(needle)

--- a/software/pdm.min.lock
+++ b/software/pdm.min.lock
@@ -5,7 +5,7 @@
 groups = ["default", "builtin-toolchain", "http"]
 strategy = ["cross_platform", "direct_minimal_versions"]
 lock_version = "4.4"
-content_hash = "sha256:a70e8da8d1913325cf4794ab3798c4c2e42fc7e3ba4a7b23be26bfe337d15257"
+content_hash = "sha256:8f3a6d83a8f959b68ed91a06346c34d47403afa5cb1c6f926db996addce63bb7"
 
 [[package]]
 name = "aiohttp"

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -28,6 +28,9 @@ requires-python = "~=3.9, !=3.10.0, !=3.10.1, !=3.10.2"
 # Whenever dependencies are changed in any way, run `pdm run update-pdm.min.lock`. If you do not
 # run this command, the CI will reject the pull request with the change.
 dependencies = [
+  # We use `typing` features not available in the lowest Python version we support. The library
+  # `typing_extensions` provides shims for such features. It uses SemVer.
+  "typing_extensions>=4.8,<5",
   # Amaranth is the core of the Glasgow software/gateware interoperability layer. It uses SemVer.
   # We use the git version of Amaranth until the next release.
   "amaranth @ git+https://github.com/amaranth-lang/amaranth.git@4e4085a95b",

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -24,6 +24,9 @@ requires-python = "~=3.9, !=3.10.0, !=3.10.1, !=3.10.2"
 # Glasgow has only a few carefully chosen dependencies. The rationale for having them, as well as
 # the rationale for the particular version constraint, is explained below, and should be kept
 # synchronized with the source code. For clarity, we do not use the `~=` version constraint.
+#
+# Whenever dependencies are changed in any way, run `pdm run update-pdm.min.lock`. If you do not
+# run this command, the CI will reject the pull request with the change.
 dependencies = [
   # Amaranth is the core of the Glasgow software/gateware interoperability layer. It uses SemVer.
   # We use the git version of Amaranth until the next release.
@@ -143,4 +146,5 @@ build-backend = "pdm.backend"
 # Development workflow configuration
 
 [tool.pdm.scripts]
-test = {cmd = "python -m unittest"}
+"update-pdm.min.lock".cmd = "pdm lock -L pdm.min.lock -S direct_minimal_versions"
+test.cmd = "python -m unittest"


### PR DESCRIPTION
Is this a policy change? Yes: I'm looking to gradually add typing annotations (specifically the Pylance dialect) to Glasgow, and then eventually to Amaranth.