### PR TITLE
applet.interface.jtag_openocd: Document how to improve performance

### DIFF
--- a/software/glasgow/applet/interface/jtag_openocd/__init__.py
+++ b/software/glasgow/applet/interface/jtag_openocd/__init__.py
@@ -94,6 +94,13 @@ class JTAGOpenOCDApplet(GlasgowApplet):
     ::
         glasgow run jtag-openocd unix:/tmp/jtag.sock
         openocd -c 'interface remote_bitbang; remote_bitbang_host /tmp/jtag.sock'
+
+    To achieve higher speeds:
+
+    - Set the clock frequency with `--freq N` on the glasgow command line
+      (Replace N with the desired clock frequency).
+    - Add `remote_bitbang use_remote_sleep on` or `adapter speed N` to the
+      OpenOCD commands.
     """
 
     __pins = ("tck", "tms", "tdi", "tdo", "trst", "srst")


### PR DESCRIPTION
The jtag_openocd gateware performs all the necessary delays to achieve the configured clock frequency, but by default OpenOCD inserts additional delays on the client side. By using the newly introduced "use_remote_sleep on" option these delays can be disabled; On older versions of OpenOCD, the "adapter speed" can be increased to minimize the delays.