### PR TITLE
applets: Remove a few unicode characters that caused problems on Windows mingw terminal

### DIFF
--- a/software/glasgow/applet/audio/dac/__init__.py
+++ b/software/glasgow/applet/audio/dac/__init__.py
@@ -118,7 +118,7 @@ class AudioDACSubtarget(Elaboratable):
 
 class AudioDACApplet(GlasgowApplet):
     logger = logging.getLogger(__name__)
-    help = "play sound using a ΣΔ-DAC"
+    help = "play sound using a sigma-delta DAC"
     description = """
     Play sound using a 1-bit sigma-delta DAC, i.e. pulse density modulation.
 

--- a/software/glasgow/applet/sensor/scd30/__init__.py
+++ b/software/glasgow/applet/sensor/scd30/__init__.py
@@ -167,9 +167,9 @@ class SCD30I2CInterface:
 
 class SensorSCD30Applet(I2CInitiatorApplet):
     logger = logging.getLogger(__name__)
-    help = "measure CO₂, humidity, and temperature with Sensirion SCD30 sensors"
+    help = "measure CO2, humidity, and temperature with Sensirion SCD30 sensors"
     description = """
-    Measure CO₂ concentration, humidity, and temperature using Sensirion SCD30 sensors
+    Measure CO2 concentration, humidity, and temperature using Sensirion SCD30 sensors
     connected over the I²C interface.
 
     NOTE: The SCD30 takes some time to start up. Run `glasgow voltage AB 3.3 --no-alert`


### PR DESCRIPTION
Thanks to Window's great unicode support, a few help strings caused errors. It's not obvious to a user as the traces look like this, the first one (for the sigma-delta DAC) doesn't even give you a character to look up:

```
$ glasgow.exe run --help
Traceback (most recent call last):
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "C:\users\c_ofl\.local\bin\glasgow.exe\__main__.py", line 7, in <module>
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\chipwhisperer\jupyter\user\glasgow\glasgow\software\glasgow\cli.py", line 940, in main
    exit(loop.run_until_complete(_main()))
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\asyncio\base_events.py", line 649, in run_until_complete
    return future.result()
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\chipwhisperer\jupyter\user\glasgow\glasgow\software\glasgow\cli.py", line 518, in _main
    args = get_argparser().parse_args()
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\argparse.py", line 1826, in parse_args
    args, argv = self.parse_known_args(args, namespace)
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\argparse.py", line 1859, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\argparse.py", line 2050, in _parse_known_args
    positionals_end_index = consume_positionals(start_index)
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\argparse.py", line 2027, in consume_positionals
    take_action(action, args)
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\argparse.py", line 1936, in take_action
    action(self, namespace, argument_values, option_string)
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\argparse.py", line 1214, in __call__
    subnamespace, arg_strings = parser.parse_known_args(arg_strings, None)
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\argparse.py", line 1859, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\argparse.py", line 2068, in _parse_known_args
    start_index = consume_optional(start_index)
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\argparse.py", line 2008, in consume_optional
    take_action(action, args, option_string)
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\argparse.py", line 1936, in take_action
    action(self, namespace, argument_values, option_string)
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\argparse.py", line 1099, in __call__
    parser.print_help()
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\argparse.py", line 2556, in print_help
    self._print_message(self.format_help(), file)
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\argparse.py", line 2562, in _print_message
    file.write(message)
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode characters in position 345-346: character maps to <undefined>
```

```
$ glasgow.exe run --help
Traceback (most recent call last):
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "C:\users\c_ofl\.local\bin\glasgow.exe\__main__.py", line 7, in <module>
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\chipwhisperer\jupyter\user\glasgow\glasgow\software\glasgow\cli.py", line 940, in main
    exit(loop.run_until_complete(_main()))
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\asyncio\base_events.py", line 649, in run_until_complete
    return future.result()
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\chipwhisperer\jupyter\user\glasgow\glasgow\software\glasgow\cli.py", line 518, in _main
    args = get_argparser().parse_args()
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\argparse.py", line 1826, in parse_args
    args, argv = self.parse_known_args(args, namespace)
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\argparse.py", line 1859, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\argparse.py", line 2050, in _parse_known_args
    positionals_end_index = consume_positionals(start_index)
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\argparse.py", line 2027, in consume_positionals
    take_action(action, args)
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\argparse.py", line 1936, in take_action
    action(self, namespace, argument_values, option_string)
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\argparse.py", line 1214, in __call__
    subnamespace, arg_strings = parser.parse_known_args(arg_strings, None)
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\argparse.py", line 1859, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\argparse.py", line 2068, in _parse_known_args
    start_index = consume_optional(start_index)
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\argparse.py", line 2008, in consume_optional
    take_action(action, args, option_string)
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\argparse.py", line 1936, in take_action
    action(self, namespace, argument_values, option_string)
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\argparse.py", line 1099, in __call__
    parser.print_help()
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\argparse.py", line 2556, in print_help
    self._print_message(self.format_help(), file)
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\argparse.py", line 2562, in _print_message
    file.write(message)
  File "C:\ChipWhisperer5_64_5_7_0\cw\home\portable\WPy64-31080\python-3.10.8.amd64\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\u2082' in position 3943: character maps to <undefined>
```

To troubleshoot I had temporarily done this in `cli.py`:

Starting at line 167 for context:
```
            if applet_cls.required_revision > "A0":
                help += f" (rev{applet_cls.required_revision}+)"
                description += "\n    This applet requires Glasgow rev{} or later." \
                               .format(applet_cls.required_revision)
+           try:
+               print(help)
+           except UnicodeEncodeError:
+               print(applet_cls)
            p_applet = subparsers.add_parser(
                handle, help=help, description=description,
                formatter_class=TextHelpFormatter)
```

There may be a way of actually checking here if an error will occur. But I think it's related to my Windows terminal, so not sure if this can be done without actually printing.

Either way, this proposed PR removes the two offending characters, at least it fixes it for 1 person.