### PR TITLE
Migrate to Amaranth 0.5

### DIFF
--- a/software/glasgow/access/__init__.py
+++ b/software/glasgow/access/__init__.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from amaranth import *
-from amaranth.lib.io import Pin
+from amaranth.lib import io
 import argparse
 
 from ..gateware.pads import Pads
@@ -69,7 +69,7 @@ class AccessMultiplexerInterface(Elaboratable, metaclass=ABCMeta):
         pass
 
     def get_pins(self, pins, name=None):
-        triple = Pin(width=len(pins), dir='io')
+        triple = io.Buffer.Signature("io", len(pins)).create()
         for n, pin in enumerate(pins):
             self.build_pin_tristate(pin, triple.oe, triple.o[n], triple.i[n])
 

--- a/software/glasgow/access/simulation/multiplexer.py
+++ b/software/glasgow/access/simulation/multiplexer.py
@@ -99,7 +99,7 @@ class SimulationMultiplexerInterface(AccessMultiplexerInterface):
 
         self.in_fifo = self._make_fifo(
             crossbar_side="read", logic_side="write", cd_logic=clock_domain, depth=depth)
-        self.in_fifo.flush = Signal(reset=auto_flush)
+        self.in_fifo.flush = Signal(init=auto_flush)
         return self.in_fifo
 
     def get_out_fifo(self, depth=512, clock_domain=None):

--- a/software/glasgow/applet/__init__.py
+++ b/software/glasgow/applet/__init__.py
@@ -116,6 +116,7 @@ from ..target.hardware import *
 from ..device.simulation import *
 from ..device.hardware import *
 from ..target.toolchain import find_toolchain
+from ..platform.all import GlasgowPlatformRevAB
 
 
 __all__ += ["GlasgowAppletTestCase", "synthesis_test", "applet_simulation_test",
@@ -292,7 +293,7 @@ class GlasgowAppletTestCase(unittest.TestCase):
             await self.device.download_target(self.target.build_plan())
         else:
             # avoid UnusedElaboratable warning
-            Fragment.get(self.target, None)
+            Fragment.get(self.target, GlasgowPlatformRevAB())
 
         return await self.applet.run(self.device, self._parsed_args)
 

--- a/software/glasgow/applet/audio/yamaha_opx/__init__.py
+++ b/software/glasgow/applet/audio/yamaha_opx/__init__.py
@@ -165,7 +165,7 @@ class YamahaCPUBus(Elaboratable):
 
         self.a  = Signal(2)
 
-        self.oe = Signal(reset=1)
+        self.oe = Signal(init=1)
         self.di = Signal(8)
         self.do = Signal(8)
 

--- a/software/glasgow/applet/control/servo/__init__.py
+++ b/software/glasgow/applet/control/servo/__init__.py
@@ -34,8 +34,8 @@ class ServoChannel(wiring.Component):
         # the first millisecond is always high (whenever the channel is enabled), the second is
         # an encoding of the position and the rest is always low.
         period_timer = Signal(range(self.period_us * resolution),
-                              reset=self.period_us * resolution - 1)
-        with m.If(period_timer == period_timer.reset):
+                              init=self.period_us * resolution - 1)
+        with m.If(period_timer == period_timer.init):
             m.d.sync += period_timer.eq(0)
             m.d.sync += en_r.eq(self.en)
             m.d.sync += pos_r.eq(self.pos)
@@ -48,7 +48,7 @@ class ServoChannel(wiring.Component):
         pulse_timer = Signal(range(resolution))
         pulse_count = Signal.like(self.pos)
 
-        with m.If(period_timer == period_timer.reset):
+        with m.If(period_timer == period_timer.init):
             m.d.sync += self.out.eq(en_r)
             m.d.sync += pulse_en.eq(1)
 

--- a/software/glasgow/applet/display/pdi/__init__.py
+++ b/software/glasgow/applet/display/pdi/__init__.py
@@ -401,7 +401,7 @@ class DisplayPDIApplet(GlasgowApplet):
 
         cog_power, self.__addr_cog_power = target.registers.add_rw(1)
         cog_disch, self.__addr_cog_disch = target.registers.add_rw(1)
-        cog_reset, self.__addr_cog_reset = target.registers.add_rw(1, reset=1)
+        cog_reset, self.__addr_cog_reset = target.registers.add_rw(1, init=1)
 
         if hasattr(iface.pads, "pwm_t"):
             cog_pwmen, self.__addr_cog_pwmen = target.registers.add_rw(1)

--- a/software/glasgow/applet/interface/jtag_openocd/__init__.py
+++ b/software/glasgow/applet/interface/jtag_openocd/__init__.py
@@ -2,6 +2,7 @@ import struct
 import logging
 import asyncio
 from amaranth import *
+from amaranth.lib import io
 
 from ....support.bits import *
 from ....support.logging import *
@@ -18,8 +19,8 @@ class JTAGOpenOCDSubtarget(Elaboratable):
         self.in_fifo    = in_fifo
         self.period_cyc = period_cyc
         self.us_cyc     = us_cyc
-        self.srst_z     = Signal(reset=0)
-        self.srst_o     = Signal(reset=0)
+        self.srst_z     = Signal(init=0)
+        self.srst_o     = Signal(init=0)
 
     def elaborate(self, platform):
         m = Module()
@@ -40,7 +41,8 @@ class JTAGOpenOCDSubtarget(Elaboratable):
 
         blink = Signal()
         try:
-            m.d.comb += platform.request("led").o.eq(blink)
+            m.submodules.io_blink = io_blink = io.Buffer("o", platform.request("led", dir="-"))
+            m.d.comb += io_blink.o.eq(blink)
         except:
             pass
 

--- a/software/glasgow/applet/interface/jtag_probe/__init__.py
+++ b/software/glasgow/applet/interface/jtag_probe/__init__.py
@@ -79,12 +79,12 @@ JTAG_TRANSITIONS = {
 class JTAGProbeBus(Elaboratable):
     def __init__(self, pads):
         self._pads = pads
-        self.tck = Signal(reset=1)
-        self.tms = Signal(reset=1)
-        self.tdo = Signal(reset=1)
-        self.tdi = Signal(reset=1)
-        self.trst_z = Signal(reset=0)
-        self.trst_o = Signal(reset=0)
+        self.tck = Signal(init=1)
+        self.tms = Signal(init=1)
+        self.tdo = Signal(init=1)
+        self.tdi = Signal(init=1)
+        self.trst_z = Signal(init=0)
+        self.trst_o = Signal(init=0)
 
     def elaborate(self, platform):
         m = Module()

--- a/software/glasgow/applet/interface/sbw_probe/__init__.py
+++ b/software/glasgow/applet/interface/sbw_probe/__init__.py
@@ -14,9 +14,9 @@ from ..jtag_probe import JTAGProbeDriver, JTAGProbeInterface
 class SpyBiWireProbeBus(Elaboratable):
     def __init__(self, pads):
         self._pads = pads
-        self.sbwtck  = Signal(reset=0)
-        self.sbwtd_z = Signal(reset=0)
-        self.sbwtd_o = Signal(reset=1)
+        self.sbwtck  = Signal(init=0)
+        self.sbwtd_z = Signal(init=0)
+        self.sbwtd_o = Signal(init=1)
         self.sbwtd_i = Signal()
 
     def elaborate(self, platform):

--- a/software/glasgow/applet/interface/spi_controller/__init__.py
+++ b/software/glasgow/applet/interface/spi_controller/__init__.py
@@ -16,10 +16,10 @@ class SPIControllerBus(Elaboratable):
         self.sck_edge = sck_edge
         self.cs_active = cs_active
 
-        self.oe   = Signal(reset=1)
+        self.oe   = Signal(init=1)
 
-        self.sck  = Signal(reset=sck_idle)
-        self.cs   = Signal(reset=not cs_active)
+        self.sck  = Signal(init=sck_idle)
+        self.cs   = Signal(init=not cs_active)
         self.copi = Signal()
         self.cipo = Signal()
 

--- a/software/glasgow/applet/interface/swd_openocd/__init__.py
+++ b/software/glasgow/applet/interface/swd_openocd/__init__.py
@@ -2,6 +2,7 @@ import struct
 import logging
 import asyncio
 from amaranth import *
+from amaranth.lib import io
 from amaranth.lib.cdc import FFSynchronizer
 
 from ....support.bits import *
@@ -15,7 +16,7 @@ from ... import *
 class SWDProbeBus(Elaboratable):
     def __init__(self, pads):
         self._pads = pads
-        self.swclk = Signal(reset=1)
+        self.swclk = Signal(init=1)
         self.swdio_i = Signal()
         self.swdio_o = Signal()
         self.swdio_z = Signal()
@@ -42,8 +43,8 @@ class SWDOpenOCDSubtarget(Elaboratable):
         self.in_fifo    = in_fifo
         self.period_cyc = period_cyc
         self.us_cyc     = us_cyc
-        self.srst_z     = Signal(reset=0)
-        self.srst_o     = Signal(reset=0)
+        self.srst_z     = Signal(init=0)
+        self.srst_o     = Signal(init=0)
 
     def elaborate(self, platform):
         m = Module()
@@ -63,7 +64,8 @@ class SWDOpenOCDSubtarget(Elaboratable):
 
         blink = Signal()
         try:
-            m.d.comb += platform.request("led").o.eq(blink)
+            m.submodules.io_blink = io_blink = io.Buffer("o", platform.request("led", dir="-"))
+            m.d.comb += io_blink.o.eq(blink)
         except:
             pass
 

--- a/software/glasgow/applet/interface/uart/__init__.py
+++ b/software/glasgow/applet/interface/uart/__init__.py
@@ -185,7 +185,7 @@ class UARTApplet(GlasgowApplet):
         self.__sys_clk_freq = target.sys_clk_freq
 
         manual_cyc, self.__addr_manual_cyc = target.registers.add_rw(32)
-        auto_cyc,   self.__addr_auto_cyc   = target.registers.add_ro(32, reset=~0)
+        auto_cyc,   self.__addr_auto_cyc   = target.registers.add_ro(32, init=~0)
         use_auto,   self.__addr_use_auto   = target.registers.add_rw(1)
 
         bit_cyc,    self.__addr_bit_cyc    = target.registers.add_ro(32)

--- a/software/glasgow/applet/memory/onfi/__init__.py
+++ b/software/glasgow/applet/memory/onfi/__init__.py
@@ -154,7 +154,7 @@ class MemoryONFISubtarget(Elaboratable):
         length  = Signal(16)
 
         wait_cyc = 3 # currently required for reliable reads
-        timer    = Signal(range(wait_cyc + 2), reset=wait_cyc)
+        timer    = Signal(range(wait_cyc + 2), init=wait_cyc)
 
         with m.FSM() as fsm:
             with m.State("RECV-COMMAND"):

--- a/software/glasgow/applet/memory/prom/__init__.py
+++ b/software/glasgow/applet/memory/prom/__init__.py
@@ -67,9 +67,9 @@ class MemoryPROMBus(Elaboratable):
         ]
 
         if hasattr(pads, "a_clk_t") and hasattr(pads, "a_si_t"):
-            a_clk = Signal(reset=1)
+            a_clk = Signal(init=1)
             a_si  = Signal()
-            a_lat = Signal(reset=0) if hasattr(pads, "a_lat_t") else None
+            a_lat = Signal(init=0) if hasattr(pads, "a_lat_t") else None
             m.d.comb += [
                 pads.a_clk_t.oe.eq(1),
                 pads.a_clk_t.o.eq(a_clk),
@@ -89,9 +89,9 @@ class MemoryPROMBus(Elaboratable):
             sa_latch = Signal(self.a_bits - len(pads.a_t.o))
 
             sh_cyc = math.ceil(platform.default_clk_frequency / self._sh_freq)
-            timer = Signal(range(sh_cyc), reset=sh_cyc - 1)
+            timer = Signal(range(sh_cyc), init=sh_cyc - 1)
             count = Signal(range(len(sa_latch) + 1))
-            first = Signal(reset=1)
+            first = Signal(init=1)
 
             with m.FSM():
                 with m.State("READY"):

--- a/software/glasgow/applet/program/m16c/__init__.py
+++ b/software/glasgow/applet/program/m16c/__init__.py
@@ -337,7 +337,7 @@ class ProgramM16CApplet(GlasgowApplet):
         }
         max_bit_cyc = max(self.__bit_cyc_for_baud.values())
 
-        bit_cyc, self.__addr_bit_cyc = target.registers.add_rw(24, reset=max_bit_cyc) # slowest
+        bit_cyc, self.__addr_bit_cyc = target.registers.add_rw(24, init=max_bit_cyc) # slowest
         reset,   self.__addr_reset   = target.registers.add_rw(1)
         mode,    self.__addr_mode    = target.registers.add_rw(1)
 

--- a/software/glasgow/applet/video/vga_output/__init__.py
+++ b/software/glasgow/applet/video/vga_output/__init__.py
@@ -1,7 +1,6 @@
 import logging
 from amaranth import *
-from amaranth.hdl.cd import ClockDomain
-from amaranth.hdl.rec import Record
+from amaranth.lib import data
 
 from ....gateware.pads import *
 from ....gateware.pll import *
@@ -63,11 +62,7 @@ class VGAOutputSubtarget(Elaboratable):
 
         h_ctr = Signal(range(h_total))
         v_ctr = Signal(range(v_total))
-        pix = Record([
-            ("r", 1),
-            ("g", 1),
-            ("b", 1),
-        ])
+        pix = Signal(data.StructLayout({"r": 1, "g": 1, "b": 1}))
 
         h_en  = Signal()
         v_en  = Signal()

--- a/software/glasgow/gateware/__init__.py
+++ b/software/glasgow/gateware/__init__.py
@@ -23,7 +23,7 @@ def simulation_test(case=None, **kwargs):
                 yield from case(self, self.tb)
             if isinstance(self.tb, Elaboratable):
                 sim = Simulator(self.tb)
-                with sim.write_vcd(vcd_file=open("test.vcd", "w")):
+                with sim.write_vcd("test.vcd"):
                     sim.add_clock(1e-8)
                     sim.add_sync_process(setup_wrapper)
                     sim.run()

--- a/software/glasgow/gateware/lfsr.py
+++ b/software/glasgow/gateware/lfsr.py
@@ -22,14 +22,14 @@ class LinearFeedbackShiftRegister(Elaboratable):
         generated.
     :type reset: int
     """
-    def __init__(self, degree, taps, reset=1):
-        assert reset != 0
+    def __init__(self, degree, taps, init=1):
+        assert init != 0
 
         self.degree = degree
         self.taps   = taps
-        self.reset  = reset
+        self.init   = init
 
-        self.value  = Signal(degree, reset=reset)
+        self.value  = Signal(degree, init=init)
 
     def elaborate(self, platform):
         m = Module()
@@ -41,7 +41,7 @@ class LinearFeedbackShiftRegister(Elaboratable):
 
     def generate(self):
         """Generate every distinct value the LFSR will take."""
-        value = self.reset
+        value = self.init
         mask  = (1 << self.degree) - 1
         while True:
             yield value
@@ -49,5 +49,5 @@ class LinearFeedbackShiftRegister(Elaboratable):
             for tap in self.taps:
                 feedback ^= (value >> (tap - 1)) & 1
             value = ((value << 1) & mask) | feedback
-            if value == self.reset:
+            if value == self.init:
                 break

--- a/software/glasgow/gateware/pads.py
+++ b/software/glasgow/gateware/pads.py
@@ -1,5 +1,5 @@
 from amaranth import *
-from amaranth.lib.io import Pin
+from amaranth.lib import io
 
 
 __all__ = ['Pads']
@@ -33,7 +33,10 @@ class Pads(Elaboratable):
     """
     def __init__(self, **kwargs):
         for name, pin in kwargs.items():
-            assert isinstance(pin, Pin)
+            if hasattr(pin, "signature"):
+                assert isinstance(pin.signature, io.Buffer.Signature)
+            else:
+                assert isinstance(pin, io.Pin)
 
             pin_name = f"{name}_t"
             if hasattr(self, pin_name):

--- a/software/glasgow/gateware/uart.py
+++ b/software/glasgow/gateware/uart.py
@@ -23,7 +23,7 @@ class UARTBus(Elaboratable):
         self.has_tx = hasattr(pads, "tx_t")
         if self.has_tx:
             self.tx_t = pads.tx_t
-            self.tx_o = Signal(reset=1)
+            self.tx_o = Signal(init=1)
 
     def elaborate(self, platform):
         m = Module()
@@ -37,9 +37,9 @@ class UARTBus(Elaboratable):
 
         if self.has_rx:
             if self.invert_rx:
-                m.submodules += FFSynchronizer(~self.rx_t.i, self.rx_i, reset=1)
+                m.submodules += FFSynchronizer(~self.rx_t.i, self.rx_i, init=1)
             else:
-                m.submodules += FFSynchronizer(self.rx_t.i, self.rx_i, reset=1)
+                m.submodules += FFSynchronizer(self.rx_t.i, self.rx_i, init=1)
 
         return m
 
@@ -110,7 +110,7 @@ class UART(Elaboratable):
         self.data_bits = data_bits
         self.parity = parity
 
-        self.bit_cyc = Signal(range(self.max_bit_cyc + 1), reset=bit_cyc)
+        self.bit_cyc = Signal(range(self.max_bit_cyc + 1), init=bit_cyc)
 
         self.rx_data = Signal(data_bits)
         self.rx_rdy  = Signal()

--- a/software/glasgow/target/hardware.py
+++ b/software/glasgow/target/hardware.py
@@ -1,13 +1,13 @@
-import hashlib
 import os
 import sys
 import tempfile
 import shutil
 import logging
 import hashlib
-import platformdirs
 import pathlib
+import platformdirs
 from amaranth import *
+from amaranth.lib import io
 from amaranth.build import ResourceError
 
 from ..gateware.i2c import I2CTarget
@@ -39,22 +39,23 @@ class GlasgowHardwareTarget(Elaboratable):
             raise ValueError("Unknown revision")
 
         try:
-            self.platform.request("unused")
+            self.platform.request("unused", dir="-")
         except ResourceError:
             pass
 
         self._submodules = []
 
-        self.i2c_target = I2CTarget(self.platform.request("i2c"))
+        self.i2c_target = I2CTarget(self.platform.request("i2c", dir={"scl": "-", "sda": "-"}))
         self.registers = I2CRegisters(self.i2c_target)
 
-        self.fx2_crossbar = FX2Crossbar(self.platform.request("fx2", xdr={
-            "sloe": 1, "slrd": 1, "slwr": 1, "pktend": 1, "fifoadr": 1, "flag": 2, "fd": 2
+        self.fx2_crossbar = FX2Crossbar(self.platform.request("fx2", dir={
+            "sloe": "-", "slrd": "-", "slwr": "-", "pktend": "-", "fifoadr": "-",
+            "flag": "-", "fd": "-"
         }))
 
         self.ports = {
-            "A": (8, lambda n: self.platform.request("port_a", n)),
-            "B": (8, lambda n: self.platform.request("port_b", n)),
+            "A": (8, lambda n: self.platform.request("port_a", n, dir={"io": "-", "oe": "-"})),
+            "B": (8, lambda n: self.platform.request("port_b", n, dir={"io": "-", "oe": "-"})),
         }
 
         if multiplexer_cls:
@@ -93,7 +94,7 @@ class GlasgowHardwareTarget(Elaboratable):
                     pass
         for unused_pin in unused_pins:
             if hasattr(unused_pin, "oe"):
-                m.d.comb += unused_pin.oe.o.eq(0)
+                m.submodules += io.Buffer("o", unused_pin.oe)
 
         return m
 

--- a/software/pdm.min.lock
+++ b/software/pdm.min.lock
@@ -5,7 +5,7 @@
 groups = ["default", "builtin-toolchain", "http"]
 strategy = ["cross_platform", "direct_minimal_versions"]
 lock_version = "4.4.1"
-content_hash = "sha256:c4843d9af3f4c9a95797219c704ed82318ca8579ca3df3247e32ebb595a525ae"
+content_hash = "sha256:d96b010a1b5f37ec954e7bbfbe35598ec0373d3f8d01af605dca3f4e25e854b5"
 
 [[package]]
 name = "aiohttp"
@@ -113,15 +113,17 @@ files = [
 
 [[package]]
 name = "amaranth"
-version = "0.4.0"
+version = "0.5.0"
 requires_python = "~=3.8"
 summary = "Amaranth hardware definition language"
 dependencies = [
     "Jinja2~=3.0",
+    "jschon~=0.11.1",
     "pyvcd<0.5,>=0.2.2",
 ]
 files = [
-    {file = "amaranth-0.4.0-py3-none-any.whl", hash = "sha256:784e0cc7fdf0378a632b1f0d56180a26bc7718fa55b1aaa886b87340f02f2c7a"},
+    {file = "amaranth-0.5.0-py3-none-any.whl", hash = "sha256:3d05d38864d6e88e40db93ed29ac0bee7f2a351d12810d4414f5b65a7cb0e23f"},
+    {file = "amaranth-0.5.0.tar.gz", hash = "sha256:9d2a1893d6ac938e0ff3983892eff5b56033e06691cc89674eb8d500dc46cdf6"},
 ]
 
 [[package]]
@@ -284,6 +286,19 @@ files = [
 ]
 
 [[package]]
+name = "jschon"
+version = "0.11.1"
+requires_python = "~=3.8"
+summary = "A JSON toolkit for Python developers."
+dependencies = [
+    "rfc3986",
+]
+files = [
+    {file = "jschon-0.11.1-py3-none-any.whl", hash = "sha256:2350e8b6747b17358022960f91208bea70de448b914827af3184d30e20500f0f"},
+    {file = "jschon-0.11.1.tar.gz", hash = "sha256:c0ca0beab1f1694a03d726b91ed75ec604a7787af3ae91ead765f78215bf149f"},
+]
+
+[[package]]
 name = "libusb1"
 version = "3.1.0"
 summary = "Pure-python wrapper for libusb-1.0"
@@ -441,6 +456,16 @@ summary = "Python VCD file support"
 files = [
     {file = "pyvcd-0.2.3-py2.py3-none-any.whl", hash = "sha256:d4132a03afd353e68fb2a2eb983606603f7e60091198a026fee5fb6da50bbd48"},
     {file = "pyvcd-0.2.3.tar.gz", hash = "sha256:c0fd7321143e821033f59dd41fc6b0350d1533ddccd4c8fc1d1f76e21cd667de"},
+]
+
+[[package]]
+name = "rfc3986"
+version = "2.0.0"
+requires_python = ">=3.7"
+summary = "Validating URI References per RFC 3986"
+files = [
+    {file = "rfc3986-2.0.0-py2.py3-none-any.whl", hash = "sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd"},
+    {file = "rfc3986-2.0.0.tar.gz", hash = "sha256:97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c"},
 ]
 
 [[package]]

--- a/software/pdm.toml
+++ b/software/pdm.toml
@@ -1,2 +1,0 @@
-[install]
-cache_method = "hardlink"

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   # `typing_extensions` provides shims for such features. It uses SemVer.
   "typing_extensions>=4.8,<5",
   # Amaranth is the core of the Glasgow software/gateware interoperability layer. It uses SemVer.
-  "amaranth>=0.4.0,<0.5",
+  "amaranth>=0.5.0,<0.6",
   # `packaging` is used in the plugin system, `support.plugin`. It uses CalVer: the major version
   # is the two last digits of the year and the minor version is the release within that year.
   "packaging>=23.0",

--- a/software/tests/gateware/test_i2c.py
+++ b/software/tests/gateware/test_i2c.py
@@ -12,9 +12,9 @@ class I2CTestbench(Elaboratable):
         self.sda_t = Pin(width=1, dir='io')
 
         self.scl_i = self.scl_t.i
-        self.scl_o = Signal(reset=1)
+        self.scl_o = Signal(init=1)
         self.sda_i = self.sda_t.i
-        self.sda_o = Signal(reset=1)
+        self.sda_o = Signal(init=1)
 
         self.period_cyc = 16
 

--- a/software/tests/gateware/test_uart.py
+++ b/software/tests/gateware/test_uart.py
@@ -1,6 +1,6 @@
 import unittest
 from amaranth import *
-from amaranth.lib.io import Pin
+from amaranth.lib import io
 
 from glasgow.gateware import simulation_test
 from glasgow.gateware.uart import UART
@@ -8,10 +8,10 @@ from glasgow.gateware.uart import UART
 
 class UARTTestbench(Elaboratable):
     def __init__(self):
-        self.rx_t = Pin(width=1, dir='i')
+        self.rx_t = io.Buffer.Signature('i', 1).create()
         self.rx_i = self.rx_t.i
 
-        self.tx_t = Pin(width=1, dir='oe')
+        self.tx_t = io.Buffer.Signature('o', 1).create()
         self.tx_o = self.tx_t.o
 
         self.bit_cyc = 4


### PR DESCRIPTION
There are still a few deprecation warnings that appear when running tests with `PYTHONWARNINGS=all` (primarily https://github.com/amaranth-lang/amaranth/issues/1402), but the bulk has been addressed.

I have not upgraded the tests, mainly because there was something *absurdly cursed* going on to allow interleaving Amaranth simulation code and asyncio code, and I don't remember how I made that work nor do I know how to upgrade it really.