### PR TITLE
software: remove uses of the deprecated `fwft` parameter.

### DIFF
--- a/software/glasgow/access/simulation/multiplexer.py
+++ b/software/glasgow/access/simulation/multiplexer.py
@@ -26,7 +26,7 @@ class SimulationMultiplexer(AccessMultiplexer):
 
 class _AsyncFIFOWrapper(Elaboratable, FIFOInterface):
     def __init__(self, inner, cd_logic):
-        super().__init__(width=inner.width, depth=inner.depth, fwft=True)
+        super().__init__(width=inner.width, depth=inner.depth)
 
         self.inner = inner
         self.cd_logic = cd_logic

--- a/software/glasgow/gateware/analyzer.py
+++ b/software/glasgow/gateware/analyzer.py
@@ -37,7 +37,7 @@ class EventSource(Elaboratable):
         if width > 0:
             self.data_fifo = SyncFIFOBuffered(width=width, depth=depth)
         else:
-            self.data_fifo = FIFOInterface(width=1, depth=0, fwft=True)
+            self.data_fifo = FIFOInterface(width=1, depth=0)
 
     def elaborate(self, platform):
         m = Module()


### PR DESCRIPTION
It is no longer present in Amaranth 0.5, and it defaults to `True` in Amaranth 0.4 anyway.