### PR TITLE
Fix small detail in uart applet doc

### DIFF
--- a/software/glasgow/applet/interface/uart/__init__.py
+++ b/software/glasgow/applet/interface/uart/__init__.py
@@ -136,7 +136,7 @@ class UARTApplet(GlasgowApplet):
     description = """
     Transmit and receive data via UART.
 
-    Any baud rate is supported. Only 8 start bits and 1 stop bits are supported, with configurable
+    Any baud rate is supported. Only 8 data bits and 1 stop bits are supported, with configurable
     parity.
 
     The automatic baud rate determination algorithm works by locking onto the shortest bit time in


### PR DESCRIPTION
As far as I know there are no UART configs with more than 1 start bit. I guess it should be "data" bits.