### PR TITLE
device.hardware.py: Add skip_on_error flag to improve Windows experience with USB discovery

### DIFF
--- a/software/glasgow/device/hardware.py
+++ b/software/glasgow/device/hardware.py
@@ -96,7 +96,7 @@ class GlasgowHardwareDevice:
             usb_context.hotplugRegisterCallback(hotplug_callback,
                 flags=usb1.HOTPLUG_ENUMERATE)
         else:
-            devices.extend(list(usb_context.getDeviceIterator()))
+            devices.extend(list(usb_context.getDeviceIterator(skip_on_error=True)))
 
         while any(devices):
             device = devices.pop()
@@ -185,7 +185,7 @@ class GlasgowHardwareDevice:
                 logger.debug("waiting for re-enumeration")
                 time.sleep(5.0)
 
-                devices.extend(list(usb_context.getDeviceIterator()))
+                devices.extend(list(usb_context.getDeviceIterator(skip_on_error=True)))
 
         return devices_by_serial
 


### PR DESCRIPTION
If any of the USB devices attached are busy or unavailable, but libusb1 sees them, you get a nice trace on Windows:

```
$ glasgow list
Traceback (most recent call last):
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "C:\users\c_ofl\.local\bin\glasgow.exe\__main__.py", line 7, in <module>
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\chipwhisperer\jupyter\user\glasgow\glasgow\software\glasgow\cli.py", line 937, in main
    exit(loop.run_until_complete(_main()))
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\asyncio\base_events.py", line 649, in run_until_complete
    return future.result()
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\chipwhisperer\jupyter\user\glasgow\glasgow\software\glasgow\cli.py", line 900, in _main
    for serial in sorted(GlasgowHardwareDevice.enumerate_serials()):
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\chipwhisperer\jupyter\user\glasgow\glasgow\software\glasgow\device\hardware.py", line 195, in enumerate_serials
    devices = cls._enumerate_devices(usb_context)
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\chipwhisperer\jupyter\user\glasgow\glasgow\software\glasgow\device\hardware.py", line 99, in _enumerate_devices
    devices.extend(list(usb_context.getDeviceIterator()))
  File "C:\Users\c_ofl\AppData\Local\pipx\pipx\venvs\glasgow\lib\site-packages\usb1\__init__.py", line 2114, in wrapper
    for value in generator:
  File "C:\Users\c_ofl\AppData\Local\pipx\pipx\venvs\glasgow\lib\site-packages\usb1\__init__.py", line 2257, in getDeviceIterator
    device = USBDevice(
  File "C:\Users\c_ofl\AppData\Local\pipx\pipx\venvs\glasgow\lib\site-packages\usb1\__init__.py", line 1784, in __init__
    mayRaiseUSBError(result)
  File "C:\Users\c_ofl\AppData\Local\pipx\pipx\venvs\glasgow\lib\site-packages\usb1\__init__.py", line 127, in mayRaiseUSBError
    __raiseUSBError(value)
  File "C:\Users\c_ofl\AppData\Local\pipx\pipx\venvs\glasgow\lib\site-packages\usb1\__init__.py", line 119, in raiseUSBError
    raise __STATUS_TO_EXCEPTION_DICT.get(value, __USBError)(value)
usb1.USBErrorIO: LIBUSB_ERROR_IO [-1]
```

With this patch you instead get what you expect:
```
$ glasgow list
C3-20240303T140525Z
```

This was something we have added to ChipWhisperer's USB discovery code, you can [see here](https://github.com/newaetech/chipwhisperer/blob/develop/software/chipwhisperer/hardware/naeusb/naeusb.py#L482C67-L482C85) if useful!