### PR TITLE
access.args: fix argparse import

### DIFF
--- a/software/glasgow/access/__init__.py
+++ b/software/glasgow/access/__init__.py
@@ -1,6 +1,7 @@
 from abc import ABCMeta, abstractmethod
 from amaranth import *
 from amaranth.lib.io import Pin
+import argparse
 
 from ..gateware.pads import Pads
 

--- a/software/glasgow/access/direct/arguments.py
+++ b/software/glasgow/access/direct/arguments.py
@@ -1,5 +1,4 @@
 import functools
-import argparse
 import re
 
 from .. import AccessArguments
@@ -7,10 +6,6 @@ from .. import AccessArguments
 
 class DirectArguments(AccessArguments):
     # First, define some state-less methods that just add arguments to an argparse instance.
-
-    def _arg_error(self, message, *args, **kwargs):
-        raise argparse.ArgumentTypeError(("applet {!r}: " + message)
-                                         .format(self._applet_name, *args, **kwargs))
 
     def _port_spec(self, arg):
         if not re.match(r"^[A-Z]+$", arg):

--- a/software/glasgow/access/simulation/arguments.py
+++ b/software/glasgow/access/simulation/arguments.py
@@ -1,6 +1,5 @@
 import functools
 import itertools
-import argparse
 import re
 
 from .. import AccessArguments


### PR DESCRIPTION
this fixes an error where _arg_error would fail in a different than expected way. Also unneeded argparse import in SimArguments.
