### PR TITLE
applet.video.vga_output: remove unnecessary clock constraint

### DIFF
--- a/software/glasgow/applet/video/vga_output/__init__.py
+++ b/software/glasgow/applet/video/vga_output/__init__.py
@@ -57,7 +57,6 @@ class VGAOutputSubtarget(Elaboratable):
 
         m.domains.pix = cd_pix = ClockDomain(reset_less=True)
         m.submodules += PLL(f_in=platform.default_clk_frequency, f_out=self.pix_clk_freq, odomain="pix")
-        platform.add_clock_constraint(cd_pix.clk, self.pix_clk_freq)
 
         h_total = self.h_front + self.h_sync + self.h_back + self.h_active
         v_total = self.v_front + self.v_sync + self.v_back + self.v_active


### PR DESCRIPTION
In the past nextpnr-ice40 was not able to infer it, but now it produces a warning:

Warning:     Overriding derived constraint of 25.3 MHz on net multiplexer.U$$0.U$$0.pix_clk with user-specified constraint of 25.2 MHz.