### PR TITLE
applet.interface.jtag_probe: add flush() method to TAPInterface

### DIFF
--- a/software/glasgow/applet/interface/jtag_probe/__init__.py
+++ b/software/glasgow/applet/interface/jtag_probe/__init__.py
@@ -819,6 +819,9 @@ class TAPInterface:
         self._dr_prefix = dr_prefix
         self._dr_suffix = dr_suffix
 
+    async def flush(self):
+        await self.lower.flush()
+
     async def test_reset(self):
         await self.lower.test_reset()
 


### PR DESCRIPTION
For now it simply calls JTAGProbeInterface.flush()

This is in order to make higher level JTAG code more readable, so not too many .lower's need to be chained.