### PR TITLE
An applet for controlling a quad-SPI (QSPI/QPI) bus

### DIFF
--- a/software/glasgow/applet/interface/qspi_controller/__init__.py
+++ b/software/glasgow/applet/interface/qspi_controller/__init__.py
@@ -1,0 +1,287 @@
+import contextlib
+import logging
+import struct
+from amaranth import *
+from amaranth.lib import enum, data, wiring, stream, io
+from amaranth.lib.wiring import In, Out, connect, flipped
+
+from ....support.logging import *
+from ....gateware.iostream import IOStreamer
+from ....gateware.qspi import QSPIMode, QSPIController
+from ... import *
+
+
+class _QSPICommand(enum.Enum, shape=4):
+    Select   = 0
+    Transfer = 1
+    Delay    = 2
+    Sync     = 3
+
+
+class QSPIControllerSubtarget(Elaboratable):
+    def __init__(self, *, ports, out_fifo, in_fifo, divisor, us_cycles):
+        self._ports    = ports
+        self._out_fifo = out_fifo
+        self._in_fifo  = in_fifo
+
+        self._divisor   = divisor
+        self._us_cycles = us_cycles
+
+    def elaborate(self, platform):
+        m = Module()
+
+        m.submodules.qspi = qspi = QSPIController(self._ports, use_ddr_buffers=True)
+        m.d.comb += qspi.divisor.eq(self._divisor)
+
+        o_fifo  = self._out_fifo.stream
+        i_fifo  = self._in_fifo.stream
+
+        command = Signal(_QSPICommand)
+        chip    = Signal(range(1 + len(self._ports.cs)))
+        mode    = Signal(QSPIMode)
+        is_put  = mode.as_value().matches(QSPIMode.PutX1, QSPIMode.PutX2, QSPIMode.PutX4,
+                                          QSPIMode.Swap)
+        is_get  = mode.as_value().matches(QSPIMode.GetX1, QSPIMode.GetX2, QSPIMode.GetX4,
+                                          QSPIMode.Swap) # FIXME: amaranth-lang/amaranth#1462
+        o_count = Signal(16)
+        i_count = Signal(16)
+        timer   = Signal(range(self._us_cycles))
+        with m.FSM():
+            with m.State("Read-Command"):
+                m.d.comb += self._in_fifo.flush.eq(1)
+                m.d.comb += o_fifo.ready.eq(1)
+                with m.If(o_fifo.valid):
+                    m.d.sync += command.eq(o_fifo.payload[4:])
+                    with m.Switch(o_fifo.payload[4:]):
+                        with m.Case(_QSPICommand.Select):
+                            m.d.sync += chip.eq(o_fifo.payload[:4])
+                            m.next = "Read-Command"
+                        with m.Case(_QSPICommand.Transfer):
+                            m.d.sync += mode.eq(o_fifo.payload[:4])
+                            m.next = "Read-Count-0:8"
+                        with m.Case(_QSPICommand.Delay):
+                            m.next = "Read-Count-0:8"
+                        with m.Case(_QSPICommand.Sync):
+                            m.next = "Sync"
+
+            with m.State("Read-Count-0:8"):
+                m.d.comb += o_fifo.ready.eq(1)
+                with m.If(o_fifo.valid):
+                    m.d.sync += o_count[0:8].eq(o_fifo.payload)
+                    m.d.sync += i_count[0:8].eq(o_fifo.payload)
+                    m.next = "Read-Count-8:16"
+
+            with m.State("Read-Count-8:16"):
+                m.d.comb += o_fifo.ready.eq(1)
+                with m.If(o_fifo.valid):
+                    m.d.sync += o_count[8:16].eq(o_fifo.payload)
+                    m.d.sync += i_count[8:16].eq(o_fifo.payload)
+                    with m.Switch(command):
+                        with m.Case(_QSPICommand.Transfer):
+                            m.next = "Transfer"
+                        with m.Case(_QSPICommand.Delay):
+                            m.next = "Delay"
+
+            with m.State("Transfer"):
+                m.d.comb += [
+                    qspi.o_octets.p.chip.eq(chip),
+                    qspi.o_octets.p.mode.eq(mode),
+                    qspi.o_octets.p.data.eq(o_fifo.payload),
+                    i_fifo.payload.eq(qspi.i_octets.p.data),
+                ]
+                with m.If(o_count != 0):
+                    with m.If(is_put):
+                        m.d.comb += qspi.o_octets.valid.eq(o_fifo.valid)
+                        m.d.comb += o_fifo.ready.eq(qspi.o_octets.ready)
+                    with m.Else():
+                        m.d.comb += qspi.o_octets.valid.eq(1)
+                    with m.If(qspi.o_octets.valid & qspi.o_octets.ready):
+                        m.d.sync += o_count.eq(o_count - 1)
+                with m.If(i_count != 0):
+                    with m.If(is_get):
+                        m.d.comb += i_fifo.valid.eq(qspi.i_octets.valid)
+                        m.d.comb += qspi.i_octets.ready.eq(i_fifo.ready)
+                        with m.If(qspi.i_octets.valid & qspi.i_octets.ready):
+                            m.d.sync += i_count.eq(i_count - 1)
+                with m.If((o_count == 0) & ((i_count == 0) | ~is_get)):
+                    m.next = "Read-Command"
+
+            with m.State("Delay"):
+                with m.If(i_count == 0):
+                    m.next = "Read-Command"
+                with m.Elif(timer == 0):
+                    m.d.sync += i_count.eq(i_count - 1)
+                    m.d.sync += timer.eq(self._us_cycles - 1)
+                with m.Else():
+                    m.d.sync += timer.eq(timer - 1)
+
+            with m.State("Sync"):
+                m.d.comb += i_fifo.valid.eq(1)
+                with m.If(i_fifo.ready):
+                    m.next = "Read-Command"
+
+        return m
+
+
+class QSPIControllerInterface:
+    def __init__(self, interface, logger):
+        self.lower   = interface
+        self._logger = logger
+        self._level  = logging.DEBUG if self._logger.name == __name__ else logging.TRACE
+
+    def _log(self, message, *args):
+        self._logger.log(self._level, "QSPI: " + message, *args)
+
+    async def reset(self):
+        self._log("reset")
+        await self.lower.reset()
+
+    @staticmethod
+    def _chunked(items, *, count=0xffff):
+        while items:
+            yield items[:count]
+            items = items[count:]
+
+    @contextlib.asynccontextmanager
+    async def select(self, index=0):
+        assert index in range(8)
+        try:
+            self._log("select chip=%d", index)
+            await self.lower.write(struct.pack("<B",
+                (_QSPICommand.Select.value << 4) | (1 + index)))
+            yield
+        finally:
+            self._log("deselect")
+            await self.lower.write(struct.pack("<BBH",
+                (_QSPICommand.Select.value << 4) | 0,
+                (_QSPICommand.Transfer.value << 4) | QSPIMode.Dummy.value, 1))
+            await self.lower.flush()
+
+    async def exchange(self, octets):
+        self._log("xchg-o=<%s>", dump_hex(octets))
+        for chunk in self._chunked(octets):
+            await self.lower.write(struct.pack("<BH",
+                (_QSPICommand.Transfer.value << 4) | QSPIMode.Swap.value, len(chunk)))
+            await self.lower.write(chunk)
+        octets = await self.lower.read(len(octets))
+        self._log("xchg-i=<%s>", dump_hex(octets))
+        return octets
+
+    async def write(self, octets, *, x=1):
+        mode = {1: QSPIMode.PutX1, 2: QSPIMode.PutX2, 4: QSPIMode.PutX4}[x]
+        self._log("write=<%s>", dump_hex(octets))
+        for chunk in self._chunked(octets):
+            await self.lower.write(struct.pack("<BH",
+                (_QSPICommand.Transfer.value << 4) | mode.value, len(chunk)))
+            await self.lower.write(chunk)
+
+    async def read(self, count, *, x=1):
+        mode = {1: QSPIMode.GetX1, 2: QSPIMode.GetX2, 4: QSPIMode.GetX4}[x]
+        for chunk in self._chunked(range(count)):
+            await self.lower.write(struct.pack("<BH",
+                (_QSPICommand.Transfer.value << 4) | mode.value, len(chunk)))
+        octets = await self.lower.read(count)
+        self._log("read=<%s>", dump_hex(octets))
+        return octets
+
+    async def dummy(self, count):
+        self._log("dummy=%d", count)
+        for chunk in self._chunked(range(count)):
+            await self.lower.write(struct.pack("<BH",
+                (_QSPICommand.Transfer.value << 4) | QSPIMode.Dummy.value, len(chunk)))
+
+    async def delay_us(self, duration):
+        self._log("delay us=%d", duration)
+        for chunk in self._chunked(range(duration)):
+            await self.lower.write(struct.pack("<BH",
+                (_QSPICommand.Delay.value << 4), len(chunk)))
+
+    async def delay_ms(self, duration):
+        self._log("delay ms=%d", duration)
+        for chunk in self._chunked(range(duration * 1000)):
+            await self.lower.write(struct.pack("<BH",
+                (_QSPICommand.Delay.value << 4), len(chunk)))
+
+    async def synchronize(self):
+        self._log("sync-o")
+        await self.lower.write(struct.pack("<B",
+            (_QSPICommand.Sync.value << 4)))
+        await self.lower.read(1)
+        self._log("sync-i")
+
+
+class QSPIControllerApplet(GlasgowApplet):
+    logger = logging.getLogger(__name__)
+    help = "initiate SPI/dual-SPI/quad-SPI/QPI transactions"
+    description = """
+    Initiate transactions on the extended variant of the SPI bus with four I/O channels.
+
+    This applet can control a wide range of devices, primarily memories, that use multi-bit variants
+    of the SPI bus. Electrically, they are all compatible, with the names indicating differences in
+    protocol logic:
+
+        * "SPI" uses COPI/CIPO for both commands and data;
+        * "dual-SPI" uses COPI/CIPO for commands and IO0/IO1 for data;
+        * "quad-SPI" uses COPI/CIPO for commands and IO0/IO1/IO2/IO3 for data;
+        * "QPI" uses IO0/IO1/IO2/IO3 for both commands and data.
+
+    In this list, COPI and CIPO refer to IO0 and IO1 respectively used as fixed direction I/O.
+    Note that vendors often make further distinction between modes, e.g. between "dual output SPI"
+    and "dual I/O SPI"; refer to the vendor documentation for details.
+
+    The command line interface only initiates SPI mode transfers. Use the REPL for other modes.
+    """
+
+    @classmethod
+    def add_build_arguments(cls, parser, access):
+        super().add_build_arguments(parser, access)
+
+        access.add_pin_argument(parser, "sck", default=True)
+        access.add_pin_set_argument(parser, "io", width=4, default=True)
+        access.add_pin_set_argument(parser, "cs", width=1, default=True)
+
+        # Most devices that advertise QSPI support should work at 1 MHz.
+        parser.add_argument(
+            "-f", "--frequency", metavar="FREQ", type=int, default=1000,
+            help="set SCK frequency to FREQ kHz (default: %(default)s)")
+
+    def build(self, target, args):
+        self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
+        return iface.add_subtarget(QSPIControllerSubtarget(
+            ports=iface.get_port_group(
+                sck=args.pin_sck,
+                io=args.pin_set_io,
+                cs=args.pin_set_cs,
+            ),
+            out_fifo=iface.get_out_fifo(),
+            in_fifo=iface.get_in_fifo(auto_flush=False),
+            divisor=int(target.sys_clk_freq // (args.frequency * 2000)),
+            us_cycles=int(target.sys_clk_freq // 1_000_000),
+        ))
+
+    async def run(self, device, args):
+        iface = await device.demultiplexer.claim_interface(self, self.mux_interface, args,
+            # Pull IO2 and IO3 high, since on QSPI flashes these correspond to WP# and HOLD#,
+            # and will interfere with operation in SPI mode. For other devices this is benign.
+            pull_high={args.pin_set_io[2], args.pin_set_io[3]})
+        qspi_iface = QSPIControllerInterface(iface, self.logger)
+        return qspi_iface
+
+    @classmethod
+    def add_interact_arguments(cls, parser):
+        def hex(arg): return bytes.fromhex(arg)
+
+        parser.add_argument(
+            "data", metavar="DATA", type=hex, nargs="+",
+            help="hex bytes to exchange with the device in SPI mode")
+
+    async def interact(self, device, args, qspi_iface):
+        for octets in args.data:
+            async with qspi_iface.select():
+                octets = await qspi_iface.exchange(octets)
+            print(octets.hex())
+
+    @classmethod
+    def tests(cls):
+        from . import test
+        return test.QSPIControllerAppletTestCase

--- a/software/glasgow/applet/interface/qspi_controller/__init__.py
+++ b/software/glasgow/applet/interface/qspi_controller/__init__.py
@@ -233,12 +233,13 @@ class QSPIControllerApplet(GlasgowApplet):
     """
 
     @classmethod
-    def add_build_arguments(cls, parser, access):
+    def add_build_arguments(cls, parser, access, *, include_pins=True):
         super().add_build_arguments(parser, access)
 
-        access.add_pin_argument(parser, "sck", default=True)
-        access.add_pin_set_argument(parser, "io", width=4, default=True)
-        access.add_pin_set_argument(parser, "cs", width=1, default=True)
+        if include_pins:
+            access.add_pin_argument(parser, "sck", default=True)
+            access.add_pin_set_argument(parser, "io", width=4, default=True)
+            access.add_pin_set_argument(parser, "cs", width=1, default=True)
 
         # Most devices that advertise QSPI support should work at 1 MHz.
         parser.add_argument(

--- a/software/glasgow/applet/interface/qspi_controller/test.py
+++ b/software/glasgow/applet/interface/qspi_controller/test.py
@@ -1,0 +1,10 @@
+from amaranth import *
+
+from ... import *
+from . import QSPIControllerApplet
+
+
+class QSPIControllerAppletTestCase(GlasgowAppletTestCase, applet=QSPIControllerApplet):
+    @synthesis_test
+    def test_build(self):
+        self.assertBuilds()

--- a/software/glasgow/applet/memory/_25x/test.py
+++ b/software/glasgow/applet/memory/_25x/test.py
@@ -7,15 +7,14 @@ from . import Memory25xApplet
 class Memory25xAppletTestCase(GlasgowAppletTestCase, applet=Memory25xApplet):
     @synthesis_test
     def test_build(self):
-        self.assertBuilds(args=["--pin-sck",  "0", "--pin-cs",   "1",
-                                "--pin-copi", "2", "--pin-cipo", "3"])
+        self.assertBuilds()
 
     # Flash used for testing: Winbond 25Q32FV
     hardware_args = [
-        "--voltage",  "3.3",
-        "--pin-cs",   "0", "--pin-cipo", "1",
-        "--pin-copi", "2", "--pin-sck",  "3",
-        "--pin-hold", "4"
+        "--voltage", "3.3",
+        "--pin-sck", "0",
+        "--pins-io", "1:4",
+        "--pins-cs", "5",
     ]
     dut_ids = (0xef, 0x15, 0x4016)
     dut_page_size   = 0x100

--- a/software/glasgow/gateware/iostream.py
+++ b/software/glasgow/gateware/iostream.py
@@ -1,0 +1,263 @@
+from amaranth import *
+from amaranth.lib import enum, data, wiring, stream, io
+from amaranth.lib.wiring import In, Out
+
+from glasgow.gateware.ports import PortGroup
+
+
+__all__ = ["IOStreamer"]
+
+
+def _filter_ioshape(direction, ioshape):
+    direction = io.Direction(direction)
+    if direction is io.Direction.Bidir:
+        return True
+    return io.Direction(ioshape[0]) in (direction, io.Direction.Bidir)
+
+
+def _iter_ioshape(direction, ioshape, *args): # actually filter+iter
+    for name, item in ioshape.items():
+        if _filter_ioshape(direction, ioshape[name]):
+            yield tuple(arg[name] for arg in args)
+
+
+def _map_ioshape(direction, ioshape, fn): # actually filter+map
+    return data.StructLayout({
+        name: fn(item[1]) for name, item in ioshape.items() if _filter_ioshape(direction, item)
+    })
+
+
+class IOStreamer(wiring.Component):
+    """I/O buffer to stream adapter.
+
+    This adapter instantiates I/O buffers for a port (FF or DDR) and connects them to a pair of
+    streams, one for the outputs of the buffers and one for the inputs. Whenever an `o_stream`
+    transfer occurs, the state of the output is updated _t1_ cycles later; if `o_stream.p.i_en`
+    is set, then _t2_ cycles later, a payload with the data captured at the same time as
+    the outputs were updated appears on `i_stream.p.i`.
+
+    Arbitrary ancillary data may be provided with `o_stream` transfers via `o_stream.p.meta`,
+    and this data will be relayed back as `i_stream.p.meta` with the output-to-input latency
+    of the buffer. Higher-level protocol engines can use this data to indicate how the inputs
+    must be processed without needing counters or state machines on a higher level to match
+    the latency (and, usually, without needing any knowledge of the latency at all).
+
+    On reset, output ports have their drivers enabled, and bidirectional ports have them disabled.
+    All of the signals are deasserted, which could be a low or a high level depending on the port
+    polarity.
+    """
+
+    @staticmethod
+    def o_stream_signature(ioshape, /, *, ratio=1, meta_layout=0):
+        return stream.Signature(data.StructLayout({
+            "port": _map_ioshape("o", ioshape, lambda width: data.StructLayout({
+                "o":  width if ratio == 1 else data.ArrayLayout(width, ratio),
+                "oe": 1,
+            })),
+            "i_en": 1,
+            "meta": meta_layout,
+        }))
+
+    @staticmethod
+    def i_stream_signature(ioshape, /, *, ratio=1, meta_layout=0):
+        return stream.Signature(data.StructLayout({
+            "port": _map_ioshape("i", ioshape, lambda width: data.StructLayout({
+                "i":  width if ratio == 1 else data.ArrayLayout(width, ratio),
+            })),
+            "meta": meta_layout,
+        }))
+
+    def __init__(self, ioshape, ports, /, *, ratio=1, init=None, meta_layout=0):
+        assert isinstance(ioshape, (int, dict))
+        assert ratio in (1, 2)
+
+        self._ioshape = ioshape
+        self._ports   = ports
+        self._ratio   = ratio
+        self._init    = init
+
+        super().__init__({
+            "o_stream":  In(self.o_stream_signature(ioshape, ratio=ratio, meta_layout=meta_layout)),
+            "i_stream": Out(self.i_stream_signature(ioshape, ratio=ratio, meta_layout=meta_layout)),
+        })
+
+    def elaborate(self, platform):
+        m = Module()
+
+        if self._ratio == 1:
+            buffer_cls, latency = io.FFBuffer, 2
+        if self._ratio == 2:
+            # FIXME: should this be 2 or 3? the latency differs between i[0] and i[1]
+            buffer_cls, latency = io.DDRBuffer, 3
+
+        if isinstance(self._ports, io.PortLike):
+            m.submodules.buffer = buffer = buffer_cls("io", self._ports)
+        if isinstance(self._ports, PortGroup):
+            buffer = {}
+            for name, sub_port in self._ports.__dict__.items():
+                direction, _width = self._ioshape[name]
+                m.submodules[f"buffer_{name}"] = buffer[name] = buffer_cls(direction, sub_port)
+
+        o_latch = Signal(_map_ioshape("o", self._ioshape, lambda width: data.StructLayout({
+            "o":  width,
+            "oe": 1,
+        })), init=self._init)
+        with m.If(self.o_stream.valid & self.o_stream.ready):
+            for buffer_parts, stream_parts in _iter_ioshape("o", self._ioshape,
+                    buffer, self.o_stream.p.port):
+                m.d.comb += buffer_parts.o.eq(stream_parts.o)
+                m.d.comb += buffer_parts.oe.eq(stream_parts.oe)
+            for latch_parts, stream_parts in _iter_ioshape("o", self._ioshape,
+                    o_latch, self.o_stream.p.port):
+                if self._ratio == 1:
+                    m.d.sync += latch_parts.o.eq(stream_parts.o)
+                else:
+                    m.d.sync += latch_parts.o.eq(stream_parts.o[-1])
+                m.d.sync += latch_parts.oe.eq(stream_parts.oe)
+        with m.Else():
+            for buffer_parts, latch_parts in _iter_ioshape("o", self._ioshape,
+                    buffer, o_latch):
+                if self._ratio == 1:
+                    m.d.comb += buffer_parts.o.eq(latch_parts.o)
+                else:
+                    m.d.comb += buffer_parts.o.eq(latch_parts.o.replicate(self._ratio))
+                m.d.comb += buffer_parts.oe.eq(latch_parts.oe)
+
+        def delay(value, name):
+            for stage in range(latency):
+                next_value = Signal.like(value, name=f"{name}_{stage}")
+                m.d.sync += next_value.eq(value)
+                value = next_value
+            return value
+
+        i_en = delay(self.o_stream.valid & self.o_stream.ready &
+                     self.o_stream.p.i_en, name="i_en")
+        meta = delay(self.o_stream.p.meta, name="meta")
+
+        # This skid buffer is organized as a shift register to avoid any uncertainties associated
+        # with the use of an async read memory. On platforms that have LUTRAM, this implementation
+        # may be slightly worse than using LUTRAM, and may have to be revisited in the future.
+        skid = Array(Signal(self.i_stream.payload.shape(), name=f"skid_{stage}")
+                     for stage in range(1 + latency))
+        for skid_parts, buffer_parts in _iter_ioshape("i", self._ioshape, skid[0].port, buffer):
+            m.d.comb += skid_parts.i.eq(buffer_parts.i)
+        m.d.comb += skid[0].meta.eq(meta)
+
+        skid_at = Signal(range(1 + latency))
+        with m.If(i_en & ~self.i_stream.ready):
+            # m.d.sync += Assert(skid_at != latency)
+            m.d.sync += skid_at.eq(skid_at + 1)
+            for n_shift in range(latency):
+                m.d.sync += skid[n_shift + 1].eq(skid[n_shift])
+        with m.Elif((skid_at != 0) & self.i_stream.ready):
+            m.d.sync += skid_at.eq(skid_at - 1)
+
+        m.d.comb += self.i_stream.payload.eq(skid[skid_at])
+        m.d.comb += self.i_stream.valid.eq(i_en | (skid_at != 0))
+        m.d.comb += self.o_stream.ready.eq(self.i_stream.ready & (skid_at == 0))
+
+        return m
+
+
+class IOClocker(wiring.Component):
+    @staticmethod
+    def i_stream_signature(ioshape, /, *, _ratio=1, meta_layout=0):
+        # Currently the only supported ratio is 1, but this will change in the future for
+        # interfaces like HyperBus.
+        return stream.Signature(data.StructLayout({
+            "bypass": 1,
+            "port": _map_ioshape("o", ioshape, lambda width: data.StructLayout({
+                "o":  width if _ratio == 1 else data.ArrayLayout(width, _ratio),
+                "oe": 1,
+            })),
+            "i_en": 1,
+            "meta": meta_layout,
+        }))
+
+    @staticmethod
+    def o_stream_signature(ioshape, /, *, ratio=1, meta_layout=0):
+        return IOStreamer.o_stream_signature(ioshape, ratio=ratio, meta_layout=meta_layout)
+
+    def __init__(self, ioshape, *, clock, o_ratio=1, meta_layout=0, divisor_width=16):
+        assert isinstance(ioshape, dict)
+        assert isinstance(clock, str)
+        assert o_ratio in (1, 2)
+        assert clock in ioshape
+
+        self._clock   = clock
+        self._ioshape = ioshape
+        self._o_ratio = o_ratio
+
+        super().__init__({
+            "i_stream":  In(self.i_stream_signature(ioshape,
+                meta_layout=meta_layout)),
+            "o_stream": Out(self.o_stream_signature(ioshape,
+                ratio=o_ratio, meta_layout=meta_layout)),
+
+            # f_clk = f_sync if (o_ratio == 2 and divisor == 0) else f_sync / (2 * max(1, divisor))
+            "divisor": In(divisor_width),
+        })
+
+    def elaborate(self, platform):
+        m = Module()
+
+        # Forward the inputs to the outputs as-is. This includes the clock; it is overridden below
+        # if the clocker is used (not bypassed).
+        for i_parts, o_parts in _iter_ioshape("io", self._ioshape,
+                self.i_stream.p.port, self.o_stream.p.port):
+            m.d.comb += o_parts.o .eq(i_parts.o.replicate(self._o_ratio))
+            m.d.comb += o_parts.oe.eq(i_parts.oe)
+        m.d.comb += self.o_stream.p.i_en.eq(self.i_stream.p.i_en)
+        m.d.comb += self.o_stream.p.meta.eq(self.i_stream.p.meta)
+
+        phase = Signal()
+        # If the clocker is used...
+        with m.If(~self.i_stream.p.bypass):
+            # ... ignore the clock in the inputs and replace it with the generated one...
+            if self._o_ratio == 1:
+                m.d.comb += self.o_stream.p.port[self._clock].o.eq(phase)
+            if self._o_ratio == 2:
+                m.d.comb += self.o_stream.p.port[self._clock].o.eq(Cat(~phase, phase))
+            m.d.comb += self.o_stream.p.port[self._clock].oe.eq(1)
+            # ... while requesting input sampling only for the rising edge. (Interfaces triggering
+            # transfers on falling edge will be inverting the clock at the `IOPort` level.)
+            m.d.comb += self.o_stream.p.i_en.eq(self.i_stream.p.i_en & phase)
+
+        timer = Signal.like(self.divisor)
+        with m.If((timer == 0) | (timer == 1)):
+            # Only produce output when the timer has expired. This ensures that no clock pulse
+            # exceeds the frequency set by `divisor`, except the ones that bypass the clocker.
+            m.d.comb += self.o_stream.valid.eq(self.i_stream.valid)
+
+            with m.FSM():
+                with m.State("Falling"):
+                    with m.If(self.i_stream.p.bypass): # Bypass the clocker entirely.
+                        m.d.comb += self.i_stream.ready.eq(self.o_stream.ready)
+
+                    with m.Else(): # Produce a falling edge at the output.
+                        # Whenever DDR output is used, `phase == 1` outputs a low state first and
+                        # a high state second. When `phase == 1` payloads are output back to back
+                        # (in DDR mode only!) this generates a pulse train with data changes
+                        # coinciding with the falling edges. Setting `divisor == 0` in this mode
+                        # allows clocking the peripheral at the `sync` frequency.
+                        with m.If((self._o_ratio == 2) & (self.divisor == 0)):
+                            m.d.comb += phase.eq(1)
+                            with m.If(self.o_stream.ready):
+                                m.d.comb += self.i_stream.ready.eq(1)
+                        with m.Else():
+                            m.d.comb += phase.eq(0)
+                            with m.If(self.o_stream.ready):
+                                m.d.sync += timer.eq(self.divisor)
+                                m.next = "Rising"
+
+                with m.State("Rising"):
+                    m.d.comb += phase.eq(1)
+                    with m.If(self.o_stream.ready):
+                        m.d.comb += self.i_stream.ready.eq(1)
+                        m.d.sync += timer.eq(self.divisor)
+                        m.next = "Falling"
+
+        with m.Else():
+            m.d.sync += timer.eq(timer - 1)
+
+        return m

--- a/software/glasgow/gateware/qspi.py
+++ b/software/glasgow/gateware/qspi.py
@@ -1,0 +1,218 @@
+from amaranth import *
+from amaranth.lib import enum, data, wiring, stream, io
+from amaranth.lib.wiring import In, Out, connect, flipped
+
+from .ports import PortGroup
+from .iostream import IOStreamer, IOClocker
+
+
+__all__ = ["QSPIMode", "QSPIEnframer", "QSPIDeframer", "QSPIController"]
+
+
+class QSPIMode(enum.Enum, shape=3):
+    Dummy = 0
+    PutX1 = 1
+    GetX1 = 2
+    PutX2 = 3
+    GetX2 = 4
+    PutX4 = 5
+    GetX4 = 6
+    Swap  = 7 # normal SPI
+
+
+class QSPIEnframer(wiring.Component):
+    def __init__(self, *, chip_count=1):
+        assert chip_count >= 1
+
+        super().__init__({
+            "octets": In(stream.Signature(data.StructLayout({
+                "chip": range(1 + chip_count),
+                "mode": QSPIMode,
+                "data": 8,
+            }))),
+            "frames": Out(IOClocker.i_stream_signature({
+                "sck": ("o",  1),
+                "io0": ("io", 1),
+                "io1": ("io", 1),
+                "io2": ("io", 1),
+                "io3": ("io", 1),
+                "cs":  ("o",  chip_count),
+            }, meta_layout=QSPIMode))
+        })
+
+    def elaborate(self, platform):
+        m = Module()
+
+        cycle = Signal(range(8))
+        m.d.comb += self.frames.valid.eq(self.octets.valid)
+        with m.If(self.octets.valid & self.frames.ready):
+            with m.Switch(self.octets.p.mode):
+                with m.Case(QSPIMode.PutX1, QSPIMode.GetX1, QSPIMode.Swap):
+                    m.d.comb += self.octets.ready.eq(cycle == 7)
+                with m.Case(QSPIMode.PutX2, QSPIMode.GetX2):
+                    m.d.comb += self.octets.ready.eq(cycle == 3)
+                with m.Case(QSPIMode.PutX4, QSPIMode.GetX4):
+                    m.d.comb += self.octets.ready.eq(cycle == 1)
+                with m.Case(QSPIMode.Dummy):
+                    m.d.comb += self.octets.ready.eq(cycle == 0)
+            m.d.sync += cycle.eq(Mux(self.octets.ready, 0, cycle + 1))
+
+        # When no chip is selected, keep clock in the idle state. The only supported `mode`
+        # in this case is `QSPIMode.Dummy`, which should be used to deassert CS# at the end of
+        # a transfer.
+        m.d.comb += self.frames.p.bypass.eq(self.octets.p.chip == 0)
+        m.d.comb += self.frames.p.port.sck.o.eq(1)  # (for bypass only)
+        m.d.comb += self.frames.p.port.sck.oe.eq(1) # (for bypass only)
+
+        rev_data = self.octets.p.data[::-1] # MSB first
+        with m.Switch(self.octets.p.mode):
+            with m.Case(QSPIMode.PutX1, QSPIMode.Swap):
+                m.d.comb += self.frames.p.port.io0.o.eq(rev_data.word_select(cycle, 1))
+                m.d.comb += self.frames.p.port.io0.oe.eq(0b1)
+                m.d.comb += self.frames.p.i_en.eq(self.octets.p.mode == QSPIMode.Swap)
+            with m.Case(QSPIMode.GetX1):
+                m.d.comb += self.frames.p.port.io0.oe.eq(0b1)
+                m.d.comb += self.frames.p.i_en.eq(1)
+            with m.Case(QSPIMode.PutX2):
+                m.d.comb += Cat(self.frames.p.port.io1.o,
+                                self.frames.p.port.io0.o).eq(rev_data.word_select(cycle, 2))
+                m.d.comb += Cat(self.frames.p.port.io1.oe,
+                                self.frames.p.port.io0.oe).eq(0b11)
+            with m.Case(QSPIMode.GetX2):
+                m.d.comb += self.frames.p.i_en.eq(1)
+            with m.Case(QSPIMode.PutX4):
+                m.d.comb += Cat(self.frames.p.port.io3.o,
+                                self.frames.p.port.io2.o,
+                                self.frames.p.port.io1.o,
+                                self.frames.p.port.io0.o).eq(rev_data.word_select(cycle, 4))
+                m.d.comb += Cat(self.frames.p.port.io3.oe,
+                                self.frames.p.port.io2.oe,
+                                self.frames.p.port.io1.oe,
+                                self.frames.p.port.io0.oe).eq(0b1111)
+            with m.Case(QSPIMode.GetX4):
+                m.d.comb += self.frames.p.i_en.eq(1)
+        m.d.comb += self.frames.p.port.cs.o.eq((1 << self.octets.p.chip)[1:])
+        m.d.comb += self.frames.p.port.cs.oe.eq(1)
+        m.d.comb += self.frames.p.meta.eq(self.octets.p.mode)
+
+        return m
+
+
+class QSPIDeframer(wiring.Component): # meow :3
+    def __init__(self):
+        super().__init__({
+            "frames": In(IOStreamer.i_stream_signature({
+                "io0": ("io", 1),
+                "io1": ("io", 1),
+                "io2": ("io", 1),
+                "io3": ("io", 1),
+            }, meta_layout=QSPIMode)),
+            "octets": Out(stream.Signature(data.StructLayout({
+                "data": 8,
+            }))),
+        })
+
+    def elaborate(self, platform):
+        m = Module()
+
+        cycle = Signal(range(8))
+        m.d.comb += self.frames.ready.eq(~self.octets.valid | self.octets.ready)
+        with m.If(self.frames.valid):
+            with m.Switch(self.frames.p.meta):
+                with m.Case(QSPIMode.GetX1, QSPIMode.Swap):
+                    m.d.comb += self.octets.valid.eq(cycle == 7)
+                with m.Case(QSPIMode.GetX2):
+                    m.d.comb += self.octets.valid.eq(cycle == 3)
+                with m.Case(QSPIMode.GetX4):
+                    m.d.comb += self.octets.valid.eq(cycle == 1)
+            with m.If(self.frames.ready):
+                m.d.sync += cycle.eq(Mux(self.octets.valid, 0, cycle + 1))
+
+        data_reg = Signal(8)
+        with m.Switch(self.frames.p.meta):
+            with m.Case(QSPIMode.GetX1, QSPIMode.Swap): # note: samples IO1
+                m.d.comb += self.octets.p.data.eq(Cat(self.frames.p.port.io1.i, data_reg))
+            with m.Case(QSPIMode.GetX2):
+                m.d.comb += self.octets.p.data.eq(Cat(self.frames.p.port.io0.i,
+                                                      self.frames.p.port.io1.i, data_reg))
+            with m.Case(QSPIMode.GetX4):
+                m.d.comb += self.octets.p.data.eq(Cat(self.frames.p.port.io0.i,
+                                                      self.frames.p.port.io1.i,
+                                                      self.frames.p.port.io2.i,
+                                                      self.frames.p.port.io3.i, data_reg))
+        with m.If(self.frames.valid & self.frames.ready):
+            m.d.sync += data_reg.eq(self.octets.p.data)
+
+        return m
+
+
+class QSPIController(wiring.Component):
+    def __init__(self, ports, *, chip_count=1, use_ddr_buffers=False):
+        assert len(ports.sck) == 1 and ports.sck.direction in (io.Direction.Output, io.Direction.Bidir)
+        assert len(ports.io) == 4 and ports.io.direction == io.Direction.Bidir
+        assert len(ports.cs) >= 1 and ports.cs.direction in (io.Direction.Output, io.Direction.Bidir)
+
+        self._ports = PortGroup(
+            sck=ports.sck,
+            io0=ports.io[0],
+            io1=ports.io[1],
+            io2=ports.io[2],
+            io3=ports.io[3],
+            cs=~ports.cs,
+        )
+        self._ddr = use_ddr_buffers
+
+        super().__init__({
+            "o_octets": In(stream.Signature(data.StructLayout({
+                "chip": range(1 + chip_count),
+                "mode": QSPIMode,
+                "data": 8
+            }))),
+            "i_octets": Out(stream.Signature(data.StructLayout({
+                "data": 8
+            }))),
+
+            "divisor": In(16),
+        })
+
+    def elaborate(self, platform):
+        ratio = (2 if self._ddr else 1)
+        ioshape = {
+            "sck": ("o",  1),
+            "io0": ("io", 1),
+            "io1": ("io", 1),
+            "io2": ("io", 1),
+            "io3": ("io", 1),
+            "cs":  ("o",  len(self._ports.cs)),
+        }
+
+        m = Module()
+
+        m.submodules.enframer = enframer = QSPIEnframer()
+        connect(m, controller=flipped(self.o_octets), enframer=enframer.octets)
+
+        m.submodules.io_clocker = io_clocker = IOClocker(ioshape,
+            clock="sck", o_ratio=ratio, meta_layout=QSPIMode)
+        connect(m, enframer=enframer.frames, io_clocker=io_clocker.i_stream)
+        m.d.comb += io_clocker.divisor.eq(self.divisor)
+
+        m.submodules.io_streamer = io_streamer = IOStreamer(ioshape, self._ports, init={
+            "sck": {"o": 1, "oe": 1}, # Motorola "Mode 3" with clock idling high
+            "cs":  {"o": 0, "oe": 1}, # deselected
+        }, ratio=ratio, meta_layout=QSPIMode)
+        connect(m, io_clocker=io_clocker.o_stream, io_streamer=io_streamer.o_stream)
+
+        m.submodules.deframer = deframer = QSPIDeframer()
+        m.d.comb += [ # connect() wouldn't work if DDR buffers are used
+            deframer.frames.p.port.io0.i.eq(io_streamer.i_stream.p.port.io0.i[0]),
+            deframer.frames.p.port.io1.i.eq(io_streamer.i_stream.p.port.io1.i[0]),
+            deframer.frames.p.port.io2.i.eq(io_streamer.i_stream.p.port.io2.i[0]),
+            deframer.frames.p.port.io3.i.eq(io_streamer.i_stream.p.port.io3.i[0]),
+            deframer.frames.p.meta.eq(io_streamer.i_stream.p.meta),
+            deframer.frames.valid.eq(io_streamer.i_stream.valid),
+            io_streamer.i_stream.ready.eq(deframer.frames.ready),
+        ]
+
+        connect(m, deframer=deframer.octets, controller=flipped(self.i_octets))
+
+        return m

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -90,6 +90,7 @@ jtag-probe = "glasgow.applet.interface.jtag_probe:JTAGProbeApplet"
 jtag-openocd = "glasgow.applet.interface.jtag_openocd:JTAGOpenOCDApplet"
 jtag-svf = "glasgow.applet.interface.jtag_svf:JTAGSVFApplet"
 ps2-host = "glasgow.applet.interface.ps2_host:PS2HostApplet"
+qspi-controller = "glasgow.applet.interface.qspi_controller:QSPIControllerApplet"
 sbw-probe = "glasgow.applet.interface.sbw_probe:SpyBiWireProbeApplet"
 swd-openocd = "glasgow.applet.interface.swd_openocd:SWDOpenOCDApplet"
 

--- a/software/tests/gateware/test_iostream.py
+++ b/software/tests/gateware/test_iostream.py
@@ -1,0 +1,158 @@
+import unittest
+from amaranth import *
+from amaranth.sim import Simulator
+from amaranth.lib import io
+
+from glasgow.gateware.ports import PortGroup
+from glasgow.gateware.iostream import IOStreamer
+
+
+class IOStreamTestCase(unittest.TestCase):
+    def test_basic(self):
+        ports = PortGroup()
+        ports.data = port = io.SimulationPort("io", 1)
+
+        dut = IOStreamer({
+            "data": ("io", 1),
+        }, ports, meta_layout=4)
+
+        async def testbench(ctx):
+            await ctx.tick()
+
+            ctx.set(dut.o_stream.p.port.data.o[0], 1)
+            ctx.set(dut.o_stream.p.port.data.oe, 0)
+            ctx.set(dut.o_stream.p.i_en, 1)
+            ctx.set(dut.o_stream.p.meta, 1)
+            ctx.set(dut.o_stream.valid, 1)
+            ctx.set(dut.i_stream.ready, 1)
+            await ctx.tick()
+            assert ctx.get(port.o[0]) == 1
+            assert ctx.get(port.oe) == 0
+            assert ctx.get(dut.i_stream.valid) == 0
+
+            ctx.set(dut.o_stream.p.port.data.oe, 1)
+            ctx.set(dut.o_stream.p.meta, 2)
+            await ctx.tick()
+            assert ctx.get(port.o[0]) == 1
+            assert ctx.get(port.oe) == 1
+            assert ctx.get(dut.i_stream.valid) == 1
+            assert ctx.get(dut.i_stream.p.port.data.i[0]) == 0
+            assert ctx.get(dut.i_stream.p.meta) == 1
+
+            ctx.set(dut.o_stream.p.port.data.o[0], 0)
+            ctx.set(dut.o_stream.p.i_en, 0)
+            await ctx.tick()
+            assert ctx.get(port.o[0]) == 0
+            assert ctx.get(port.oe) == 1
+            assert ctx.get(dut.i_stream.valid) == 1
+            assert ctx.get(dut.i_stream.p.port.data.i[0]) == 1
+            assert ctx.get(dut.i_stream.p.meta) == 2
+
+            ctx.set(dut.o_stream.valid, 0)
+            await ctx.tick()
+            assert ctx.get(dut.i_stream.valid) == 0
+
+            await ctx.tick()
+            assert ctx.get(dut.i_stream.valid) == 0
+
+        sim = Simulator(dut)
+        sim.add_clock(1e-6)
+        sim.add_testbench(testbench)
+        with sim.write_vcd("test.vcd", fs_per_delta=1):
+            sim.run()
+
+    def test_skid(self):
+        ports = PortGroup()
+        ports.data = port = io.SimulationPort("io", 4)
+
+        dut = IOStreamer({
+            "data": ("io", 4),
+        }, ports, meta_layout=4)
+
+        async def testbench(ctx):
+            await ctx.tick()
+
+            ctx.set(dut.o_stream.valid, 1)
+            ctx.set(dut.o_stream.p.i_en, 1)
+
+            _, _, o_stream_ready, i_stream_valid = \
+                await ctx.tick().sample(dut.o_stream.ready, dut.i_stream.valid)
+            assert o_stream_ready == 0
+            assert i_stream_valid == 0
+
+            _, _, o_stream_ready, i_stream_valid = \
+                await ctx.tick().sample(dut.o_stream.ready, dut.i_stream.valid)
+            assert o_stream_ready == 0
+            assert i_stream_valid == 0
+
+            ctx.set(dut.o_stream.p.meta, 0b0101)
+            ctx.set(dut.i_stream.ready, 1)
+            assert ctx.get(dut.o_stream.ready) == 1
+            _, _, o_stream_ready, i_stream_valid = \
+                await ctx.tick().sample(dut.o_stream.ready, dut.i_stream.valid)
+            assert o_stream_ready == 1
+            assert i_stream_valid == 0
+
+            ctx.set(dut.o_stream.p.meta, 0b1100)
+            ctx.set(port.i, 0b0101)
+            _, _, o_stream_ready, i_stream_valid = \
+                await ctx.tick().sample(dut.o_stream.ready, dut.i_stream.valid)
+            assert o_stream_ready == 1
+            assert i_stream_valid == 0
+            ctx.set(dut.i_stream.ready, 0)
+            assert ctx.get(dut.o_stream.ready) == 0
+
+            ctx.set(port.i, 0b1100)
+            _, _, o_stream_ready, i_stream_valid, i_stream_p = \
+                await ctx.tick().sample(dut.o_stream.ready, dut.i_stream.valid, dut.i_stream.p)
+            assert o_stream_ready == 0
+            assert i_stream_valid == 1
+            assert i_stream_p.port.data.i == 0b0101, f"{i_stream_p.i:#06b}"
+            assert i_stream_p.meta == 0b0101, f"{i_stream_p.meta:#06b}"
+
+            _, _, o_stream_ready, i_stream_valid, i_stream_p = \
+                await ctx.tick().sample(dut.o_stream.ready, dut.i_stream.valid, dut.i_stream.p)
+            assert o_stream_ready == 0
+            assert i_stream_valid == 1
+            assert i_stream_p.port.data.i == 0b0101, f"{i_stream_p.i:#06b}"
+            assert i_stream_p.meta == 0b0101, f"{i_stream_p.meta:#06b}"
+
+            ctx.set(dut.i_stream.ready, 1)
+            _, _, o_stream_ready, i_stream_valid, i_stream_p = \
+                await ctx.tick().sample(dut.o_stream.ready, dut.i_stream.valid, dut.i_stream.p)
+            assert o_stream_ready == 0
+            assert i_stream_valid == 1
+            assert i_stream_p.port.data.i == 0b0101, f"{i_stream_p.i:#06b}"
+            assert i_stream_p.meta == 0b0101, f"{i_stream_p.meta:#06b}"
+
+            ctx.set(dut.o_stream.p.meta, 0b1001)
+            _, _, o_stream_ready, i_stream_valid, i_stream_p = \
+                await ctx.tick().sample(dut.o_stream.ready, dut.i_stream.valid, dut.i_stream.p)
+            assert o_stream_ready == 0
+            assert i_stream_valid == 1
+            assert i_stream_p.port.data.i == 0b1100, f"{i_stream_p.i:#06b}"
+            assert i_stream_p.meta == 0b1100, f"{i_stream_p.meta:#06b}"
+
+            _, _, o_stream_ready, i_stream_valid, i_stream_p = \
+                await ctx.tick().sample(dut.o_stream.ready, dut.i_stream.valid, dut.i_stream.p)
+            assert o_stream_ready == 1
+            assert i_stream_valid == 0
+
+            ctx.set(port.i, 0b1001)
+            _, _, o_stream_ready, i_stream_valid, i_stream_p = \
+                await ctx.tick().sample(dut.o_stream.ready, dut.i_stream.valid, dut.i_stream.p)
+            assert o_stream_ready == 1
+            assert i_stream_valid == 0
+
+            _, _, o_stream_ready, i_stream_valid, i_stream_p = \
+                await ctx.tick().sample(dut.o_stream.ready, dut.i_stream.valid, dut.i_stream.p)
+            assert o_stream_ready == 1
+            assert i_stream_valid == 1
+            assert i_stream_p.port.data.i == 0b1001, f"{i_stream_p.i:#06b}"
+            assert i_stream_p.meta == 0b1001, f"{i_stream_p.meta:#06b}"
+
+        sim = Simulator(dut)
+        sim.add_clock(1e-6)
+        sim.add_testbench(testbench)
+        with sim.write_vcd("test.vcd", fs_per_delta=1):
+            sim.run()

--- a/software/tests/gateware/test_qspi.py
+++ b/software/tests/gateware/test_qspi.py
@@ -1,0 +1,319 @@
+import unittest
+from amaranth import *
+from amaranth.sim import Simulator
+from amaranth.lib import io
+
+from glasgow.gateware.ports import PortGroup
+from glasgow.gateware.qspi import *
+
+
+async def stream_get(ctx, stream):
+    ctx.set(stream.ready, 1)
+    payload, = await ctx.tick().sample(stream.payload).until(stream.valid)
+    ctx.set(stream.ready, 0)
+    return payload
+
+
+async def stream_put(ctx, stream, payload):
+    ctx.set(stream.payload, payload)
+    ctx.set(stream.valid, 1)
+    await ctx.tick().until(stream.ready)
+    ctx.set(stream.valid, 0)
+
+
+def simulate_flash(ports, memory=b"nya nya nya nya nyaaaaan"):
+    class CSDeasserted(Exception):
+        pass
+
+    async def watch_cs(cs_o, triggers):
+        *values, cs_o = await triggers.sample(cs_o)
+        if cs_o == 1:
+            raise CSDeasserted
+        return values
+
+    async def dev_get(ctx, ports, *, x):
+        sck, io0, io1, io2, io3, cs = ports.sck, *ports.io, ports.cs
+        word = 0
+        for _ in range(0, 8, x):
+            if ctx.get(sck.o):
+                await watch_cs(cs.o, ctx.negedge(sck.o))
+            _, io0_oe, io0_o, io1_oe, io1_o, io2_oe, io2_o, io3_oe, io3_o = \
+                await watch_cs(cs.o, ctx.posedge(sck.o).sample(
+                    io0.oe, io0.o, io1.oe, io1.o, io2.oe, io2.o, io3.oe, io3.o))
+            if x == 1:
+                assert (io0_oe, io1_oe, io2_oe, io3_oe) == (1, 0, 0, 0)
+                word = (word << 1) | (io0_o << 0)
+            if x == 2:
+                assert (io0_oe, io1_oe, io2_oe, io3_oe) == (1, 1, 0, 0)
+                word = (word << 2) | (io1_o << 1) | (io0_o << 0)
+            if x == 4:
+                assert (io0_oe, io1_oe, io2_oe, io3_oe) == (1, 1, 1, 1)
+                word = (word << 4) | (io3_o << 3) | (io2_o << 2) | (io1_o << 1) | (io0_o << 0)
+        return word
+
+    async def dev_nop(ctx, ports, *, x, cycles):
+        sck, io0, io1, io2, io3, cs = ports.sck, *ports.io, ports.cs
+        for _ in range(cycles):
+            if ctx.get(sck.o):
+                await watch_cs(cs.o, ctx.negedge(sck.o))
+            _, io0_oe, io1_oe, io2_oe, io3_oe = \
+                await watch_cs(cs.o, ctx.posedge(sck.o).sample(io0.oe, io1.oe, io2.oe, io3.oe))
+            if x == 1:
+                assert (        io1_oe, io2_oe, io3_oe) == (   0, 0, 0)
+            else:
+                assert (io0_oe, io1_oe, io2_oe, io3_oe) == (0, 0, 0, 0)
+
+    async def dev_put(ctx, ports, word, *, x):
+        sck, io0, io1, io2, io3, cs = ports.sck, *ports.io, ports.cs
+        for _ in range(0, 8, x):
+            if ctx.get(sck.o):
+                await watch_cs(cs.o, ctx.negedge(sck.o))
+            if x == 1:
+                ctx.set(Cat(io1.i), (word >> 7))
+                word = (word << 1) & 0xff
+            if x == 2:
+                ctx.set(Cat(io0.i, io1.i), (word >> 6))
+                word = (word << 2) & 0xff
+            if x == 4:
+                ctx.set(Cat(io0.i, io1.i, io2.i, io3.i), (word >> 4))
+                word = (word << 4) & 0xff
+            _, io0_oe, io1_oe, io2_oe, io3_oe = \
+                await watch_cs(cs.o, ctx.posedge(sck.o).sample(io0.oe, io1.oe, io2.oe, io3.oe))
+            assert (io0_oe, io1_oe, io2_oe, io3_oe) == (x == 1, 0, 0, 0)
+
+    async def testbench(ctx):
+        await ctx.negedge(ports.cs.o)
+        while True:
+            try:
+                cmd = await dev_get(ctx, ports, x=1)
+                if cmd in (0x0B, 0x3B, 0x6B):
+                    addr2 = await dev_get(ctx, ports, x=1)
+                    addr1 = await dev_get(ctx, ports, x=1)
+                    addr0 = await dev_get(ctx, ports, x=1)
+                    if cmd == 0x0B:
+                        await dev_nop(ctx, ports, x=1, cycles=8)
+                    if cmd == 0x3B:
+                        await dev_nop(ctx, ports, x=2, cycles=4)
+                    if cmd == 0x6B:
+                        await dev_nop(ctx, ports, x=4, cycles=4)
+                    addr = (addr2 << 16) | (addr1 << 8) | (addr0 << 0)
+                    while True:
+                        if addr >= len(memory):
+                            addr = 0
+                        if cmd == 0x0B:
+                            await dev_put(ctx, ports, memory[addr], x=1)
+                        if cmd == 0x3B:
+                            await dev_put(ctx, ports, memory[addr], x=2)
+                        if cmd == 0x6B:
+                            await dev_put(ctx, ports, memory[addr], x=4)
+                        addr += 1
+            except CSDeasserted:
+                continue
+
+    return testbench
+
+
+class QSPITestCase(unittest.TestCase):
+    def test_qspi_enframer(self):
+        dut = QSPIEnframer()
+
+        async def testbench_in(ctx):
+            async def data_put(*, chip, data, mode):
+                await stream_put(ctx, dut.octets, {"chip": chip, "data": data, "mode": mode})
+
+            await data_put(chip=1, data=0xBA, mode=QSPIMode.Swap)
+
+            await data_put(chip=1, data=0xAA, mode=QSPIMode.PutX1)
+            await data_put(chip=1, data=0x55, mode=QSPIMode.PutX1)
+            await data_put(chip=1, data=0xC1, mode=QSPIMode.PutX1)
+
+            await data_put(chip=1, data=0xAA, mode=QSPIMode.PutX2)
+            await data_put(chip=1, data=0x55, mode=QSPIMode.PutX2)
+            await data_put(chip=1, data=0xC1, mode=QSPIMode.PutX2)
+
+            await data_put(chip=1, data=0xAA, mode=QSPIMode.PutX4)
+            await data_put(chip=1, data=0x55, mode=QSPIMode.PutX4)
+            await data_put(chip=1, data=0xC1, mode=QSPIMode.PutX4)
+
+            for _ in range(6):
+                await data_put(chip=1, data=0, mode=QSPIMode.Dummy)
+
+            await data_put(chip=1, data=0, mode=QSPIMode.GetX1)
+            await data_put(chip=1, data=0, mode=QSPIMode.GetX2)
+            await data_put(chip=1, data=0, mode=QSPIMode.GetX4)
+
+            await data_put(chip=0, data=0, mode=QSPIMode.Dummy)
+
+        async def testbench_out(ctx):
+            async def bits_get(*, cs, ox, oe, i_en, mode):
+                for cycle, o in enumerate(ox):
+                    expected = {
+                        "bypass": (cs == 0),
+                        "port": {
+                            "sck": {"o":        1, "oe":         1},
+                            "io0": {"o": (o>>0)&1, "oe": (oe>>0)&1},
+                            "io1": {"o": (o>>1)&1, "oe": (oe>>1)&1},
+                            "io2": {"o": (o>>2)&1, "oe": (oe>>2)&1},
+                            "io3": {"o": (o>>3)&1, "oe": (oe>>3)&1},
+                            "cs":  {"o":       cs, "oe":         1},
+                        },
+                        "i_en": i_en,
+                        "meta": mode
+                    }
+                    assert (actual := await stream_get(ctx, dut.frames)) == expected, \
+                        f"(cycle {cycle}) {actual} != {expected}"
+
+            await bits_get(cs=1, ox=[1,0,1,1,1,0,1,0], oe=1, i_en=1, mode=QSPIMode.Swap)
+
+            await bits_get(cs=1, ox=[1,0,1,0,1,0,1,0], oe=1, i_en=0, mode=QSPIMode.PutX1)
+            await bits_get(cs=1, ox=[0,1,0,1,0,1,0,1], oe=1, i_en=0, mode=QSPIMode.PutX1)
+            await bits_get(cs=1, ox=[1,1,0,0,0,0,0,1], oe=1, i_en=0, mode=QSPIMode.PutX1)
+
+            await bits_get(cs=1, ox=[0b10,0b10,0b10,0b10], oe=0b11, i_en=0, mode=QSPIMode.PutX2)
+            await bits_get(cs=1, ox=[0b01,0b01,0b01,0b01], oe=0b11, i_en=0, mode=QSPIMode.PutX2)
+            await bits_get(cs=1, ox=[0b11,0b00,0b00,0b01], oe=0b11, i_en=0, mode=QSPIMode.PutX2)
+
+            await bits_get(cs=1, ox=[0b1010,0b1010], oe=0b1111, i_en=0, mode=QSPIMode.PutX4)
+            await bits_get(cs=1, ox=[0b0101,0b0101], oe=0b1111, i_en=0, mode=QSPIMode.PutX4)
+            await bits_get(cs=1, ox=[0b1100,0b0001], oe=0b1111, i_en=0, mode=QSPIMode.PutX4)
+
+            await bits_get(cs=1, ox=[0,0,0,0,0,0], oe=0, i_en=0, mode=QSPIMode.Dummy)
+
+            await bits_get(cs=1, ox=[0,0,0,0,0,0,0,0], oe=1, i_en=1, mode=QSPIMode.GetX1)
+            await bits_get(cs=1, ox=[0,0,0,0],         oe=0, i_en=1, mode=QSPIMode.GetX2)
+            await bits_get(cs=1, ox=[0,0],             oe=0, i_en=1, mode=QSPIMode.GetX4)
+
+            await bits_get(cs=0, ox=[0], oe=0, i_en=0, mode=QSPIMode.Dummy)
+
+        sim = Simulator(dut)
+        sim.add_clock(1e-6)
+        sim.add_testbench(testbench_in)
+        sim.add_testbench(testbench_out)
+        with sim.write_vcd("test.vcd"):
+            sim.run()
+
+    def test_qspi_deframer(self):
+        dut = QSPIDeframer()
+
+        async def testbench_in(ctx):
+            async def bits_put(*, ix, mode):
+                for cycle, i in enumerate(ix):
+                    await stream_put(ctx, dut.frames, {
+                        "port": {
+                            "io0": {"i": (i>>0)&1},
+                            "io1": {"i": (i>>1)&1},
+                            "io2": {"i": (i>>2)&1},
+                            "io3": {"i": (i>>3)&1},
+                        },
+                        "meta": mode
+                    })
+
+            await bits_put(ix=[i<<1 for i in [1,0,1,1,1,0,1,0]], mode=QSPIMode.Swap)
+
+            await bits_put(ix=[i<<1 for i in [1,0,1,0,1,0,1,0]], mode=QSPIMode.GetX1)
+            await bits_put(ix=[i<<1 for i in [0,1,0,1,0,1,0,1]], mode=QSPIMode.GetX1)
+            await bits_put(ix=[i<<1 for i in [1,1,0,0,0,0,0,1]], mode=QSPIMode.GetX1)
+
+            await bits_put(ix=[0b10,0b10,0b10,0b10], mode=QSPIMode.GetX2)
+            await bits_put(ix=[0b01,0b01,0b01,0b01], mode=QSPIMode.GetX2)
+            await bits_put(ix=[0b11,0b00,0b00,0b01], mode=QSPIMode.GetX2)
+
+            await bits_put(ix=[0b1010,0b1010], mode=QSPIMode.GetX4)
+            await bits_put(ix=[0b0101,0b0101], mode=QSPIMode.GetX4)
+            await bits_put(ix=[0b1100,0b0001], mode=QSPIMode.GetX4)
+
+        async def testbench_out(ctx):
+            async def data_get(*, data):
+                expected = {"data": data}
+                assert (actual := await stream_get(ctx, dut.octets)) == expected, \
+                    f"{actual} != {expected}; data: {actual.data:08b} != {data:08b}"
+
+            await data_get(data=0xBA)
+
+            await data_get(data=0xAA)
+            await data_get(data=0x55)
+            await data_get(data=0xC1)
+
+            await data_get(data=0xAA)
+            await data_get(data=0x55)
+            await data_get(data=0xC1)
+
+            await data_get(data=0xAA)
+            await data_get(data=0x55)
+            await data_get(data=0xC1)
+
+        sim = Simulator(dut)
+        sim.add_clock(1e-6)
+        sim.add_testbench(testbench_in)
+        sim.add_testbench(testbench_out)
+        with sim.write_vcd("test.vcd"):
+            sim.run()
+
+    def test_qspi_controller(self):
+        ports = PortGroup()
+        ports.sck = io.SimulationPort("o",  1)
+        ports.io  = io.SimulationPort("io", 4)
+        ports.cs  = io.SimulationPort("o",  1)
+
+        dut = QSPIController(ports)
+
+        async def testbench_controller(ctx):
+            async def ctrl_idle():
+                await stream_put(ctx, dut.o_octets, {"chip": 0, "data": 0, "mode": QSPIMode.Dummy})
+
+            async def ctrl_put(*, mode, data=0):
+                await stream_put(ctx, dut.o_octets, {"chip": 1, "data": data, "mode": mode})
+
+            async def ctrl_get(*, mode, count=1):
+                ctx.set(dut.o_octets.p.chip, 1)
+                ctx.set(dut.o_octets.p.mode, mode)
+                ctx.set(dut.o_octets.valid, 1)
+                ctx.set(dut.i_octets.ready, 1)
+                words = bytearray()
+                o_count = i_count = 0
+                while True:
+                    _, _, o_octets_ready, i_octets_valid, i_octets_p_data = \
+                        await ctx.tick().sample(
+                            dut.o_octets.ready, dut.i_octets.valid, dut.i_octets.p.data)
+                    if o_octets_ready:
+                        o_count += 1
+                        if o_count == count:
+                            ctx.set(dut.o_octets.valid, 0)
+                    if i_octets_valid:
+                        words.append(i_octets_p_data)
+                        if len(words) == count:
+                            ctx.set(dut.i_octets.ready, 0)
+                            assert not ctx.get(dut.o_octets.valid)
+                            break
+                return words
+
+            await ctrl_idle()
+
+            await ctrl_put(mode=QSPIMode.PutX1, data=0x0B)
+            await ctrl_put(mode=QSPIMode.PutX1, data=0x00)
+            await ctrl_put(mode=QSPIMode.PutX1, data=0x00)
+            await ctrl_put(mode=QSPIMode.PutX1, data=0x08)
+            for _ in range(8):
+                await ctrl_put(mode=QSPIMode.Dummy)
+            assert (data := await ctrl_get(mode=QSPIMode.GetX1, count=4)) == b"awa!", data
+
+            await ctrl_idle()
+
+            await ctrl_put(mode=QSPIMode.PutX1, data=0x6B)
+            await ctrl_put(mode=QSPIMode.PutX1, data=0x00)
+            await ctrl_put(mode=QSPIMode.PutX1, data=0x00)
+            await ctrl_put(mode=QSPIMode.PutX1, data=0x10)
+            for _ in range(4):
+                await ctrl_put(mode=QSPIMode.Dummy)
+            assert (data := await ctrl_get(mode=QSPIMode.GetX4, count=8)) == b"nyaaaaan", data
+
+            await ctrl_idle()
+
+        testbench_flash = simulate_flash(ports, memory=b"nya nya awa!nya nyaaaaan")
+
+        sim = Simulator(dut)
+        sim.add_clock(1e-6)
+        sim.add_testbench(testbench_controller)
+        sim.add_testbench(testbench_flash, background=True)
+        with sim.write_vcd("test.vcd"):
+            sim.run()


### PR DESCRIPTION
Remaining work:
- [x] wait for upstream issues to be resolved in amaranth 0.5.1
  - https://github.com/amaranth-lang/amaranth/issues/1418
  - https://github.com/amaranth-lang/amaranth/issues/1405
  - https://github.com/amaranth-lang/amaranth/issues/1417
  - https://github.com/amaranth-lang/amaranth/issues/1414
  - https://github.com/amaranth-lang/amaranth/pull/1448
- [ ] address FIXMEs
  - [ ] `# FIXME: should this be 2 or 3? the latency differs between i[0] and i[1]` (IOStream)
  - [x] `# FIXME: needs new name and location` (Downscaler)
  - [x] `# FIXME: i_stream/o_stream or fast/slow? [io]_stream has opposite meaning of IOStream` (Downscaler)
- [x] add local `SimulationPort` to make `IOStream` tests pass
- [x] put IOStream into its own file under `glasgow.gateware`?
- [x] add chunking to all commands
- [x] `with iface.select()`?
- [x] support for lowering SCK frequency
- [x] support for setting SCK frequency from CLI
- [x] support for delays
- [x] support for synchronization
- [x] kill or replace `iface.transfer`
- [x] some default `interact` implementation, like for spi-controller?
- [x] order pins as `sck`, `ioN`, `cs` (for convenience of multiple `cs`)
- [x] commit tests to repo
- [x] reduce redundancy in get/put/swap/dummy stream transfer implementations
- [x] port `memory-25x` to this applet (even without adding new commands)
  - [x] deprecate and remove `hold_ss` first, maybe? https://github.com/GlasgowEmbedded/glasgow/pull/626
  - [x] `memory-25x` does not drive the bus when CS# is deasserted
    - happens inherently for IOx, but was enabled explicitly for SCK
  - ~~`memory-25x` makes IO2/IO3 optional~~
    - for now IO2/IO3 become mandatory