### PR TITLE
applet.interface.swd_openocd: new applet

### DIFF
--- a/software/glasgow/applet/interface/swd_openocd/test.py
+++ b/software/glasgow/applet/interface/swd_openocd/test.py
@@ -1,0 +1,8 @@
+from ... import *
+from . import SWDOpenOCDApplet
+
+
+class SWDOpenOCDAppletTestCase(GlasgowAppletTestCase, applet=SWDOpenOCDApplet):
+    @synthesis_test
+    def test_build(self):
+        self.assertBuilds()

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -91,6 +91,7 @@ jtag-openocd = "glasgow.applet.interface.jtag_openocd:JTAGOpenOCDApplet"
 jtag-svf = "glasgow.applet.interface.jtag_svf:JTAGSVFApplet"
 ps2-host = "glasgow.applet.interface.ps2_host:PS2HostApplet"
 sbw-probe = "glasgow.applet.interface.sbw_probe:SpyBiWireProbeApplet"
+swd-openocd = "glasgow.applet.interface.swd_openocd:SWDOpenOCDApplet"
 
 memory-24x = "glasgow.applet.memory._24x:Memory24xApplet"
 memory-25x = "glasgow.applet.memory._25x:Memory25xApplet"


### PR DESCRIPTION
Requires a pre-release version of openocd. Works fine here with a random STM32F1:

```
$ ../src/openocd -c 'adapter driver remote_bitbang; transport select swd; remote_bitbang port 2222' -f target/stm32f1x.cfg
Open On-Chip Debugger 0.12.0+dev-03105-g07141132a (2024-03-06-04:16)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
Info : Listening on port 6666 for tcl connections
Info : Listening on port 4444 for telnet connections
Info : Initializing remote_bitbang driver
Info : Connecting to localhost:2222
Info : remote_bitbang driver initialized
Info : Note: The adapter "remote_bitbang" doesn't support configurable speed
Info : SWD DPIDR 0x2ba01477
Info : [stm32f1x.cpu] Cortex-M3 r2p1 processor detected
Info : [stm32f1x.cpu] target has 6 breakpoints, 4 watchpoints
Info : [stm32f1x.cpu] Examination succeed
Info : starting gdb server for stm32f1x.cpu on 3333
Info : Listening on port 3333 for gdb connections
^Cshutdown command invoked
Info : remote_bitbang interface quit
```

Compared to extending `jtag-openocd` (#266), this has the downside that you can't use both transports in the same session, but the upside that there's no weird interdependencies between JTAG and SWD and the pin arguments are *much* less contrived.

ARM ships a combined SWD/JTAG debug port (SWJ-DP) which actually supports mode switching between the two, but the mode switch sequence from JTAG to SWD is possible to execute using SWD alone, so it's not a problem unless you actively want to use both for some godforsaken reason. (I can't imagine any reason to do it since SWJ-DP exposes *more* functionality in the SWD mode, and covers everything you can do in JTAG mode. And it's faster.)

The applets (both `jtag-openocd` and `swd-openocd`) hang when receiving an unknown command, but openocd does not issue any JTAG-only commands in SWD mode. (However if you forget `transport select swd` it will do that and then openocd itself will have to be SIGKILL'd; it ignores SIGQUIT and SIGINT for some reason. Annoying!)