### PR TITLE
Update boilerplate applet

### DIFF
--- a/examples/boilerplate.py
+++ b/examples/boilerplate.py
@@ -16,7 +16,7 @@ class BoilerplateSubtarget(Elaboratable):
         return m
 
 
-class BoilerplateApplet(GlasgowApplet, name="boilerplate"):
+class BoilerplateApplet(GlasgowApplet):
     logger = logging.getLogger(__name__)
     help = "boilerplate applet"
     preview = True


### PR DESCRIPTION
This applies the following commit to boilerplate.py as well:

 - 9ff95922 ("applet: kill `all`, use Python entry points to declare applets.")