### PR TITLE
Fix typo in pyproject.toml

### DIFF
--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -140,8 +140,8 @@ radio-nrf24l01 = "glasgow.applet.radio.nrf24l01:RadioNRF24L01Applet"
 
 [project.urls]
 "Documentation" = "https://glasgow-embedded.org/"
-"Source Code" = "https://github.com/GlasgowEmebedded/Glasgow"
-"Bug Tracker" = "https://github.com/GlasgowEmebedded/Glasgow/issues"
+"Source Code" = "https://github.com/GlasgowEmbedded/glasgow"
+"Bug Tracker" = "https://github.com/GlasgowEmbedded/glasgow/issues"
 
 # Build system configuration
 


### PR DESCRIPTION
In [project.urls], the URL of the Glasgow repository is misspelled.