### PR TITLE
Update to Python 3.9+ syntax

### DIFF
--- a/software/glasgow/access/__init__.py
+++ b/software/glasgow/access/__init__.py
@@ -87,7 +87,7 @@ class AccessMultiplexerInterface(Elaboratable, metaclass=ABCMeta):
         pad_args = {}
 
         for pin in pins:
-            pin_num = getattr(args, "pin_{}".format(pin))
+            pin_num = getattr(args, f"pin_{pin}")
             if pin_num is None:
                 self.logger.debug("not assigning pin %r to any device pin", pin)
             else:
@@ -96,7 +96,7 @@ class AccessMultiplexerInterface(Elaboratable, metaclass=ABCMeta):
                 pad_args[pin] = self.get_pin(pin_num, name=pin)
 
         for pin_set in pin_sets:
-            pin_nums = getattr(args, "pin_set_{}".format(pin_set))
+            pin_nums = getattr(args, f"pin_set_{pin_set}")
             if pin_nums is None:
                 self.logger.debug("not assigning pin set %r to any device pins", pin_set)
             else:

--- a/software/glasgow/access/direct/arguments.py
+++ b/software/glasgow/access/direct/arguments.py
@@ -49,7 +49,7 @@ class DirectArguments(AccessArguments):
         return self._mandatory_pin_number(arg)
 
     def _add_pin_argument(self, parser, name, default, required):
-        help = "bind the applet I/O line {!r} to pin NUM".format(name)
+        help = f"bind the applet I/O line {name!r} to pin NUM"
         if default is not None:
             help += " (default: %(default)s)"
 
@@ -78,13 +78,13 @@ class DirectArguments(AccessArguments):
             if len(width) == 1:
                 width_desc = str(width[0])
             else:
-                width_desc = "{}..{}".format(width.start, width.stop - 1)
+                width_desc = f"{width.start}..{width.stop - 1}"
             self._arg_error("set {} includes {} pins, but {} pins are required",
                             arg, len(numbers), width_desc)
         return numbers
 
     def _add_pin_set_argument(self, parser, name, width, default, required):
-        help = "bind the applet I/O lines {!r} to pins SET".format(name)
+        help = f"bind the applet I/O lines {name!r} to pins SET"
         if default is not None:
             if default:
                 help += " (default: %(default)s)"
@@ -93,7 +93,7 @@ class DirectArguments(AccessArguments):
 
         opt_name = "--pins-" + name.lower().replace("_", "-")
         parser.add_argument(
-            opt_name, dest="pin_set_{}".format(name), metavar="SET",
+            opt_name, dest=f"pin_set_{name}", metavar="SET",
             type=functools.partial(self._pin_set, width), default=default, required=required,
             help=help)
 

--- a/software/glasgow/access/direct/multiplexer.py
+++ b/software/glasgow/access/direct/multiplexer.py
@@ -198,7 +198,7 @@ class DirectMultiplexerInterface(AccessMultiplexerInterface):
 
     def get_pin_name(self, pin_num):
         port, bit, req = self._pins[pin_num]
-        return "{}{}".format(port, bit)
+        return f"{port}{bit}"
 
     def build_pin_tristate(self, pin_num, oe, o, i):
         port, bit, req = self._pins[pin_num]

--- a/software/glasgow/access/simulation/arguments.py
+++ b/software/glasgow/access/simulation/arguments.py
@@ -33,13 +33,13 @@ class SimulationArguments(AccessArguments):
         return numbers
 
     def _add_pin_set_argument(self, parser, name, width, default, required):
-        help = "bind the applet I/O lines {!r} to pins SET".format(self._applet_name, name)
+        help = f"bind the applet I/O lines {self._applet_name!r} to pins SET"
         if default is not None:
             help += " (default: %(default)s)"
 
         opt_name = "--pins-" + name.lower().replace("_", "-")
         parser.add_argument(
-            opt_name, dest="pin_set_{}".format(name), metavar="SET",
+            opt_name, dest=f"pin_set_{name}", metavar="SET",
             type=functools.partial(self._pin_set, width), default=default, required=required,
             help=help)
 

--- a/software/glasgow/applet/__init__.py
+++ b/software/glasgow/applet/__init__.py
@@ -44,7 +44,7 @@ class GlasgowApplet(metaclass=ABCMeta):
             if clock_name is None:
                 raise GlasgowAppletError(e)
             else:
-                raise GlasgowAppletError("clock {}: {}".format(clock_name, e))
+                raise GlasgowAppletError(f"clock {clock_name}: {e}")
 
     @abstractmethod
     def build(self, target):
@@ -318,7 +318,7 @@ def applet_simulation_test(setup, args=[]):
             sim = Simulator(self.target)
             sim.add_clock(1e-9)
             sim.add_sync_process(run)
-            vcd_name = "{}.vcd".format(case.__name__)
+            vcd_name = f"{case.__name__}.vcd"
             with sim.write_vcd(vcd_name):
                 sim.run()
             os.remove(vcd_name)
@@ -336,7 +336,7 @@ def applet_hardware_test(setup="run_hardware_applet", args=[]):
                                         case.__name__ + ".json")
             os.makedirs(os.path.dirname(fixture_path), exist_ok=True)
             if os.path.exists(fixture_path):
-                fixture = open(fixture_path, "r")
+                fixture = open(fixture_path)
                 mode = "replay"
             else:
                 fixture = open(fixture_path, "w")

--- a/software/glasgow/applet/debug/arc/__init__.py
+++ b/software/glasgow/applet/debug/arc/__init__.py
@@ -120,7 +120,7 @@ class DebugARCApplet(JTAGProbeApplet):
     There is currently no debug server implemented. This applet only allows manipulating Memory,
     Core and Aux spaces via a Python REPL.
     """.format(
-        devices="\n".join(map(lambda x: "        * {.name}".format(x), devices.values()))
+        devices="\n".join(map(lambda x: f"        * {x.name}", devices.values()))
     )
 
     @classmethod

--- a/software/glasgow/applet/debug/mips/__init__.py
+++ b/software/glasgow/applet/debug/mips/__init__.py
@@ -667,7 +667,7 @@ class EJTAGDebugInterface(aobject, GDBRemote):
             assert False
 
     def target_register_names(self):
-        reg_names  = ["${}".format(reg) for reg in range(32)]
+        reg_names  = [f"${reg}" for reg in range(32)]
         reg_names += ["sr", "lo", "hi", "bad", "cause", "pc"]
         return reg_names
 
@@ -865,7 +865,7 @@ class DebugMIPSApplet(JTAGProbeApplet):
 
             reg_names = ejtag_iface.target_register_names()
             for name, value in zip(reg_names, reg_values):
-                print("{:<3} = {:08x}".format(name, value))
+                print(f"{name:<3} = {value:08x}")
 
         if args.operation == "gdb":
             endpoint = await ServerEndpoint("GDB socket", self.logger, args.gdb_endpoint)

--- a/software/glasgow/applet/display/pdi/__init__.py
+++ b/software/glasgow/applet/display/pdi/__init__.py
@@ -230,7 +230,7 @@ class PDIG1DisplayInterface(PDIDisplayInterface):
         # Verify that COG has the right generation
         cog_id = await self._identify()
         if cog_id != 0x11:
-            raise PDIDisplayError("COG is not PDI EPD G1 (id={:#04x})".format(cog_id))
+            raise PDIDisplayError(f"COG is not PDI EPD G1 (id={cog_id:#04x})")
 
         self._log("power on cog driver")
         # Channel Select

--- a/software/glasgow/applet/interface/analyzer/__init__.py
+++ b/software/glasgow/applet/interface/analyzer/__init__.py
@@ -100,7 +100,7 @@ class AnalyzerApplet(GlasgowApplet):
         vcd_writer = VCDWriter(args.file, timescale="1 ns", check_values=False)
         signals = []
         for index in range(self._event_sources[0].width):
-            signals.append(vcd_writer.register_var(scope="", name="pin[{}]".format(index),
+            signals.append(vcd_writer.register_var(scope="", name=f"pin[{index}]",
                 var_type="wire", size=1, init=0))
 
         try:

--- a/software/glasgow/applet/interface/i2c_initiator/__init__.py
+++ b/software/glasgow/applet/interface/i2c_initiator/__init__.py
@@ -246,7 +246,7 @@ class I2CInitiatorInterface:
             if write:
                 if await self.write(addr, [], stop=True) is True:
                     self._logger.log(self._level, "I2C scan: found write address %s",
-                                        "{:#09b}".format(addr))
+                                        f"{addr:#09b}")
                     found.add(addr)
                     # After a successful write detection no read scan is done anymore
                     continue
@@ -255,7 +255,7 @@ class I2CInitiatorInterface:
                 # so that the addressed device releases SDA.
                 if await self.read(addr, 1, stop=True) is not None:
                     self._logger.log(self._level, "I2C scan: found read address %s",
-                                        "{:#09b}".format(addr))
+                                        f"{addr:#09b}")
                     found.add(addr)
         return found
 
@@ -338,7 +338,7 @@ class I2CInitiatorApplet(GlasgowApplet):
             found_addrs = await i2c_iface.scan(read=args.read, write=args.write)
             for addr in sorted(found_addrs):
                 self.logger.info("scan found address %s",
-                                    "{:#09b}".format(addr))
+                                    f"{addr:#09b}")
                 if args.device_id:
                     device_id = await i2c_iface.device_id(addr)
                     if device_id is None:

--- a/software/glasgow/applet/interface/jtag_pinout/__init__.py
+++ b/software/glasgow/applet/interface/jtag_pinout/__init__.py
@@ -131,29 +131,29 @@ class JTAGPinoutInterface:
         await self._cmd(CMD_W)
 
     async def set_oe(self, word):
-        self._log("set oe=%s", "{:016b}".format(word))
+        self._log("set oe=%s", f"{word:016b}")
         await self._cmd(CMD_OE)
         await self._arg(word)
 
     async def set_o(self, word):
-        self._log("set o= %s", "{:016b}".format(word))
+        self._log("set o= %s", f"{word:016b}")
         await self._cmd(CMD_O)
         await self._arg(word)
 
     async def set_o_1(self, word):
-        self._log("set h= %s", "{:016b}".format(word))
+        self._log("set h= %s", f"{word:016b}")
         await self._cmd(CMD_H)
         await self._arg(word)
 
     async def set_o_0(self, word):
-        self._log("set l= %s", "{:016b}".format(word))
+        self._log("set l= %s", f"{word:016b}")
         await self._cmd(CMD_L)
         await self._arg(word)
 
     async def get_i(self):
         await self._cmd(CMD_I)
         word = await self._ret()
-        self._log("get i= %s", "{:016b}".format(word))
+        self._log("get i= %s", f"{word:016b}")
         return word
 
 
@@ -199,7 +199,7 @@ class JTAGPinoutApplet(GlasgowApplet):
 
     @staticmethod
     def _from_word(word):
-        return set(bit for bit in range(word.bit_length()) if word & (1 << bit))
+        return {bit for bit in range(word.bit_length()) if word & (1 << bit)}
 
     async def _detect_pulls(self, iface):
         each = self._to_word(self.bits)
@@ -429,7 +429,7 @@ class JTAGPinoutApplet(GlasgowApplet):
             probe_args = ["jtag-probe"]
 
             if args.voltage is not None:
-                probe_args += ["-V", "{:.1f}".format(args.voltage)]
+                probe_args += ["-V", f"{args.voltage:.1f}"]
             elif args.mirror_voltage:
                 probe_args += ["-M"]
             elif args.keep_voltage:

--- a/software/glasgow/applet/interface/jtag_probe/__init__.py
+++ b/software/glasgow/applet/interface/jtag_probe/__init__.py
@@ -632,11 +632,11 @@ class JTAGProbeInterface:
             if value is None:
                 self._log_h("scan %s overlong", xr)
                 if check:
-                    raise JTAGProbeError("{} shift chain is too long".format(xr.upper()))
+                    raise JTAGProbeError(f"{xr.upper()} shift chain is too long")
             elif len(value) == 0:
                 self._log_h("scan %s empty", xr)
                 if check:
-                    raise JTAGProbeError("{} shift chain is empty".format(xr.upper()))
+                    raise JTAGProbeError(f"{xr.upper()} shift chain is empty")
             else:
                 self._log_h("scan %s length=%d data=<%s>",
                             xr, length, dump_bin(data_0[:length]))
@@ -788,7 +788,7 @@ class JTAGProbeInterface:
             for ir_start0, ir_start1 in zip(ir_starts, ir_starts[1:] + [len(ir_value)]):
                 ir_chunks.append(ir_start1 - ir_start0)
             self._log_h("ambiguous ir taps=%d chunks=[%s]",
-                        tap_count, ",".join("{:d}".format(chunk) for chunk in ir_chunks))
+                        tap_count, ",".join(f"{chunk:d}" for chunk in ir_chunks))
             if check:
                 raise JTAGProbeError("IR capture insufficiently constrains IR lengths")
             return

--- a/software/glasgow/applet/interface/ps2_host/__init__.py
+++ b/software/glasgow/applet/interface/ps2_host/__init__.py
@@ -364,9 +364,9 @@ class PS2HostInterface:
             # the first place. (Some devices will reset themselves after sending FC.)
             #
             # In practice treating FE and FC the same seems to be the best option.
-            raise PS2HostError("peripheral did not accept command {:#04x}".format(cmd))
+            raise PS2HostError(f"peripheral did not accept command {cmd:#04x}")
         else:
-            raise PS2HostError("peripheral returned unknown response {:#04x}".format(cmd))
+            raise PS2HostError(f"peripheral returned unknown response {cmd:#04x}")
         return result
 
     async def recv_packet(self, ret):
@@ -437,7 +437,7 @@ class PS2HostApplet(GlasgowApplet):
         for init_byte in args.init:
             await iface.send_command(init_byte)
         async def print_byte(byte):
-            print("{:02x}".format(byte), end=" ", flush=True)
+            print(f"{byte:02x}", end=" ", flush=True)
         await iface.stream(print_byte)
 
     @classmethod

--- a/software/glasgow/applet/internal/selftest/__init__.py
+++ b/software/glasgow/applet/internal/selftest/__init__.py
@@ -131,7 +131,7 @@ class SelfTestApplet(GlasgowApplet):
                 await set_o(o)
                 await set_oe(oe)
             i = await get_i()
-            desc = "oe={:016b} o={:016b} i={:016b}".format(oe, o, i)
+            desc = f"oe={oe:016b} o={o:016b} i={i:016b}"
             return i, desc
 
         pin_names = sum([["%s%d" % (p, n) for n in range(8)] for p in ("A", "B")], [])
@@ -272,14 +272,14 @@ class SelfTestApplet(GlasgowApplet):
                         await asyncio.wait_for(iface.flush(), timeout=0.1)
                     except asyncio.TimeoutError:
                         passed = False
-                        report.append((mode, "USB {} timeout".format(ep_out)))
+                        report.append((mode, f"USB {ep_out} timeout"))
                         continue
 
                     try:
                         received = await asyncio.wait_for(iface.read(len(data)), timeout=0.1)
                     except asyncio.TimeoutError:
                         passed = False
-                        report.append((mode, "USB {} timeout".format(ep_in)))
+                        report.append((mode, f"USB {ep_in} timeout"))
                         continue
 
                     if received != data:

--- a/software/glasgow/applet/memory/_25x/__init__.py
+++ b/software/glasgow/applet/memory/_25x/__init__.py
@@ -104,7 +104,7 @@ class Memory25xInterface:
 
         data = bytearray()
         while length > len(data):
-            callback(len(data), length, "reading address {:#08x}".format(address))
+            callback(len(data), length, f"reading address {address:#08x}")
             chunk    = await self._command(cmd, arg=self._format_addr(address),
                                            dummy=dummy, ret=min(chunk_size, length - len(data)))
             data    += chunk
@@ -131,7 +131,7 @@ class Memory25xInterface:
 
     async def read_status(self):
         status, = await self._command(0x05, ret=1)
-        self._log("read status=%s", "{:#010b}".format(status))
+        self._log("read status=%s", f"{status:#010b}")
         return status
 
     async def write_enable(self):
@@ -150,11 +150,11 @@ class Memory25xInterface:
             # that. Work around by checking twice in a row. Sigh.
             status = await self.read_status()
             if status & BIT_WEL and not status & BIT_WIP:
-                raise Memory25xError("{} command failed (status {:08b})".format(command, status))
+                raise Memory25xError(f"{command} command failed (status {status:08b})")
         return bool(status & BIT_WIP)
 
     async def write_status(self, status):
-        self._log("write status=%s", "{:#010b}".format(status))
+        self._log("write status=%s", f"{status:#010b}")
         await self._command(0x01, arg=[status])
         while await self.write_in_progress(command="WRITE STATUS"): pass
 
@@ -187,7 +187,7 @@ class Memory25xInterface:
             chunk    = data[:page_size - address % page_size]
             data     = data[len(chunk):]
 
-            callback(done, total, "programming page {:#08x}".format(address))
+            callback(done, total, f"programming page {address:#08x}")
             await self.write_enable()
             await self.page_program(address, chunk)
 
@@ -211,7 +211,7 @@ class Memory25xInterface:
                 sector_data = await self.read(sector_start, sector_size)
                 sector_data[address % sector_size:(address % sector_size) + len(chunk)] = chunk
 
-            callback(done, total, "erasing sector {:#08x}".format(sector_start))
+            callback(done, total, f"erasing sector {sector_start:#08x}")
             await self.write_enable()
             await self.sector_erase(sector_start)
 
@@ -389,9 +389,9 @@ class Memory25xApplet(SPIControllerApplet):
         if sys.stdout.isatty():
             sys.stdout.write("\r\033[0K")
             if done < total:
-                sys.stdout.write("{}/{} bytes done".format(done, total))
+                sys.stdout.write(f"{done}/{total} bytes done")
                 if status:
-                    sys.stdout.write("; {}".format(status))
+                    sys.stdout.write(f"; {status}")
             sys.stdout.flush()
 
     async def interact(self, device, args, m25x_iface):
@@ -511,7 +511,7 @@ class Memory25xApplet(SPIControllerApplet):
             status = await m25x_iface.read_status()
             if args.bits is None:
                 self.logger.info("block protect bits are set to %s",
-                                 "{:04b}".format((status & MSK_PROT) >> 2))
+                                 f"{(status & MSK_PROT) >> 2:04b}")
             else:
                 status = (status & ~MSK_PROT) | ((args.bits << 2) & MSK_PROT)
                 await m25x_iface.write_enable()

--- a/software/glasgow/applet/memory/floppy/__init__.py
+++ b/software/glasgow/applet/memory/floppy/__init__.py
@@ -787,7 +787,7 @@ class MemoryFloppyAppletTool(GlasgowAppletTool, applet=MemoryFloppyApplet):
 
             mfm = SoftwareMFMDecoder(self.logger)
             data.append(np.array(list(mfm.edges(bytestream))) * self._timebase)
-            labels.append("cylinder {}, head {}".format(cylinder, head))
+            labels.append(f"cylinder {cylinder}, head {head}")
 
         fig, ax = plt.subplots()
         fig.suptitle("Domain size histogram for {} (heads: {})"

--- a/software/glasgow/applet/memory/onfi/__init__.py
+++ b/software/glasgow/applet/memory/onfi/__init__.py
@@ -469,7 +469,7 @@ class MemoryONFIApplet(GlasgowApplet):
         available_ce = range(1, 1 + len(args.pin_set_ce))
         if args.chip not in available_ce:
             raise GlasgowAppletError("cannot select chip {}; available select signals are {}"
-                .format(args.chip, ", ".join("CE{}#".format(n) for n in available_ce)))
+                .format(args.chip, ", ".join(f"CE{n}#" for n in available_ce)))
         await onfi_iface.select(args.chip - 1)
 
         return onfi_iface
@@ -551,7 +551,7 @@ class MemoryONFIApplet(GlasgowApplet):
         # so print these for convenience as well.
         signature = await onfi_iface.read_signature()
         self.logger.info("ID signature: %s",
-                         " ".join("{:02x}".format(byte) for byte in signature))
+                         " ".join(f"{byte:02x}" for byte in signature))
 
         onfi_param = None
         if await onfi_iface.read_onfi_signature() == b"ONFI":

--- a/software/glasgow/applet/memory/prom/__init__.py
+++ b/software/glasgow/applet/memory/prom/__init__.py
@@ -342,7 +342,7 @@ class MemoryPROMInterface:
             n = len(self)
             if isinstance(key, int):
                 if key not in range(-n, n):
-                    raise IndexError("Cannot index {} words into {}-word data".format(key, n))
+                    raise IndexError(f"Cannot index {key} words into {n}-word data")
                 if key < 0:
                     key += n
                 elem = self.raw_data[key * self.dq_bytes:(key + 1) * self.dq_bytes]
@@ -351,7 +351,7 @@ class MemoryPROMInterface:
                 start, stop, step = key.indices(n)
                 return [self[index] for index in range(start, stop, step)]
             else:
-                raise TypeError("Cannot index value with {}".format(repr(key)))
+                raise TypeError(f"Cannot index value with {key!r}")
 
             if index not in range(len(self)):
                 raise IndexError
@@ -559,7 +559,7 @@ class MemoryPROMApplet(GlasgowApplet):
         def voltage_range(arg):
             m = re.match(r"^(\d+(?:\.\d*)?):(\d+(?:\.\d*)?)$", arg)
             if not m:
-                raise argparse.ArgumentTypeError("'{}' is not a voltage range".format(arg))
+                raise argparse.ArgumentTypeError(f"'{arg}' is not a voltage range")
             return float(m[1]), float(m[2])
 
         p_operation = parser.add_subparsers(dest="operation", metavar="OPERATION", required=True)

--- a/software/glasgow/applet/program/avr/__init__.py
+++ b/software/glasgow/applet/program/avr/__init__.py
@@ -242,19 +242,19 @@ class ProgramAVRApplet(GlasgowApplet):
                 fuses = await avr_iface.read_fuse_range(range(device.fuses_size))
                 if device.fuses_size > 2:
                     self.logger.info("fuses: low %s high %s extra %s",
-                                     "{:08b}".format(fuses[0]),
-                                     "{:08b}".format(fuses[1]),
-                                     "{:08b}".format(fuses[2]))
+                                     f"{fuses[0]:08b}",
+                                     f"{fuses[1]:08b}",
+                                     f"{fuses[2]:08b}")
                 elif device.fuses_size > 1:
                     self.logger.info("fuses: low %s high %s",
-                                     "{:08b}".format(fuses[0]),
-                                     "{:08b}".format(fuses[1]))
+                                     f"{fuses[0]:08b}",
+                                     f"{fuses[1]:08b}")
                 else:
-                    self.logger.info("fuse: %s", "{:08b}".format(fuses[0]))
+                    self.logger.info("fuse: %s", f"{fuses[0]:08b}")
 
             if args.lock_bits:
                 lock_bits = await avr_iface.read_lock_bits()
-                self.logger.info("lock bits: %s", "{:08b}".format(lock_bits))
+                self.logger.info("lock bits: %s", f"{lock_bits:08b}")
 
             if args.calibration:
                 calibration = \
@@ -284,7 +284,7 @@ class ProgramAVRApplet(GlasgowApplet):
                 written = await avr_iface.read_fuse(0)
                 if written != args.low:
                     raise ProgramAVRError("verification of low fuse failed: %s" %
-                                          "{:08b} != {:08b}".format(written, args.low))
+                                          f"{written:08b} != {args.low:08b}")
 
             if args.high:
                 self.logger.info("writing high fuse")
@@ -292,7 +292,7 @@ class ProgramAVRApplet(GlasgowApplet):
                 written = await avr_iface.read_fuse(1)
                 if written != args.high:
                     raise ProgramAVRError("verification of high fuse failed: %s" %
-                                          "{:08b} != {:08b}".format(written, args.high))
+                                          f"{written:08b} != {args.high:08b}")
 
             if args.extra:
                 self.logger.info("writing extra fuse")
@@ -300,7 +300,7 @@ class ProgramAVRApplet(GlasgowApplet):
                 written = await avr_iface.read_fuse(2)
                 if written != args.extra:
                     raise ProgramAVRError("verification of extra fuse failed: %s" %
-                                          "{:08b} != {:08b}".format(written, args.extra))
+                                          f"{written:08b} != {args.extra:08b}")
 
         if args.operation == "write-lock":
             self.logger.info("writing lock bits")
@@ -308,7 +308,7 @@ class ProgramAVRApplet(GlasgowApplet):
             written = await avr_iface.read_lock_bits()
             if written != args.bits:
                 raise ProgramAVRError("verification of lock bits failed: %s" %
-                                      "{:08b} != {:08b}".format(written, args.bits))
+                                      f"{written:08b} != {args.bits:08b}")
 
         if args.operation == "write-program":
             self.logger.info("erasing chip")

--- a/software/glasgow/applet/program/m16c/__init__.py
+++ b/software/glasgow/applet/program/m16c/__init__.py
@@ -175,7 +175,7 @@ class ProgramM16CInterface:
         try:
             return await asyncio.wait_for(response(), timeout=self.timeout)
         except asyncio.TimeoutError:
-            raise M16CBootloaderError("bootloader does not support baud rate {}".format(baud_rate))
+            raise M16CBootloaderError(f"bootloader does not support baud rate {baud_rate}")
 
     async def bootloader_version(self):
         self._log("command version")
@@ -194,7 +194,7 @@ class ProgramM16CInterface:
         await self.lower.write([Command.READ_STATUS])
         async def response():
             srd1, srd2 = await self.lower.read(2)
-            self._log("response srd1=%s srd2=%s", "{:08b}".format(srd1), "{:08b}".format(srd2))
+            self._log("response srd1=%s srd2=%s", f"{srd1:08b}", f"{srd2:08b}")
             return srd1, srd2
         try:
             return await asyncio.wait_for(response(), timeout=self.timeout)
@@ -207,7 +207,7 @@ class ProgramM16CInterface:
             await self.lower.write([Command.READ_STATUS])
             async def response():
                 srd1, srd2 = await self.lower.read(2)
-                self._log("response srd1=%s srd2=%s", "{:08b}".format(srd1), "{:08b}".format(srd2))
+                self._log("response srd1=%s srd2=%s", f"{srd1:08b}", f"{srd2:08b}")
                 return srd1, srd2
             try:
                 return await asyncio.wait_for(response(), timeout=0.1)
@@ -257,7 +257,7 @@ class ProgramM16CInterface:
         try:
             return await asyncio.wait_for(response(), timeout=self.timeout)
         except asyncio.TimeoutError:
-            raise M16CBootloaderError("cannot read page {:06x}".format(address))
+            raise M16CBootloaderError(f"cannot read page {address:06x}")
 
     async def program_page(self, address, data):
         assert address % PAGE_SIZE == 0 and len(data) == PAGE_SIZE
@@ -273,7 +273,7 @@ class ProgramM16CInterface:
             srd1, srd2 = await self._bootloader_poll_status(1.0)
             assert (srd1 & ST_READY) != 0
             if (srd1 & ST_PROGRAM_FAIL) != 0:
-                raise M16CBootloaderError("cannot program page {:06x}".format(address))
+                raise M16CBootloaderError(f"cannot program page {address:06x}")
         except asyncio.TimeoutError:
             raise M16CBootloaderError("page program timeout")
 
@@ -290,7 +290,7 @@ class ProgramM16CInterface:
             srd1, srd2 = await self._bootloader_poll_status(1.0)
             assert (srd1 & ST_READY) != 0
             if (srd1 & ST_ERASE_FAIL) != 0:
-                raise M16CBootloaderError("cannot erase block {:06x}".format(address))
+                raise M16CBootloaderError(f"cannot erase block {address:06x}")
         except asyncio.TimeoutError:
             raise M16CBootloaderError("block erase timeout")
 
@@ -372,9 +372,9 @@ class ProgramM16CApplet(GlasgowApplet):
             try:
                 key = bytes.fromhex(arg)
             except ValueError:
-                raise argparse.ArgumentTypeError("{} is not a hexadecimal string".format(arg))
+                raise argparse.ArgumentTypeError(f"{arg} is not a hexadecimal string")
             if len(key) > 7:
-                raise argparse.ArgumentTypeError("{} is not a valid bootloader key".format(arg))
+                raise argparse.ArgumentTypeError(f"{arg} is not a valid bootloader key")
             return key
 
         parser.add_argument(
@@ -384,12 +384,12 @@ class ProgramM16CApplet(GlasgowApplet):
         def page_address(arg):
             address = int(arg, 0)
             if address % PAGE_SIZE != 0:
-                raise argparse.ArgumentTypeError("{} is not a page-aligned address".format(arg))
+                raise argparse.ArgumentTypeError(f"{arg} is not a page-aligned address")
             return address
         def page_length(arg):
             address = int(arg, 0)
             if address % PAGE_SIZE != 0:
-                raise argparse.ArgumentTypeError("{} is not a page-aligned length".format(arg))
+                raise argparse.ArgumentTypeError(f"{arg} is not a page-aligned length")
             return address
 
         p_operation = parser.add_subparsers(dest="operation", metavar="OPERATION")

--- a/software/glasgow/applet/program/nrf24lx1/__init__.py
+++ b/software/glasgow/applet/program/nrf24lx1/__init__.py
@@ -116,11 +116,11 @@ class ProgramNRF24Lx1Interface:
 
     async def read_status(self):
         status, = await self._command(0x05, ret=1)
-        self._log("read status=%s", "{:#010b}".format(status))
+        self._log("read status=%s", f"{status:#010b}")
         return status
 
     async def write_status(self, status):
-        self._log("write status=%s", "{:#010b}".format(status))
+        self._log("write status=%s", f"{status:#010b}")
         await self._command(0x01, arg=[status])
 
     async def wait_status(self):

--- a/software/glasgow/applet/program/xc6s/__init__.py
+++ b/software/glasgow/applet/program/xc6s/__init__.py
@@ -53,7 +53,7 @@ class XC6SJTAGInterface:
         async for status in self._poll(IR_CFG_IN, limit=16):
             if status.INIT_B:
                 return
-        raise GlasgowAppletError("configuration reset failed: {}".format(status.bits_repr()))
+        raise GlasgowAppletError(f"configuration reset failed: {status.bits_repr()}")
 
     async def load_bitstream(self, bitstream, *, byte_reverse=True):
         bitstream = bits(bitstream)
@@ -71,7 +71,7 @@ class XC6SJTAGInterface:
             await self.lower.run_test_idle(16)
             if status.ISC_DONE:
                 return
-        raise GlasgowAppletError("configuration start failed: {}".format(status.bits_repr()))
+        raise GlasgowAppletError(f"configuration start failed: {status.bits_repr()}")
 
 
 class ProgramXC6SApplet(JTAGProbeApplet):

--- a/software/glasgow/applet/program/xc9500xl/__init__.py
+++ b/software/glasgow/applet/program/xc9500xl/__init__.py
@@ -508,7 +508,7 @@ class ProgramXC9500XLApplet(JTAGProbeApplet):
     Supported devices are:
 {devices}
     """.format(
-        devices="\n".join("        * {.name}".format(device) for device in devices)
+        devices="\n".join(f"        * {device.name}" for device in devices)
     )
 
     @classmethod

--- a/software/glasgow/applet/radio/nrf24l01/__init__.py
+++ b/software/glasgow/applet/radio/nrf24l01/__init__.py
@@ -239,7 +239,7 @@ class RadioNRF24L01Applet(GlasgowApplet):
             value = int(value, 10)
             if value not in range(126):
                 raise argparse.ArgumentTypeError(
-                    "invalid channel: {} (choose from 0..125)".format(value))
+                    f"invalid channel: {value} (choose from 0..125)")
             return value
         def address(value):
             # In our API, byte 0 is LSB (which matches the order of writes to registers).
@@ -249,13 +249,13 @@ class RadioNRF24L01Applet(GlasgowApplet):
             value = int(value, 10)
             if value not in range(33):
                 raise argparse.ArgumentTypeError(
-                    "invalid length: {} (choose from 0..32)".format(value))
+                    f"invalid length: {value} (choose from 0..32)")
             return value
         def payload(value):
             payload = bytes.fromhex(value)
             if len(payload) not in range(33):
                 raise argparse.ArgumentTypeError(
-                    "invalid payload length: {} (must be between 0..32)".format(len(value)))
+                    f"invalid payload length: {len(value)} (must be between 0..32)")
             return payload
 
         parser.add_argument(
@@ -568,7 +568,7 @@ class RadioNRF24L01Applet(GlasgowApplet):
                             crc_msg = ""
 
                         self.logger.info("packet received: PID=%s %s%s",
-                                         "{:02b}".format(packet_id), payload_msg, crc_msg)
+                                         f"{packet_id:02b}", payload_msg, crc_msg)
                     else:
                         self.logger.info("packet received: %s", dump_hex(payload))
 

--- a/software/glasgow/applet/sensor/bmx280/__init__.py
+++ b/software/glasgow/applet/sensor/bmx280/__init__.py
@@ -442,14 +442,14 @@ class SensorBMx280Applet(I2CInitiatorApplet):
 
             temp_degC = await bmx280.get_temperature()
             press_Pa  = await bmx280.get_pressure()
-            print("temperature : {:.0f} °C".format(temp_degC))
-            print("pressure    : {:.0f} Pa".format(press_Pa))
+            print(f"temperature : {temp_degC:.0f} °C")
+            print(f"pressure    : {press_Pa:.0f} Pa")
             if args.report_altitude:
                 altitude_m = await bmx280.get_altitude(p0=args.sea_level_pressure)
-                print("altitude    : {:.0f} m".format(altitude_m))
+                print(f"altitude    : {altitude_m:.0f} m")
             if bmx280.has_humidity:
                 humidity_pct = await bmx280.get_humidity()
-                print("humidity    : {:.0f}%".format(humidity_pct))
+                print(f"humidity    : {humidity_pct:.0f}%")
 
         if args.operation == "log":
             await bmx280.set_mode("normal")

--- a/software/glasgow/applet/sensor/hx711/__init__.py
+++ b/software/glasgow/applet/sensor/hx711/__init__.py
@@ -204,7 +204,7 @@ class SensorHX711Applet(GlasgowApplet):
 
         if args.operation == "measure":
             sample = await hx711.sample()
-            print("count : {:+d} LSB".format(sample))
+            print(f"count : {sample:+d} LSB")
 
         if args.operation == "log":
             data_logger = await DataLogger(self.logger, args, field_names={"n": "count(LSB)"})

--- a/software/glasgow/applet/sensor/ina260/__init__.py
+++ b/software/glasgow/applet/sensor/ina260/__init__.py
@@ -134,9 +134,9 @@ class SensorINA260Applet(I2CInitiatorApplet):
             volts = await ina260.get_voltage()
             amps  = await ina260.get_current()
             watts = await ina260.get_power()
-            print("bus voltage : {:7.03f} V".format(volts))
-            print("current     : {:+7.03f} A".format(amps))
-            print("power       : {:7.03f} W".format(watts))
+            print(f"bus voltage : {volts:7.03f} V")
+            print(f"current     : {amps:+7.03f} A")
+            print(f"power       : {watts:7.03f} W")
 
         if args.operation == "log":
             field_names = dict(u="u(V)", i="i(A)", p="p(W)")

--- a/software/glasgow/applet/sensor/pmsx003/__init__.py
+++ b/software/glasgow/applet/sensor/pmsx003/__init__.py
@@ -127,15 +127,15 @@ class SensorPMSx003Applet(GlasgowApplet):
     async def interact(self, device, args, pmsx003):
         if args.operation == "measure":
             sample = await pmsx003.read_measurement()
-            print("PM1.0 air quality : {:d} µg/m³".format(sample.pm1_0_ug_m3))
-            print("PM2.5 air quality : {:d} µg/m³".format(sample.pm2_5_ug_m3))
-            print("PM10 air quality  : {:d} µg/m³".format(sample.pm10_ug_m3))
-            print("0.3 µm particles  : {:d} n/dL".format(sample.p0_3_n_dL))
-            print("0.5 µm particles  : {:d} n/dL".format(sample.p0_5_n_dL))
-            print("1.0 µm particles  : {:d} n/dL".format(sample.p1_0_n_dL))
-            print("2.5 µm particles  : {:d} n/dL".format(sample.p2_5_n_dL))
-            print("5.0 µm particles  : {:d} n/dL".format(sample.p5_0_n_dL))
-            print("10 µm particles   : {:d} n/dL".format(sample.p10_n_dL))
+            print(f"PM1.0 air quality : {sample.pm1_0_ug_m3:d} µg/m³")
+            print(f"PM2.5 air quality : {sample.pm2_5_ug_m3:d} µg/m³")
+            print(f"PM10 air quality  : {sample.pm10_ug_m3:d} µg/m³")
+            print(f"0.3 µm particles  : {sample.p0_3_n_dL:d} n/dL")
+            print(f"0.5 µm particles  : {sample.p0_5_n_dL:d} n/dL")
+            print(f"1.0 µm particles  : {sample.p1_0_n_dL:d} n/dL")
+            print(f"2.5 µm particles  : {sample.p2_5_n_dL:d} n/dL")
+            print(f"5.0 µm particles  : {sample.p5_0_n_dL:d} n/dL")
+            print(f"10 µm particles   : {sample.p10_n_dL:d} n/dL")
 
         if args.operation == "log":
             field_names = dict(

--- a/software/glasgow/applet/sensor/scd30/__init__.py
+++ b/software/glasgow/applet/sensor/scd30/__init__.py
@@ -59,7 +59,7 @@ class SCD30I2CInterface:
         data = bytearray()
         for index, (chunk, crc) in enumerate(struct.iter_unpack(">2sB", crc_data)):
             if self._crc(chunk) != crc:
-                raise SCD30Error("CRC failed on word {}".format(index))
+                raise SCD30Error(f"CRC failed on word {index}")
             data += chunk
         return data
 
@@ -187,7 +187,7 @@ class SensorSCD30Applet(I2CInitiatorApplet):
                 value = conv(value)
                 if not (low <= value <= high):
                     raise argparse.ArgumentTypeError(
-                        "{} is not between {} and {}".format(value, low, high))
+                        f"{value} is not between {low} and {high}")
                 return value
             return arg
 
@@ -252,10 +252,10 @@ class SensorSCD30Applet(I2CInitiatorApplet):
             altitude_compensation = await scd30.get_altitude_compensation()
             measurement_interval  = await scd30.get_measurement_interval()
             print("auto-calibration      : {}".format("on" if auto_calibration else "off"))
-            print("forced calibration    : {} ppm (last)".format(force_calibration))
-            print("temperature offset    : {} °C".format(temperature_offset))
-            print("altitude compensation : {} m".format(altitude_compensation))
-            print("measurement interval  : {} s".format(measurement_interval))
+            print(f"forced calibration    : {force_calibration} ppm (last)")
+            print(f"temperature offset    : {temperature_offset} °C")
+            print(f"altitude compensation : {altitude_compensation} m")
+            print(f"measurement interval  : {measurement_interval} s")
 
         if args.operation == "start":
             await scd30.start_measurement(args.pressure_mbar)
@@ -268,9 +268,9 @@ class SensorSCD30Applet(I2CInitiatorApplet):
                 await asyncio.sleep(1.0)
 
             sample = await scd30.read_measurement()
-            print("CO₂ concentration : {:.0f} ppm".format(sample.co2_ppm))
-            print("temperature       : {:.2f} °C".format(sample.temp_degC))
-            print("relative humidity : {:.0f} %".format(sample.rh_pct))
+            print(f"CO₂ concentration : {sample.co2_ppm:.0f} ppm")
+            print(f"temperature       : {sample.temp_degC:.2f} °C")
+            print(f"relative humidity : {sample.rh_pct:.0f} %")
 
         if args.operation == "log":
             field_names = dict(co2="CO₂(ppm)", t="T(°C)", rh="RH(%)")

--- a/software/glasgow/applet/sensor/sen5x/__init__.py
+++ b/software/glasgow/applet/sensor/sen5x/__init__.py
@@ -58,7 +58,7 @@ class SEN5xI2CInterface:
         data = bytearray()
         for index, (chunk, crc) in enumerate(struct.iter_unpack(">2sB", crc_data)):
             if self._crc(chunk) != crc:
-                raise SEN5xError("CRC failed on word {}".format(index))
+                raise SEN5xError(f"CRC failed on word {index}")
             data += chunk
         return data
 
@@ -143,7 +143,7 @@ class SensorSEN5xApplet(I2CInitiatorApplet):
                 value = conv(value)
                 if not (low <= value <= high):
                     raise argparse.ArgumentTypeError(
-                        "{} is not between {} and {}".format(value, low, high))
+                        f"{value} is not between {low} and {high}")
                 return value
             return arg
 
@@ -180,14 +180,14 @@ class SensorSEN5xApplet(I2CInitiatorApplet):
                 await asyncio.sleep(1.0)
 
             sample = await sen5x.read_measurement()
-            print("PM1.0 concentration : {:.1f} µg/m³".format(sample.pm1_0))
-            print("PM2.5 concentration : {:.1f} µg/m³".format(sample.pm2_5))
-            print("PM4.0 concentration : {:.1f} µg/m³".format(sample.pm4_0))
-            print("PM10  concentration : {:.1f} µg/m³".format(sample.pm10))
-            print("relative humidity   : {:.2f} %".format(sample.rh_pct))
-            print("temperature         : {:.2f} °C".format(sample.temp_degC))
-            print("VOC index           : {:.1f}".format(sample.voc_index))
-            print("NOx index           : {:.1f}".format(sample.nox_index))
+            print(f"PM1.0 concentration : {sample.pm1_0:.1f} µg/m³")
+            print(f"PM2.5 concentration : {sample.pm2_5:.1f} µg/m³")
+            print(f"PM4.0 concentration : {sample.pm4_0:.1f} µg/m³")
+            print(f"PM10  concentration : {sample.pm10:.1f} µg/m³")
+            print(f"relative humidity   : {sample.rh_pct:.2f} %")
+            print(f"temperature         : {sample.temp_degC:.2f} °C")
+            print(f"VOC index           : {sample.voc_index:.1f}")
+            print(f"NOx index           : {sample.nox_index:.1f}")
 
         if args.operation == "log":
             field_names = dict(

--- a/software/glasgow/applet/video/rgb_input/__init__.py
+++ b/software/glasgow/applet/video/rgb_input/__init__.py
@@ -173,7 +173,7 @@ class VideoRGBInputApplet(GlasgowApplet):
             frame = (sync & 0x3e) >> 1
             row   = ((sync & 0x01) << 7) | (await iface.read(1))[0]
 
-            print("frame {} row {}".format(frame, row))
+            print(f"frame {frame} row {row}")
 
     @classmethod
     def tests(cls):

--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -165,7 +165,7 @@ def get_argparser():
                 description = "    This applet is PREVIEW QUALITY and may CORRUPT DATA or " \
                               "have missing features. Use at your own risk.\n" + description
             if applet_cls.required_revision > "A0":
-                help += " (rev{}+)".format(applet_cls.required_revision)
+                help += f" (rev{applet_cls.required_revision}+)"
                 description += "\n    This applet requires Glasgow rev{} or later." \
                                .format(applet_cls.required_revision)
 
@@ -221,7 +221,7 @@ def get_argparser():
         if re.match(r"^[A-C][0-9]-\d{8}T\d{6}Z$", arg):
             return arg
         else:
-            raise argparse.ArgumentTypeError("{} is not a valid serial number".format(arg))
+            raise argparse.ArgumentTypeError(f"{arg} is not a valid serial number")
 
     parser.add_argument(
         "--serial", metavar="SERIAL", type=serial,
@@ -238,7 +238,7 @@ def get_argparser():
     def add_voltage_arg(parser, help):
         parser.add_argument(
             "voltage", metavar="VOLTS", type=float, nargs="?", default=None,
-            help="{} (range: 1.8-5.0)".format(help))
+            help=f"{help} (range: 1.8-5.0)")
 
     p_voltage = subparsers.add_parser(
         "voltage", formatter_class=TextHelpFormatter,
@@ -445,7 +445,7 @@ class TerminalFormatter(logging.Formatter):
         for color_override in os.getenv("GLASGOW_COLORS", "").split(":"):
             if color_override:
                 level, color = color_override.split("=", 2)
-                self.colors[level] = "\033[{}m".format(color)
+                self.colors[level] = f"\033[{color}m"
 
     def format(self, record):
         color = self.colors.get(record.levelname, "")
@@ -453,7 +453,7 @@ class TerminalFormatter(logging.Formatter):
         record.name = record.name.replace("glasgow.", "g.")
         # applet.memory._25x → applet.memory.25x
         record.name = record.name.replace("._", ".")
-        return "{}{}\033[0m".format(color, super().format(record))
+        return f"{color}{super().format(record)}\033[0m"
 
 
 class SubjectFilter:
@@ -570,7 +570,7 @@ async def _main():
             plan = target.build_plan()
 
             if args.prebuilt or args.bitstream:
-                bitstream_file = args.bitstream or open("{}.bin".format(args.applet), "rb")
+                bitstream_file = args.bitstream or open(f"{args.applet}.bin", "rb")
                 with bitstream_file:
                     await device.download_prebuilt(plan, bitstream_file)
             else:
@@ -625,7 +625,7 @@ async def _main():
                             next_timestamp += 100 # 1us
                             break
 
-                        event_repr = " ".join("{}={}".format(n, v)
+                        event_repr = " ".join(f"{n}={v}"
                                               for n, v in events.items())
                         target.analyzer.logger.trace("cycle %d: %s", cycle, event_repr)
 
@@ -821,7 +821,7 @@ async def _main():
             plan = target.build_plan()
             if args.type in ("il", "rtlil"):
                 logger.info("generating RTLIL for applet %r", args.applet)
-                with open(args.filename or args.applet + ".il", "wt") as f:
+                with open(args.filename or args.applet + ".il", "w") as f:
                     f.write(plan.rtlil)
             if args.type in ("zip", "archive"):
                 logger.info("generating archive for applet %r", args.applet)

--- a/software/glasgow/database/jedec.py
+++ b/software/glasgow/database/jedec.py
@@ -1846,7 +1846,7 @@ def _jedec_update_mfg_from_pdf():
     jep106_matches = re.findall(r'^(\d+) (.+(?:\n.+){0,1})(?:(?:\n\d ){8})(?:\n)([0-9A-F]{2})', pdf_text, re.MULTILINE)
 
     output_text = ""
-    with open(__file__, 'r') as source_file:
+    with open(__file__) as source_file:
         output_text += source_file.read()
 
     # Update version string

--- a/software/glasgow/database/microchip/avr.py
+++ b/software/glasgow/database/microchip/avr.py
@@ -14,14 +14,14 @@ AVRDevice = namedtuple("AVRDevice", (
 ))
 
 def ATtiny(name, signature, program_size, program_page, eeprom_size, fuses_size=2, erase_time=None):
-    return AVRDevice("ATtiny{}".format(name), signature=signature,
+    return AVRDevice(f"ATtiny{name}", signature=signature,
                      calibration_size=2, fuses_size=fuses_size,
                      program_size=program_size, program_page=program_page,
                      eeprom_size=eeprom_size, eeprom_page=4,
                      erase_time=erase_time)
 
 def ATmega(name, signature, program_size, program_page, eeprom_size, eeprom_page=4, erase_time=None):
-    return AVRDevice("ATmega{}".format(name), signature=signature,
+    return AVRDevice(f"ATmega{name}", signature=signature,
                      calibration_size=1, fuses_size=3,
                      program_size=program_size, program_page=program_page,
                      eeprom_size=eeprom_size, eeprom_page=eeprom_page,

--- a/software/glasgow/device/config.py
+++ b/software/glasgow/device/config.py
@@ -66,7 +66,7 @@ class GlasgowConfig:
             major, minor = string
             return ((ord(major) - ord("A") + 1) << 4) | (ord(minor) - ord("0"))
         else:
-            raise ValueError("invalid revision string {!r}".format(string))
+            raise ValueError(f"invalid revision string {string!r}")
 
     @staticmethod
     def decode_revision(value):
@@ -81,7 +81,7 @@ class GlasgowConfig:
         elif minor in range(10):
             return chr(ord("A") + major - 1) + chr(ord("0") + minor)
         else:
-            raise ValueError("invalid revision value {:#04x}".format(value))
+            raise ValueError(f"invalid revision value {value:#04x}")
 
     def encode(self):
         """

--- a/software/glasgow/device/hardware.py
+++ b/software/glasgow/device/hardware.py
@@ -290,7 +290,7 @@ class GlasgowHardwareDevice:
                 result_future.set_exception(GlasgowDeviceError("device disconnected"))
             else:
                 result_future.set_exception(GlasgowDeviceError(
-                    "transfer error: {}".format(usb1.libusb1.libusb_transfer_status(status))))
+                    f"transfer error: {usb1.libusb1.libusb_transfer_status(status)}"))
 
         def handle_usb_error(func):
             try:
@@ -382,7 +382,7 @@ class GlasgowHardwareDevice:
         elif kind == "ice":
             base_offset = 1
         else:
-            raise ValueError("Unknown EEPROM kind {}".format(kind))
+            raise ValueError(f"Unknown EEPROM kind {kind}")
         return 0x10000 * base_offset + addr
 
     async def read_eeprom(self, kind, addr, length):
@@ -504,7 +504,7 @@ class GlasgowHardwareDevice:
             elif port == "B":
                 mask |= IO_BUF_B
             else:
-                raise GlasgowDeviceError("unknown I/O port {}".format(port))
+                raise GlasgowDeviceError(f"unknown I/O port {port}")
         return mask
 
     @staticmethod
@@ -554,19 +554,19 @@ class GlasgowHardwareDevice:
         try:
             return await self._read_voltage(REQ_IO_VOLT, spec)
         except usb1.USBErrorPipe:
-            raise GlasgowDeviceError("cannot get I/O port {} I/O voltage".format(spec))
+            raise GlasgowDeviceError(f"cannot get I/O port {spec} I/O voltage")
 
     async def get_voltage_limit(self, spec):
         try:
             return await self._read_voltage(REQ_LIMIT_VOLT, spec)
         except usb1.USBErrorPipe:
-            raise GlasgowDeviceError("cannot get I/O port {} I/O voltage limit".format(spec))
+            raise GlasgowDeviceError(f"cannot get I/O port {spec} I/O voltage limit")
 
     async def measure_voltage(self, spec):
         try:
             return await self._read_voltage(REQ_SENSE_VOLT, spec)
         except usb1.USBErrorPipe:
-            raise GlasgowDeviceError("cannot measure I/O port {} sense voltage".format(spec))
+            raise GlasgowDeviceError(f"cannot measure I/O port {spec} sense voltage")
 
     async def set_alert(self, spec, low_volts, high_volts):
         low_millivolts  = round(low_volts * 1000)
@@ -608,7 +608,7 @@ class GlasgowHardwareDevice:
             high_volts = round(high_millivolts / 1000, 2)
             return low_volts, high_volts
         except usb1.USBErrorPipe:
-            raise GlasgowDeviceError("cannot get I/O port {} voltage alert".format(spec))
+            raise GlasgowDeviceError(f"cannot get I/O port {spec} voltage alert")
 
     async def poll_alert(self):
         try:
@@ -648,7 +648,7 @@ class GlasgowHardwareDevice:
 
     async def _register_error(self, addr):
         if await self._status() & ST_FPGA_RDY:
-            raise GlasgowDeviceError("register 0x{:02x} does not exist".format(addr))
+            raise GlasgowDeviceError(f"register 0x{addr:02x} does not exist")
         else:
             raise GlasgowDeviceError("FPGA is not configured")
 

--- a/software/glasgow/gateware/analyzer.py
+++ b/software/glasgow/gateware/analyzer.py
@@ -370,7 +370,7 @@ class TraceDecoder:
         for event_src in self.event_sources:
             if event_src.fields:
                 for field_name, field_width in event_src.fields:
-                    yield ("%s-%s" % (field_name, event_src.name), event_src.kind, field_width)
+                    yield ("{}-{}".format(field_name, event_src.name), event_src.kind, field_width)
             else:
                 yield (event_src.name, event_src.kind, event_src.width)
 
@@ -438,7 +438,7 @@ class TraceDecoder:
                     if self._event_src.fields:
                         offset = 0
                         for field_name, field_width in self._event_src.fields:
-                            self._pending["%s-%s" % (field_name, self._event_src.name)] = \
+                            self._pending["{}-{}".format(field_name, self._event_src.name)] = \
                                 (self._event_data >> offset) & ((1 << field_width) - 1)
                             offset += field_width
                     else:

--- a/software/glasgow/gateware/clockgen.py
+++ b/software/glasgow/gateware/clockgen.py
@@ -147,7 +147,7 @@ class ClockGen(Elaboratable):
             if clock_name is None:
                 clock = "clock"
             else:
-                clock = "clock {}".format(clock_name)
+                clock = f"clock {clock_name}"
             if cyc in (0, 1):
                 duty = 50
             else:

--- a/software/glasgow/gateware/pads.py
+++ b/software/glasgow/gateware/pads.py
@@ -35,7 +35,7 @@ class Pads(Elaboratable):
         for name, pin in kwargs.items():
             assert isinstance(pin, Pin)
 
-            pin_name = "{}_t".format(name)
+            pin_name = f"{name}_t"
             if hasattr(self, pin_name):
                 raise ValueError("Cannot add {!r} as attribute {}; attribute already exists")
 

--- a/software/glasgow/platform/ice40.py
+++ b/software/glasgow/platform/ice40.py
@@ -18,7 +18,7 @@ class GlasgowPlatformICE40(LatticeICE40Platform):
         return file_templates
 
     def toolchain_program(self, products, name):
-        bitstream = products.get("{}.bin".format(name))
+        bitstream = products.get(f"{name}.bin")
         async def do_program():
             device = GlasgowHardwareDevice()
             await device.download_bitstream(bitstream)

--- a/software/glasgow/protocol/gdb_remote.py
+++ b/software/glasgow/protocol/gdb_remote.py
@@ -143,9 +143,9 @@ class GDBRemote(metaclass=ABCMeta):
 
                     error_num, error_msg = response
                     if self.__error_strings:
-                        response = "E{:02d};{}".format(error_num, error_msg).encode("ascii")
+                        response = f"E{error_num:02d};{error_msg}".encode("ascii")
                     else:
-                        response = "E{:02d}".format(error_num).encode("ascii")
+                        response = f"E{error_num:02d}".encode("ascii")
 
                 while True:
                     response_asc = response.decode("ascii", errors="replace")

--- a/software/glasgow/protocol/jtag_svf.py
+++ b/software/glasgow/protocol/jtag_svf.py
@@ -190,7 +190,7 @@ class SVFParser:
         elif isinstance(self._token, bits):
             actual = "scan data"
         elif isinstance(self._token, tuple):
-            actual = "(%s)" % (*self._token,)
+            actual = "({})".format(*self._token)
         elif self._token is None:
             actual = "end of file"
         else:

--- a/software/glasgow/protocol/sfdp.py
+++ b/software/glasgow/protocol/sfdp.py
@@ -125,15 +125,15 @@ class SFDPTable(_JEDECRevisionMixin):
         else:
             vendor_name = jedec_mfg_name_from_bytes([self.vendor_id])
         if vendor_name is None:
-            return "Unknown Vendor {:#04x}".format(self.vendor_id)
+            return f"Unknown Vendor {self.vendor_id:#04x}"
         return vendor_name
 
     @property
     def table_name(self):
-        return "Unknown Table {:#04x}".format(self.table_id)
+        return f"Unknown Table {self.table_id:#04x}"
 
     def __str__(self):
-        return "{}, {}".format(self.vendor_name, self.table_name)
+        return f"{self.vendor_name}, {self.table_name}"
 
     def __iter__(self):
         return iter(())
@@ -225,7 +225,7 @@ class SFDPJEDECFlashParametersTable(SFDPTable):
                     word6._fast_read_4_4_4_mode_bits)
 
         except ValueError as e:
-            raise ValueError("cannot parse {}: {}".format(str(self), str(e))) from None
+            raise ValueError(f"cannot parse {str(self)}: {str(e)}") from None
 
     @property
     def table_name(self):
@@ -233,15 +233,15 @@ class SFDPJEDECFlashParametersTable(SFDPTable):
 
     def __iter__(self):
         properties = {}
-        properties["density (Mebibits)"]  = "{}".format(self.density >> 20)
-        properties["density (Mebibytes)"] = "{}".format(self.density >> 23)
+        properties["density (Mebibits)"]  = f"{self.density >> 20}"
+        properties["density (Mebibytes)"] = f"{self.density >> 23}"
         properties["address byte count"]  = ", ".join(map(str, self.address_byte_count))
-        properties["write granularity"]   = "{} byte(s)".format(self.write_granularity)
+        properties["write granularity"]   = f"{self.write_granularity} byte(s)"
 
         properties["sector sizes"] = ", ".join(map(str, self.sector_sizes))
         for sector_size, opcode in self.sector_sizes.items():
-            properties["sector size {}".format(sector_size)] = \
-                "erase opcode {:#04x}".format(opcode)
+            properties[f"sector size {sector_size}"] = \
+                f"erase opcode {opcode:#04x}"
 
         properties["double transfer rate"] = "yes" if self.has_double_transfer_rate else "no"
         properties["fast read modes"] = \

--- a/software/glasgow/support/aobject.py
+++ b/software/glasgow/support/aobject.py
@@ -1,7 +1,7 @@
 __all__ = ["aobject"]
 
 
-class aobject(object):
+class aobject:
     """
     Base class for objects with an async ``__init__`` method.
 

--- a/software/glasgow/support/bitstruct.py
+++ b/software/glasgow/support/bitstruct.py
@@ -57,7 +57,7 @@ class _bitstruct:
             cls["_layout_"][name] = (offset, width)
             offset += width
 
-        cls["__slots__"] = tuple("_f_{}".format(field) for field in cls["_layout_"])
+        cls["__slots__"] = tuple(f"_f_{field}" for field in cls["_layout_"])
 
         code = textwrap.dedent(f"""
         def __init__(self, {", ".join(f"{field}=0" for field in cls["_named_fields_"])}):
@@ -151,7 +151,7 @@ class _bitstruct:
         return " ".join(fields)
 
     def __repr__(self):
-        return "<{}.{} {}>".format(self.__module__, self.__class__.__name__, self.bits_repr())
+        return f"<{self.__module__}.{self.__class__.__name__} {self.bits_repr()}>"
 
     def __eq__(self, other):
         return isinstance(other, self.__class__) and self.to_bits() == other.to_bits()

--- a/software/glasgow/support/data_logger.py
+++ b/software/glasgow/support/data_logger.py
@@ -74,7 +74,7 @@ class STDOUTDataLogger(DataLogger, name="stdout"):
 
     async def setup(self, args):
         self.format = "[{timestamp}] " + ", ".join([
-            "{}={{{}}}".format(name, key) for key, name in self.field_names.items()
+            f"{name}={{{key}}}" for key, name in self.field_names.items()
         ]) + "\n"
         self.stream = sys.stdout
 
@@ -126,7 +126,7 @@ class InfluxDBDataLogger(DataLogger, name="influxdb"):
 
     @staticmethod
     def _escape_name(charset, value):
-        return re.sub(r"([{}])".format(charset), r"\\\1", value)
+        return re.sub(fr"([{charset}])", r"\\\1", value)
 
     @staticmethod
     def _escape_value(value):
@@ -174,7 +174,7 @@ class InfluxDBDataLogger(DataLogger, name="influxdb"):
             help="write to measurement SERIES")
         def tag(arg):
             if "=" not in arg:
-                raise argparse.ArgumentTypeError("{} is not a valid tag".format(arg))
+                raise argparse.ArgumentTypeError(f"{arg} is not a valid tag")
             key, value = arg.split("=", 1)
             return key, value
         parser.add_argument(
@@ -277,7 +277,7 @@ class InfluxDB2DataLogger(DataLogger, name="influxdb2"):
             help="write to measurement SERIES")
         def tag(arg):
             if "=" not in arg:
-                raise argparse.ArgumentTypeError("{} is not a valid tag".format(arg))
+                raise argparse.ArgumentTypeError(f"{arg} is not a valid tag")
             key, value = arg.split("=", 1)
             return key, value
         parser.add_argument(

--- a/software/glasgow/support/lazy.py
+++ b/software/glasgow/support/lazy.py
@@ -38,7 +38,7 @@ class lazy:
             rep = repr(self._thunk_)
         else:
             rep = repr(self._object_)
-        return "<lazy {}>".format(rep)
+        return f"<lazy {rep}>"
 
     @classmethod
     def _define_special_(cls, name):

--- a/software/tests/protocol/test_jtag_svf.py
+++ b/software/tests/protocol/test_jtag_svf.py
@@ -88,7 +88,7 @@ class SVFParserTestCase(unittest.TestCase):
         self.assertEqual(self.handler.events, events)
 
     def assertErrors(self, source, error):
-        with self.assertRaisesRegex(SVFParsingError, r"^{}".format(re.escape(error))):
+        with self.assertRaisesRegex(SVFParsingError, fr"^{re.escape(error)}"):
             self.handler = SVFMockEventHandler()
             self.parser = SVFParser(source, self.handler)
             self.parser.parse_file()
@@ -137,12 +137,12 @@ class SVFParserTestCase(unittest.TestCase):
             ("ENDIR", "svf_endir"),
             ("ENDDR", "svf_enddr")
         ]:
-            self.assertParses("{c} IRPAUSE;".format(c=command),
+            self.assertParses(f"{command} IRPAUSE;",
                               [(event, {"state": "IRPAUSE"})])
 
-            self.assertErrors("{c} IRSHIFT;".format(c=command),
+            self.assertErrors(f"{command} IRSHIFT;",
                               "expected stable TAP state")
-            self.assertErrors("{c};".format(c=command),
+            self.assertErrors(f"{command};",
                               "expected stable TAP state")
 
     def test_hir_sir_tir_hdr_sdr_tdr(self):
@@ -154,7 +154,7 @@ class SVFParserTestCase(unittest.TestCase):
             ("SDR", "svf_sdr"),
             ("TDR", "svf_tdr"),
         ]:
-            self.assertParses("{c} 0;".format(c=command), [
+            self.assertParses(f"{command} 0;", [
                 (event, {
                     "tdi":   bits(""),
                     "smask": bits(""),
@@ -162,7 +162,7 @@ class SVFParserTestCase(unittest.TestCase):
                     "mask":  bits(""),
                 }),
             ])
-            self.assertParses("{c} 8 TDI(a);".format(c=command), [
+            self.assertParses(f"{command} 8 TDI(a);", [
                 (event, {
                     "tdi":   bits("00001010"),
                     "smask": bits("11111111"),
@@ -170,7 +170,7 @@ class SVFParserTestCase(unittest.TestCase):
                     "mask":  bits("00000000"),
                 }),
             ])
-            self.assertParses("{c} 6 TDI(0a);".format(c=command), [
+            self.assertParses(f"{command} 6 TDI(0a);", [
                 (event, {
                     "tdi":   bits("001010"),
                     "smask": bits("111111"),
@@ -242,11 +242,11 @@ class SVFParserTestCase(unittest.TestCase):
                 }),
             ])
 
-            self.assertErrors("{c} 8 TDI(aaa);".format(c=command),
+            self.assertErrors(f"{command} 8 TDI(aaa);",
                               "scan data length 12 exceeds command length 8")
-            self.assertErrors("{c} 8 TDI(0) TDI(0);".format(c=command),
+            self.assertErrors(f"{command} 8 TDI(0) TDI(0);",
                               "parameter TDI specified twice")
-            self.assertErrors("{c} 8;".format(c=command),
+            self.assertErrors(f"{command} 8;",
                               "initial value for parameter TDI required")
             self.assertErrors("{c} 8 TDI(aa); {c} 12;".format(c=command),
                               "parameter TDI needs to be specified again because "

--- a/software/tests/support/test_endpoint.py
+++ b/software/tests/support/test_endpoint.py
@@ -45,7 +45,7 @@ class EndpointArgumentTestCase(unittest.TestCase):
 
 class ServerEndpointTestCase(unittest.TestCase):
     async def do_test_lifecycle(self):
-        sock = ("unix", "{}/test_lifecycle_sock".format(tempfile.gettempdir()))
+        sock = ("unix", f"{tempfile.gettempdir()}/test_lifecycle_sock")
         endp = await ServerEndpoint("test_lifecycle", logging.getLogger(__name__), sock)
 
         conn_rd, conn_wr = await asyncio.open_unix_connection(*sock[1:])
@@ -75,7 +75,7 @@ class ServerEndpointTestCase(unittest.TestCase):
             self.do_test_lifecycle())
 
     async def do_test_until(self):
-        sock = ("unix", "{}/test_until_sock".format(tempfile.gettempdir()))
+        sock = ("unix", f"{tempfile.gettempdir()}/test_until_sock")
         endp = await ServerEndpoint("test_until", logging.getLogger(__name__), sock)
 
         conn_rd, conn_wr = await asyncio.open_unix_connection(*sock[1:])

--- a/software/tests/support/test_lazy.py
+++ b/software/tests/support/test_lazy.py
@@ -3,7 +3,7 @@ import unittest
 from glasgow.support.lazy import lazy
 
 
-class _test(object):
+class _test:
     pass
 
 


### PR DESCRIPTION
I ran [pyupgrade](https://github.com/asottile/pyupgrade) on the entire tree. This mostly changes `"".format()` to use f-strings (something that is otherwise very annoying to do), with a few other changes.