### PR TITLE
support.endpoint: allow waiting for incoming connection.

### DIFF
--- a/software/glasgow/support/endpoint.py
+++ b/software/glasgow/support/endpoint.py
@@ -88,6 +88,7 @@ class ServerEndpoint(aobject, asyncio.Protocol):
             self._log(logging.INFO, "closing old connection")
             self._transport.close()
             self._new_transport = transport
+        self.data_received(b"")
 
     def connection_lost(self, exc):
         peername = self._transport.get_extra_info("peername")

--- a/software/tests/support/test_endpoint.py
+++ b/software/tests/support/test_endpoint.py
@@ -117,3 +117,21 @@ class ServerEndpointTestCase(unittest.TestCase):
     def test_tcp(self):
         asyncio.get_event_loop().run_until_complete(
             self.do_test_tcp())
+
+    async def do_test_server_banner(self):
+        sock = ("tcp", "localhost", 2345)
+        endp = await ServerEndpoint("test_server_banner", logging.getLogger(__name__), sock)
+
+        async def endpoint_task():
+            await endp.recv_wait()
+            await endp.send(b"Hello")
+        asyncio.create_task(endpoint_task())
+
+        conn_rd, _ = await asyncio.open_connection(*sock[1:])
+        r = await conn_rd.read(5)
+        self.assertEqual(r, b"Hello")
+
+    def test_server_banner(self):
+        logging.basicConfig(level=logging.TRACE)
+        asyncio.get_event_loop().run_until_complete(
+            self.do_test_server_banner())


### PR DESCRIPTION
Some protocols start with the server sending some data as soon as the client connects. If such data is not sent, the client will not proceed with its first message.

When send is called before a client is connected, it is immediately discarded. To wait for data sent by the client, a server implementation can call recv_wait. This commit makes recv_wait return after a client connects, too.

TODO:
- [x] fix test to work always