### PR TITLE
software: bump platformdirs upper bound

### DIFF
--- a/software/pdm.min.lock
+++ b/software/pdm.min.lock
@@ -5,7 +5,7 @@
 groups = ["default", "builtin-toolchain", "http"]
 strategy = ["cross_platform", "direct_minimal_versions"]
 lock_version = "4.4.1"
-content_hash = "sha256:37e2438e6ff31b28bfc416f69732caacea588cfcaf88c59551824ff41ab4137f"
+content_hash = "sha256:c4843d9af3f4c9a95797219c704ed82318ca8579ca3df3247e32ebb595a525ae"
 
 [[package]]
 name = "aiohttp"

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "packaging>=23.0",
   # `platformdirs` is used in the bitstream builder to use platform-appropriate cache directories.
   # It uses SemVer.
-  "platformdirs>=3.0.0,<4",
+  "platformdirs>=3.0.0,<5",
   # `fx2` is effectively maintained together with Glasgow. It uses SemVer, and keeps backward
   # compatibility within the 0.x release series.
   "fx2>=0.11,<1",


### PR DESCRIPTION
The only change in this major version bump was to `site_cache_dir` (/var/cache instead of /var/tmp), but Glasgow only relies on `user_cache_dir` and is unaffected by this.

For reference: [platformdirs diff (3.11.0...4.0.0)][1]

[1]: https://github.com/platformdirs/platformdirs/compare/3.11.0...4.0.0