### PR TITLE
applet.interface.analyzer: restrict to revC0+

### DIFF
--- a/software/glasgow/applet/interface/analyzer/__init__.py
+++ b/software/glasgow/applet/interface/analyzer/__init__.py
@@ -50,6 +50,7 @@ class AnalyzerApplet(GlasgowApplet):
     description = """
     Capture waveforms, similar to a logic analyzer.
     """
+    required_revision = "C0" # iCE40UP5K isn't quite fast enoughs
 
     @classmethod
     def add_build_arguments(cls, parser, access):


### PR DESCRIPTION
After upgrading Yosys to 0.39, the applet stopped passing timing when built for revA. This was reported against Yosys (YosysHQ/yosys#4280), but as there don't seem to be any commits that could change synthesis quality, it was likely just that the analyzer applet was marginal in first place.

Since this is blocking all further development, the applet is now restricted to revC0+.