### PR TITLE
applet.interface.spi_flashrom: documentation, spi-serprog -> spi-flashrom

### DIFF
--- a/software/glasgow/applet/interface/spi_flashrom/__init__.py
+++ b/software/glasgow/applet/interface/spi_flashrom/__init__.py
@@ -155,7 +155,7 @@ class SPIFlashromApplet(SPIControllerApplet):
     Usage:
 
     ::
-        glasgow run spi-serprog -V 3.3 --pin-cs 0 --pin-cipo 1 --pin-copi 2 --pin-sck 3 \\
+        glasgow run spi-flashrom -V 3.3 --pin-cs 0 --pin-cipo 1 --pin-copi 2 --pin-sck 3 \\
             --freq 4000 tcp::2222
         /sbin/flashrom -p serprog:ip=localhost:2222
 


### PR DESCRIPTION
Just a very small fix for the example cmdline given in the new spi-flashrom applet.
Thanks to everyone involved with it, I've been using it for the last days, it works very well 😎