### PR TITLE
CODEOWNERS: fix spi_flashrom applet name

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,4 +13,4 @@
 
 /software/glasgow/applet/servo/ @tpwrules
 
-/software/glasgow/applet/interface/spi_serprog/ @neuschaefer
+/software/glasgow/applet/interface/spi_flashrom/ @neuschaefer


### PR DESCRIPTION
It changed at the last minute; update CODEOWNERS too.