### PR TITLE
cli.py: Fix small typo ("f{arg} -> f"{arg})

### DIFF
--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -375,7 +375,7 @@ def get_argparser():
         if len(arg) <= 23:
             return arg
         else:
-            raise argparse.ArgumentTypeError("f{arg} is too long for the manufacturer field")
+            raise argparse.ArgumentTypeError(f"{arg} is too long for the manufacturer field")
 
     p_factory = subparsers.add_parser(
         "factory", formatter_class=TextHelpFormatter,


### PR DESCRIPTION
It feels like a waste to make  PR for, but I don't want to throw it in with unrelated things... feel free to fix yourself & close this if easier!