### PR TITLE
software: fix "glasgow flash" command

### DIFF
--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -784,7 +784,7 @@ async def _main():
                             fx2_config.append(addr, chunk)
                 else:
                     logger.info("using built-in firmware")
-                    for (addr, chunk) in GlasgowHardwareDevice.firmware():
+                    for (addr, chunk) in GlasgowHardwareDevice.firmware_data():
                         fx2_config.append(addr, chunk)
                 fx2_config.disconnect = True
                 new_image = fx2_config.encode()


### PR DESCRIPTION
I attached an older, C1-like glasgow which was untouched for some time and got told its API level 1 was too old:
```
$ glasgow list
I: g.device.hardware: found revC1 device with API level 1 (supported API level is 2)
W: g.device.hardware: please run `glasgow flash` to update firmware of device C1-20191109T210718Z
C1-20191109T210718Z
```

Trying the suggested "glasgow flash" command lead to an error:
```
$ glasgow flash
I: g.cli: reading device configuration
I: g.cli: device has serial C1-20191109T210718Z
I: g.cli: device has flashed firmware
I: g.cli: device does not have flashed bitstream
I: g.cli: using built-in firmware
Traceback (most recent call last):
  File "/home/moritz/.local/bin/glasgow", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/moritz/src/glasgow/software/glasgow/cli.py", line 937, in main
    exit(loop.run_until_complete(_main()))
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/home/moritz/src/glasgow/software/glasgow/cli.py", line 787, in _main
    for (addr, chunk) in GlasgowHardwareDevice.firmware():
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: type object 'GlasgowHardwareDevice' has no attribute 'firmware'
```

Apparently this was caused by commit 3ad3c5e23481fa1a107474f0880a11e870657dce, here is a pull request to fix this (like that commit did in hardware.py).