### PR TITLE
support.plugin: add feature-gated support for out-of-tree applets

### DIFF
--- a/examples/out_of_tree/.gitignore
+++ b/examples/out_of_tree/.gitignore
@@ -1,0 +1,11 @@
+# Python
+*.pyc
+__pycache__/
+/dist
+
+# pdm
+/.pdm-plugins
+/.pdm-python
+/.pdm-build
+/.venv*
+/pdm.lock

--- a/examples/out_of_tree/README.md
+++ b/examples/out_of_tree/README.md
@@ -1,0 +1,20 @@
+# Example out-of-tree applet
+
+Most applets currently reside in-tree (within the `glasgow` repository or its forks). On an **experimental** basis, support for out-of-tree applets is also provided. This feature is considered experimental because the Glasgow software does not provide a stable API.
+
+To use this feature, first install the out-of-tree applet. With the recommended method of installation (pipx) this can be done with:
+
+```console
+$ pipx inject glasgow -e ./examples/out_of_tree
+```
+
+Once installed, the applet is runnable provided a special environment variable is set:
+
+```console
+$ export GLASGOW_OUT_OF_TREE_APPLETS=I-am-okay-with-breaking-changes
+$ glasgow run exampleoot
+W: g.support.plugin: loading out-of-tree plugin 'glasgowcontrib-applet-exampleoot'; plugin API is currently unstable and subject to change without warning
+...
+```
+
+Note that there are no `glasgowcontrib/__init__.py` or `glasgowcontrib/applet/__init__.py` files included. This is intentional; `glasgowcontrib` and `glasgowcontrib.applet` are [PEP 420 namespace packages](https://peps.python.org/pep-0420/). Including such an `__init__` file by mistake will break every other out-of-tree applet, so take care.

--- a/examples/out_of_tree/glasgowcontrib/applet/exampleoot/__init__.py
+++ b/examples/out_of_tree/glasgowcontrib/applet/exampleoot/__init__.py
@@ -1,0 +1,13 @@
+import logging
+
+from glasgow.applet import *
+
+
+class ExampleOOTApplet(GlasgowApplet):
+    logger = logging.getLogger(__name__)
+    help = "example out-of-tree applet"
+    description = """
+    An example of an applet that is loaded from an externally installed package.
+
+    This applet does not implement any functionality.
+    """

--- a/examples/out_of_tree/pyproject.toml
+++ b/examples/out_of_tree/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "glasgowcontrib-applet-exampleoot"
+version = "0"
+description = "Example out-of-tree applet for the Glasgow Interface Explorer"
+authors = [{name = "Glasgow Interface Explorer contributors"}]
+license = {text = "0BSD OR Apache-2.0"}
+
+requires-python = "~=3.9"
+dependencies = ["glasgow"]
+
+[project.entry-points."glasgow.applet"]
+exampleoot = "glasgowcontrib.applet.exampleoot:ExampleOOTApplet"
+
+[build-system]
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
+
+[tool.pdm.build]
+includes = ["glasgowcontrib"]

--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -469,7 +469,7 @@ class SubjectFilter:
         return levelno >= self.level
 
 
-def create_logger(args):
+def create_logger():
     root_logger = logging.getLogger()
 
     term_formatter_args = {"style": "{",
@@ -480,6 +480,10 @@ def create_logger(args):
     else:
         term_handler.setFormatter(logging.Formatter(**term_formatter_args))
     root_logger.addHandler(term_handler)
+    return term_handler
+
+def configure_logger(args, term_handler):
+    root_logger = logging.getLogger()
 
     file_formatter_args = {"style": "{",
         "fmt": "[{asctime:s}] {levelname:s}: {name:s}: {message:s}"}
@@ -504,8 +508,12 @@ def create_logger(args):
 
 
 async def _main():
+    # Handle log messages emitted during construction of the argument parser (e.g. by the plugin
+    # subsystem).
+    term_handler = create_logger()
+
     args = get_argparser().parse_args()
-    create_logger(args)
+    configure_logger(args, term_handler)
 
     device = None
     try:


### PR DESCRIPTION
If `GLASGOW_OUT_OF_TREE_APPLETS` environment variable is not set to `I-am-okay-with-breaking-changes` then the software stack behaves exactly as before. If it is, a warning is printed anyways. I think this is a good compromise to allow us to proceed with enabling *some* out-of-tree applet use without locking ourselves into an API we don't want to keep.

We may regularly change the `GLASGOW_OUT_OF_TREE_APPLETS` code phrase to make sure people do not get complacent about it and use OOT applets for more than experimenting.