### PR TITLE
applet.internal.{benchmark,selftest}: fix after commit 5e1f94dd

### DIFF
--- a/software/glasgow/applet/internal/benchmark/__init__.py
+++ b/software/glasgow/applet/internal/benchmark/__init__.py
@@ -133,8 +133,9 @@ class BenchmarkApplet(GlasgowApplet):
             help="run benchmark mode MODE (default: {})".format(" ".join(cls.__all_modes)))
 
     async def run(self, device, args):
-        iface = await device.demultiplexer.claim_interface(self, self.mux_interface, args=None)
+        return await device.demultiplexer.claim_interface(self, self.mux_interface, args=None)
 
+    async def interact(self, device, args, iface):
         golden = bytearray()
         while len(golden) < args.count:
             golden += self._sequence[:args.count - len(golden)]

--- a/software/glasgow/applet/internal/selftest/__init__.py
+++ b/software/glasgow/applet/internal/selftest/__init__.py
@@ -101,6 +101,9 @@ class SelfTestApplet(GlasgowApplet):
             help="run self-test mode MODE (default: {})".format(" ".join(cls.__default_modes)))
 
     async def run(self, device, args):
+        return None
+
+    async def interact(self, device, args, iface):
         async def set_oe(bits):
             await device.write_register(self.addr_oe_a, (bits >> 0) & 0xff)
             await device.write_register(self.addr_oe_b, (bits >> 8) & 0xff)


### PR DESCRIPTION
I'm not sure why that change is in commit 5e1f94dd--it may be unintentional?