### PR TITLE
Enable the use of Amaranth 0.5 new I/O

### DIFF
--- a/examples/boilerplate.py
+++ b/examples/boilerplate.py
@@ -44,7 +44,7 @@ class BoilerplateApplet(GlasgowApplet):
     def build(self, target, args):
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
         iface.add_subtarget(BoilerplateSubtarget(
-            pads=iface.get_pads(args, pins=self.__pins),
+            pads=iface.get_deprecated_pads(args, pins=self.__pins),
             in_fifo=iface.get_in_fifo(),
             out_fifo=iface.get_out_fifo(),
         ))

--- a/software/glasgow/access/__init__.py
+++ b/software/glasgow/access/__init__.py
@@ -148,19 +148,9 @@ class AccessDemultiplexerInterface(metaclass=ABCMeta):
     async def read(self, length=None, *, flush=True):
         pass
 
-    async def read_str(self, *args, encoding="utf-8", **kwargs):
-        result = await self.read(*args, **kwargs)
-        if result is None:
-            return None
-        else:
-            return result.decode(encoding)
-
     @abstractmethod
     async def write(self, data):
         pass
-
-    async def write_str(self, data, *args, encoding="utf-8", **kwargs):
-        await self.write(data.encode(encoding), *args, **kwargs)
 
     @abstractmethod
     async def flush(self, wait=True):

--- a/software/glasgow/access/__init__.py
+++ b/software/glasgow/access/__init__.py
@@ -65,6 +65,10 @@ class AccessMultiplexerInterface(Elaboratable, metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def get_port(self, pin, *, name):
+        pass
+
+    @abstractmethod
     def _build_pad_tristate(self, pin, oe, o, i):
         pass
 

--- a/software/glasgow/access/direct/multiplexer.py
+++ b/software/glasgow/access/direct/multiplexer.py
@@ -165,7 +165,7 @@ class DirectMultiplexerInterface(AccessMultiplexerInterface):
         self._throttle      = throttle
         self._subtargets    = []
         self._fifos         = []
-        self._pin_tristates = []
+        self._pad_tristates = []
 
         self.reset, self._addr_reset = self._registers.add_rw(1, init=1)
         self.logger.debug("adding reset register at address %#04x", self._addr_reset)
@@ -183,7 +183,7 @@ class DirectMultiplexerInterface(AccessMultiplexerInterface):
 
             m.submodules += fifo
 
-        for pin_parts, oe, o, i in self._pin_tristates:
+        for pin_parts, oe, o, i in self._pad_tristates:
             m.submodules += (io_buffer := io.Buffer("io", pin_parts.io))
             m.d.comb += [
                 io_buffer.oe.eq(oe),
@@ -200,10 +200,10 @@ class DirectMultiplexerInterface(AccessMultiplexerInterface):
         port, bit, req = self._pins[pin_num]
         return f"{port}{bit}"
 
-    def build_pin_tristate(self, pin_num, oe, o, i):
+    def _build_pad_tristate(self, pin_num, oe, o, i):
         port, bit, req = self._pins[pin_num]
         pin_parts = req(bit)
-        self._pin_tristates.append((pin_parts, oe, o, i))
+        self._pad_tristates.append((pin_parts, oe, o, i))
 
     def get_in_fifo(self, **kwargs):
         fifo = self._fx2_crossbar.get_in_fifo(self._pipe_num, **kwargs, reset=self.reset)

--- a/software/glasgow/access/direct/multiplexer.py
+++ b/software/glasgow/access/direct/multiplexer.py
@@ -174,8 +174,6 @@ class DirectMultiplexerInterface(AccessMultiplexerInterface):
         m = Module()
 
         m.submodules += self._subtargets
-        if self.pads is not None:
-            m.submodules.pads = self.pads
 
         for fifo in self._fifos:
             if self._throttle == "full":

--- a/software/glasgow/access/simulation/multiplexer.py
+++ b/software/glasgow/access/simulation/multiplexer.py
@@ -109,9 +109,6 @@ class SimulationMultiplexerInterface(AccessMultiplexerInterface):
             crossbar_side="write", logic_side="read", cd_logic=clock_domain, depth=depth)
         return self.out_fifo
 
-    def get_inout_fifo(self, **kwargs):
-        return self.get_in_fifo(**kwargs), self.get_out_fifo(**kwargs)
-
     def add_subtarget(self, subtarget):
         self._subtargets.append(subtarget)
         return subtarget

--- a/software/glasgow/access/simulation/multiplexer.py
+++ b/software/glasgow/access/simulation/multiplexer.py
@@ -75,6 +75,9 @@ class SimulationMultiplexerInterface(AccessMultiplexerInterface):
     def get_pin_name(self, pin):
         return str(pin)
 
+    def get_port(self, pin, *, name):
+        raise NotImplementedError
+
     def _build_pad_tristate(self, pin, oe, o, i):
         pass
 

--- a/software/glasgow/access/simulation/multiplexer.py
+++ b/software/glasgow/access/simulation/multiplexer.py
@@ -75,7 +75,7 @@ class SimulationMultiplexerInterface(AccessMultiplexerInterface):
     def get_pin_name(self, pin):
         return str(pin)
 
-    def build_pin_tristate(self, pin, oe, o, i):
+    def _build_pad_tristate(self, pin, oe, o, i):
         pass
 
     def _make_fifo(self, crossbar_side, logic_side, cd_logic, depth, wrapper=lambda x: x):

--- a/software/glasgow/access/simulation/multiplexer.py
+++ b/software/glasgow/access/simulation/multiplexer.py
@@ -65,8 +65,6 @@ class SimulationMultiplexerInterface(AccessMultiplexerInterface):
         m = Module()
 
         m.submodules += self._subtargets
-        if self.pads is not None:
-            m.submodules.pads = self.pads
         if self.in_fifo is not None:
             m.submodules.in_fifo = self.in_fifo
         if self.out_fifo is not None:

--- a/software/glasgow/applet/__init__.py
+++ b/software/glasgow/applet/__init__.py
@@ -116,7 +116,7 @@ from ..target.hardware import *
 from ..device.simulation import *
 from ..device.hardware import *
 from ..target.toolchain import find_toolchain
-from ..platform.all import GlasgowPlatformRevAB
+from ..platform.rev_ab import GlasgowPlatformRevAB
 
 
 __all__ += ["GlasgowAppletTestCase", "synthesis_test", "applet_simulation_test",

--- a/software/glasgow/applet/__init__.py
+++ b/software/glasgow/applet/__init__.py
@@ -116,7 +116,7 @@ from ..target.hardware import *
 from ..device.simulation import *
 from ..device.hardware import *
 from ..target.toolchain import find_toolchain
-from ..platform.rev_ab import GlasgowPlatformRevAB
+from ..platform.rev_ab import GlasgowRevABPlatform
 
 
 __all__ += ["GlasgowAppletTestCase", "synthesis_test", "applet_simulation_test",
@@ -293,7 +293,7 @@ class GlasgowAppletTestCase(unittest.TestCase):
             await self.device.download_target(self.target.build_plan())
         else:
             # avoid UnusedElaboratable warning
-            Fragment.get(self.target, GlasgowPlatformRevAB())
+            Fragment.get(self.target, GlasgowRevABPlatform())
 
         return await self.applet.run(self.device, self._parsed_args)
 

--- a/software/glasgow/applet/audio/dac/__init__.py
+++ b/software/glasgow/applet/audio/dac/__init__.py
@@ -183,7 +183,7 @@ class AudioDACApplet(GlasgowApplet):
             # the oscillator on the board is imprecise, and with no additional error.
             max_deviation_ppm=0)
         subtarget = iface.add_subtarget(AudioDACSubtarget(
-            pads=iface.get_pads(args, pin_sets=self.__pin_sets),
+            pads=iface.get_deprecated_pads(args, pin_sets=self.__pin_sets),
             out_fifo=iface.get_out_fifo(),
             pulse_cyc=pulse_cyc,
             sample_cyc=sample_cyc,

--- a/software/glasgow/applet/audio/yamaha_opx/__init__.py
+++ b/software/glasgow/applet/audio/yamaha_opx/__init__.py
@@ -1112,7 +1112,7 @@ class AudioYamahaOPxApplet(GlasgowApplet):
 
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
         subtarget = iface.add_subtarget(YamahaOPxSubtarget(
-            pads=iface.get_pads(args, pins=self.__pins, pin_sets=self.__pin_sets),
+            pads=iface.get_deprecated_pads(args, pins=self.__pins, pin_sets=self.__pin_sets),
             out_fifo=iface.get_out_fifo(),
             in_fifo=iface.get_in_fifo(auto_flush=False),
             sample_decoder_cls=device_iface_cls.sample_decoder,

--- a/software/glasgow/applet/control/servo/__init__.py
+++ b/software/glasgow/applet/control/servo/__init__.py
@@ -195,7 +195,7 @@ class ControlServoApplet(GlasgowApplet):
     def build(self, target, args):
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
         iface.add_subtarget(ControlServoSubtarget(
-            pads=iface.get_pads(args, pins=("out",)),
+            pads=iface.get_deprecated_pads(args, pins=("out",)),
             out_fifo=iface.get_out_fifo(),
         ))
 

--- a/software/glasgow/applet/display/hd44780/__init__.py
+++ b/software/glasgow/applet/display/hd44780/__init__.py
@@ -218,7 +218,7 @@ class DisplayHD44780Applet(GlasgowApplet):
     def build(self, target, args):
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
         iface.add_subtarget(HD44780Subtarget(
-            pads=iface.get_pads(args, pins=("rs", "rw", "e"), pin_sets=("d",)),
+            pads=iface.get_deprecated_pads(args, pins=("rs", "rw", "e"), pin_sets=("d",)),
             out_fifo=iface.get_out_fifo(),
             in_fifo=iface.get_in_fifo(),
             sys_clk_freq=target.sys_clk_freq,

--- a/software/glasgow/applet/display/pdi/__init__.py
+++ b/software/glasgow/applet/display/pdi/__init__.py
@@ -389,7 +389,7 @@ class DisplayPDIApplet(GlasgowApplet):
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
 
         controller = SPIControllerSubtarget(
-            pads=iface.get_pads(args, pins=self.__pins + self.__pins_g1),
+            pads=iface.get_deprecated_pads(args, pins=self.__pins + self.__pins_g1),
             out_fifo=iface.get_out_fifo(),
             in_fifo=iface.get_in_fifo(auto_flush=False),
             period_cyc=math.ceil(target.sys_clk_freq / 5e6),

--- a/software/glasgow/applet/interface/analyzer/__init__.py
+++ b/software/glasgow/applet/interface/analyzer/__init__.py
@@ -61,7 +61,7 @@ class AnalyzerApplet(GlasgowApplet):
     def build(self, target, args):
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
         subtarget = iface.add_subtarget(AnalyzerSubtarget(
-            pads=iface.get_pads(args, pin_sets=("i",)),
+            pads=iface.get_deprecated_pads(args, pin_sets=("i",)),
             in_fifo=iface.get_in_fifo(),
         ))
 

--- a/software/glasgow/applet/interface/i2c_initiator/__init__.py
+++ b/software/glasgow/applet/interface/i2c_initiator/__init__.py
@@ -286,7 +286,7 @@ class I2CInitiatorApplet(GlasgowApplet):
     def build(self, target, args):
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
         iface.add_subtarget(I2CInitiatorSubtarget(
-            pads=iface.get_pads(args, pins=self.__pins),
+            pads=iface.get_deprecated_pads(args, pins=self.__pins),
             out_fifo=iface.get_out_fifo(),
             in_fifo=iface.get_in_fifo(),
             period_cyc=math.ceil(target.sys_clk_freq / (args.bit_rate * 1000))

--- a/software/glasgow/applet/interface/i2c_target/__init__.py
+++ b/software/glasgow/applet/interface/i2c_target/__init__.py
@@ -223,7 +223,7 @@ class I2CTargetApplet(GlasgowApplet):
     def build(self, target, args):
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
         iface.add_subtarget(I2CTargetSubtarget(
-            pads=iface.get_pads(args, pins=self.__pins),
+            pads=iface.get_deprecated_pads(args, pins=self.__pins),
             out_fifo=iface.get_out_fifo(),
             in_fifo=iface.get_in_fifo(),
             address=args.address,

--- a/software/glasgow/applet/interface/jtag_openocd/__init__.py
+++ b/software/glasgow/applet/interface/jtag_openocd/__init__.py
@@ -110,14 +110,19 @@ class JTAGOpenOCDApplet(GlasgowApplet):
     ::
         glasgow run jtag-openocd tcp:localhost:2222
         openocd -c 'adapter driver remote_bitbang; transport select jtag' \\
-            -c 'remote_bitbang port 2222'
+            -c 'remote_bitbang port 2222' \\
+            -c 'reset_config none'
 
     Usage with Unix domain sockets:
 
     ::
         glasgow run jtag-openocd unix:/tmp/jtag.sock
         openocd -c 'adapter driver remote_bitbang; transport select jtag' \\
-            -c 'remote_bitbang host /tmp/jtag.sock'
+            -c 'remote_bitbang host /tmp/jtag.sock' \\
+            -c 'reset_config none'
+
+    If you use TRST# and/or SRST# pins, the 'reset_config none' option above must be
+    replaced with 'reset_config trst', 'reset_config srst', or 'reset_config trst_and_srst'.
     """
 
     @classmethod

--- a/software/glasgow/applet/interface/jtag_openocd/__init__.py
+++ b/software/glasgow/applet/interface/jtag_openocd/__init__.py
@@ -122,7 +122,7 @@ class JTAGOpenOCDApplet(GlasgowApplet):
     def build(self, target, args):
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
         iface.add_subtarget(JTAGOpenOCDSubtarget(
-            pads=iface.get_pads(args, pins=self.__pins),
+            pads=iface.get_deprecated_pads(args, pins=self.__pins),
             out_fifo=iface.get_out_fifo(),
             in_fifo=iface.get_in_fifo(),
             period_cyc=int(target.sys_clk_freq // (args.frequency * 1000)),

--- a/software/glasgow/applet/interface/jtag_pinout/__init__.py
+++ b/software/glasgow/applet/interface/jtag_pinout/__init__.py
@@ -177,7 +177,7 @@ class JTAGPinoutApplet(GlasgowApplet):
     def build(self, target, args):
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
         iface.add_subtarget(JTAGPinoutSubtarget(
-            pins=[iface.get_pin(pin) for pin in args.pin_set_jtag],
+            pins=[iface.get_deprecated_pad(pin) for pin in args.pin_set_jtag],
             out_fifo=iface.get_out_fifo(),
             in_fifo=iface.get_in_fifo(),
             period_cyc=int(target.sys_clk_freq // (args.frequency * 1000)),

--- a/software/glasgow/applet/interface/jtag_probe/__init__.py
+++ b/software/glasgow/applet/interface/jtag_probe/__init__.py
@@ -1022,7 +1022,7 @@ class JTAGProbeApplet(GlasgowApplet):
     def build(self, target, args):
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
         iface.add_subtarget(JTAGProbeSubtarget(
-            pads=iface.get_pads(args, pins=self.__pins),
+            pads=iface.get_deprecated_pads(args, pins=self.__pins),
             out_fifo=iface.get_out_fifo(),
             in_fifo=iface.get_in_fifo(auto_flush=False),
             period_cyc=target.sys_clk_freq // (args.frequency * 1000),

--- a/software/glasgow/applet/interface/ps2_host/__init__.py
+++ b/software/glasgow/applet/interface/ps2_host/__init__.py
@@ -414,7 +414,7 @@ class PS2HostApplet(GlasgowApplet):
     def build(self, target, args):
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
         subtarget = iface.add_subtarget(PS2HostSubtarget(
-            pads=iface.get_pads(args, pins=self.__pins),
+            pads=iface.get_deprecated_pads(args, pins=self.__pins),
             in_fifo=iface.get_in_fifo(),
             out_fifo=iface.get_out_fifo(),
             inhibit_cyc=int(target.sys_clk_freq * 60e-6),

--- a/software/glasgow/applet/interface/sbw_probe/__init__.py
+++ b/software/glasgow/applet/interface/sbw_probe/__init__.py
@@ -214,7 +214,7 @@ class SpyBiWireProbeApplet(GlasgowApplet):
     def build(self, target, args):
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
         iface.add_subtarget(SpyBiWireProbeSubtarget(
-            pads=iface.get_pads(args, pins=self.__pins),
+            pads=iface.get_deprecated_pads(args, pins=self.__pins),
             out_fifo=iface.get_out_fifo(),
             in_fifo=iface.get_in_fifo(auto_flush=False),
             period_cyc=target.sys_clk_freq // (args.frequency * 1000),

--- a/software/glasgow/applet/interface/spi_controller/__init__.py
+++ b/software/glasgow/applet/interface/spi_controller/__init__.py
@@ -332,7 +332,7 @@ class SPIControllerApplet(GlasgowApplet):
     def build_subtarget(self, target, args, pins=__pins):
         iface = self.mux_interface
         return SPIControllerSubtarget(
-            pads=iface.get_pads(args, pins=pins),
+            pads=iface.get_deprecated_pads(args, pins=pins),
             out_fifo=iface.get_out_fifo(),
             in_fifo=iface.get_in_fifo(auto_flush=False),
             period_cyc=self.derive_clock(input_hz=target.sys_clk_freq,

--- a/software/glasgow/applet/interface/spi_flashrom/__init__.py
+++ b/software/glasgow/applet/interface/spi_flashrom/__init__.py
@@ -179,7 +179,7 @@ class SPIFlashromApplet(SPIControllerApplet):
     def build_subtarget(self, target, args):
         subtarget = super().build_subtarget(target, args)
         if args.pin_hold is not None:
-            hold_t = self.mux_interface.get_pin(args.pin_hold)
+            hold_t = self.mux_interface.get_deprecated_pad(args.pin_hold)
         else:
             hold_t = None
         return Memory25xSubtarget(subtarget, hold_t, args.cs_active)

--- a/software/glasgow/applet/interface/swd_openocd/__init__.py
+++ b/software/glasgow/applet/interface/swd_openocd/__init__.py
@@ -148,7 +148,7 @@ class SWDOpenOCDApplet(GlasgowApplet):
     def build(self, target, args):
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
         iface.add_subtarget(SWDOpenOCDSubtarget(
-            pads=iface.get_pads(args, pins=self.__pins),
+            pads=iface.get_deprecated_pads(args, pins=self.__pins),
             out_fifo=iface.get_out_fifo(),
             in_fifo=iface.get_in_fifo(),
             period_cyc=int(target.sys_clk_freq // (args.frequency * 1000)),

--- a/software/glasgow/applet/interface/uart/__init__.py
+++ b/software/glasgow/applet/interface/uart/__init__.py
@@ -195,7 +195,7 @@ class UARTApplet(GlasgowApplet):
 
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
         subtarget = iface.add_subtarget(UARTSubtarget(
-            pads=iface.get_pads(args, pins=self.__pins),
+            pads=iface.get_deprecated_pads(args, pins=self.__pins),
             out_fifo=iface.get_out_fifo(),
             in_fifo=iface.get_in_fifo(),
             parity=args.parity,

--- a/software/glasgow/applet/memory/_25x/__init__.py
+++ b/software/glasgow/applet/memory/_25x/__init__.py
@@ -284,7 +284,7 @@ class Memory25xApplet(SPIControllerApplet):
     def build_subtarget(self, target, args):
         subtarget = super().build_subtarget(target, args)
         if args.pin_hold is not None:
-            hold_t = self.mux_interface.get_pin(args.pin_hold)
+            hold_t = self.mux_interface.get_deprecated_pad(args.pin_hold)
         else:
             hold_t = None
         return Memory25xSubtarget(subtarget, hold_t, args.cs_active)

--- a/software/glasgow/applet/memory/floppy/__init__.py
+++ b/software/glasgow/applet/memory/floppy/__init__.py
@@ -649,7 +649,7 @@ class MemoryFloppyApplet(GlasgowApplet):
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
         self._sys_clk_freq = target.sys_clk_freq
         iface.add_subtarget(ShugartFloppySubtarget(
-            pins=iface.get_pads(pins=self.__pins, args=args),
+            pins=iface.get_deprecated_pads(pins=self.__pins, args=args),
             out_fifo=iface.get_out_fifo(),
             in_fifo=iface.get_in_fifo(auto_flush=False),
             sys_freq=target.sys_clk_freq,

--- a/software/glasgow/applet/memory/onfi/__init__.py
+++ b/software/glasgow/applet/memory/onfi/__init__.py
@@ -443,7 +443,7 @@ class MemoryONFIApplet(GlasgowApplet):
     def build(self, target, args):
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
         iface.add_subtarget(MemoryONFISubtarget(
-            pads=iface.get_pads(args, pin_sets=self.pin_sets, pins=self.pins),
+            pads=iface.get_deprecated_pads(args, pin_sets=self.pin_sets, pins=self.pins),
             in_fifo=iface.get_in_fifo(auto_flush=False),
             out_fifo=iface.get_out_fifo(),
         ))

--- a/software/glasgow/applet/memory/prom/__init__.py
+++ b/software/glasgow/applet/memory/prom/__init__.py
@@ -533,7 +533,7 @@ class MemoryPROMApplet(GlasgowApplet):
 
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
         bus = MemoryPROMBus(
-            pads=iface.get_pads(args, pins=self.__pins, pin_sets=self.__pin_sets),
+            pads=iface.get_deprecated_pads(args, pins=self.__pins, pin_sets=self.__pin_sets),
             a_bits=args.a_bits,
             sh_freq=args.shift_freq * 1e6,
         )

--- a/software/glasgow/applet/program/avr/spi/__init__.py
+++ b/software/glasgow/applet/program/avr/spi/__init__.py
@@ -233,7 +233,7 @@ class ProgramAVRSPIApplet(ProgramAVRApplet):
     def build(self, target, args):
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
         controller = SPIControllerSubtarget(
-            pads=iface.get_pads(args, pins=self.__pins),
+            pads=iface.get_deprecated_pads(args, pins=self.__pins),
             out_fifo=iface.get_out_fifo(),
             in_fifo=iface.get_in_fifo(auto_flush=False),
             period_cyc=math.ceil(target.sys_clk_freq / (args.frequency * 1000)),

--- a/software/glasgow/applet/program/ice40_flash/__init__.py
+++ b/software/glasgow/applet/program/ice40_flash/__init__.py
@@ -72,7 +72,7 @@ class ProgramICE40FlashApplet(Memory25xApplet):
         subtarget = super().build_subtarget(target, args)
 
         if args.pin_reset is not None:
-            reset_t = self.mux_interface.get_pin(args.pin_reset)
+            reset_t = self.mux_interface.get_deprecated_pad(args.pin_reset)
             dut_reset, self.__addr_dut_reset = target.registers.add_rw(1)
         else:
             reset_t = None
@@ -80,7 +80,7 @@ class ProgramICE40FlashApplet(Memory25xApplet):
             self.__addr_dut_reset = None
 
         if args.pin_done is not None:
-            done_t = self.mux_interface.get_pin(args.pin_done)
+            done_t = self.mux_interface.get_deprecated_pad(args.pin_done)
             dut_done, self.__addr_dut_done = target.registers.add_ro(1)
         else:
             done_t = None

--- a/software/glasgow/applet/program/ice40_sram/__init__.py
+++ b/software/glasgow/applet/program/ice40_sram/__init__.py
@@ -87,11 +87,11 @@ class ProgramICE40SRAMApplet(SPIControllerApplet):
     def build_subtarget(self, target, args):
         subtarget = super().build_subtarget(target, args, pins=("sck", "cs", "copi"))
 
-        reset_t = self.mux_interface.get_pin(args.pin_reset)
+        reset_t = self.mux_interface.get_deprecated_pad(args.pin_reset)
         dut_reset, self.__addr_dut_reset = target.registers.add_rw(1)
 
         if args.pin_done is not None:
-            done_t = self.mux_interface.get_pin(args.pin_done)
+            done_t = self.mux_interface.get_deprecated_pad(args.pin_done)
             dut_done, self.__addr_dut_done = target.registers.add_ro(1)
         else:
             done_t = None

--- a/software/glasgow/applet/program/m16c/__init__.py
+++ b/software/glasgow/applet/program/m16c/__init__.py
@@ -343,7 +343,7 @@ class ProgramM16CApplet(GlasgowApplet):
 
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
         subtarget = iface.add_subtarget(ProgramM16CSubtarget(
-            pads=iface.get_pads(args, pins=self.__pins),
+            pads=iface.get_deprecated_pads(args, pins=self.__pins),
             out_fifo=iface.get_out_fifo(),
             in_fifo=iface.get_in_fifo(),
             bit_cyc=bit_cyc,

--- a/software/glasgow/applet/program/nrf24lx1/__init__.py
+++ b/software/glasgow/applet/program/nrf24lx1/__init__.py
@@ -202,7 +202,7 @@ class ProgramNRF24Lx1Applet(GlasgowApplet):
         dut_reset, self.__addr_dut_reset = target.registers.add_rw(1)
 
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
-        pads = iface.get_pads(args, pins=self.__pins)
+        pads = iface.get_deprecated_pads(args, pins=self.__pins)
 
         controller = SPIControllerSubtarget(
             pads=pads,

--- a/software/glasgow/applet/radio/nrf24l01/__init__.py
+++ b/software/glasgow/applet/radio/nrf24l01/__init__.py
@@ -209,7 +209,7 @@ class RadioNRF24L01Applet(GlasgowApplet):
         dut_ce, self.__addr_dut_ce = target.registers.add_rw(1)
 
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
-        pads = iface.get_pads(args, pins=self.__pins)
+        pads = iface.get_deprecated_pads(args, pins=self.__pins)
 
         controller = SPIControllerSubtarget(
             pads=pads,

--- a/software/glasgow/applet/sensor/hx711/__init__.py
+++ b/software/glasgow/applet/sensor/hx711/__init__.py
@@ -167,7 +167,7 @@ class SensorHX711Applet(GlasgowApplet):
 
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
         iface.add_subtarget(SensorHX711Subtarget(
-            pads=iface.get_pads(args, pins=self.__pins),
+            pads=iface.get_deprecated_pads(args, pins=self.__pins),
             out_fifo=iface.get_out_fifo(),
             in_fifo=iface.get_in_fifo(),
             # The highest conversion rate supported by this sensor is about 144 Hz, and at 1 MHz,

--- a/software/glasgow/applet/sensor/pmsx003/__init__.py
+++ b/software/glasgow/applet/sensor/pmsx003/__init__.py
@@ -100,7 +100,7 @@ class SensorPMSx003Applet(GlasgowApplet):
     def build(self, target, args):
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
         iface.add_subtarget(PMSx003Subtarget(
-            pads=iface.get_pads(args, pins=self.__pins),
+            pads=iface.get_deprecated_pads(args, pins=self.__pins),
             in_fifo=iface.get_in_fifo(),
             out_fifo=iface.get_out_fifo(),
         ))

--- a/software/glasgow/applet/video/hub75_output/__init__.py
+++ b/software/glasgow/applet/video/hub75_output/__init__.py
@@ -151,7 +151,7 @@ class VideoHub75OutputApplet(GlasgowApplet):
 
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
         subtarget = iface.add_subtarget(VideoHub75OutputSubtarget(
-            pads=iface.get_pads(args, pins=self.__pins, pin_sets=self.__pin_sets),
+            pads=iface.get_deprecated_pads(args, pins=self.__pins, pin_sets=self.__pin_sets),
             px_width=args.px_width,
             px_height=args.px_height,
             expose_delay=args.expose_delay,

--- a/software/glasgow/applet/video/rgb_input/__init__.py
+++ b/software/glasgow/applet/video/rgb_input/__init__.py
@@ -158,7 +158,7 @@ class VideoRGBInputApplet(GlasgowApplet):
             rows=args.rows,
             columns=args.columns,
             vblank=args.vblank,
-            pads=iface.get_pads(args, pins=("dck",), pin_sets=("r", "g", "b")),
+            pads=iface.get_deprecated_pads(args, pins=("dck",), pin_sets=("r", "g", "b")),
             in_fifo=iface.get_in_fifo(depth=512 * 30, auto_flush=False),
             sys_clk_freq=target.sys_clk_freq,
         ))

--- a/software/glasgow/applet/video/vga_output/__init__.py
+++ b/software/glasgow/applet/video/vga_output/__init__.py
@@ -182,7 +182,7 @@ class VGAOutputApplet(GlasgowApplet):
     def build(self, target, args, test_pattern=True):
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
         subtarget = iface.add_subtarget(VGAOutputSubtarget(
-            pads=iface.get_pads(args, pins=self.__pins),
+            pads=iface.get_deprecated_pads(args, pins=self.__pins),
             h_front=args.h_front,
             h_sync=args.h_sync,
             h_back=args.h_back,

--- a/software/glasgow/applet/video/ws2812_output/__init__.py
+++ b/software/glasgow/applet/video/ws2812_output/__init__.py
@@ -168,7 +168,7 @@ class VideoWS2812OutputApplet(GlasgowApplet):
 
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
         subtarget = iface.add_subtarget(VideoWS2812OutputSubtarget(
-            pads=[iface.get_pin(pin) for pin in args.pin_set_out],
+            pads=[iface.get_deprecated_pad(pin) for pin in args.pin_set_out],
             count=args.count,
             pix_in_size=self.pix_in_size,
             pix_out_size=pix_out_size,

--- a/software/glasgow/gateware/pads.py
+++ b/software/glasgow/gateware/pads.py
@@ -5,7 +5,7 @@ from amaranth.lib import io
 __all__ = ['Pads']
 
 
-class Pads(Elaboratable):
+class Pads:
     """
     Pad adapter.
 
@@ -43,7 +43,3 @@ class Pads(Elaboratable):
                 raise ValueError("Cannot add {!r} as attribute {}; attribute already exists")
 
             setattr(self, pin_name, pin)
-
-    def elaborate(self, platform):
-        m = Module()
-        return m

--- a/software/glasgow/platform/all.py
+++ b/software/glasgow/platform/all.py
@@ -1,2 +1,0 @@
-from .rev_ab import *
-from .rev_c import *

--- a/software/glasgow/platform/generic.py
+++ b/software/glasgow/platform/generic.py
@@ -1,0 +1,92 @@
+from amaranth import *
+from amaranth.lib import wiring, io
+
+from ..gateware import GatewareBuildError
+from ..device.hardware import GlasgowHardwareDevice
+
+
+class GlasgowPlatformPort(io.PortLike):
+    def __init__(self, *, io, oe=None):
+        assert oe is None or len(io) == len(oe)
+        self._io_port = io
+        self._oe_port = oe
+
+    @property
+    def io_port(self):
+        return self._io_port
+
+    @property
+    def oe_port(self):
+        return self._oe_port
+
+    @property
+    def direction(self):
+        return io.Direction.Bidir
+
+    def __len__(self):
+        return len(self.io_port)
+
+    def __invert__(self):
+        return GlasgowPlatformPort(io=~self.io_port, oe=self.oe_port)
+
+    def __getitem__(self, key):
+        if self.oe_port is None:
+            return GlasgowPlatformPort(io=self.io_port[key])
+        else:
+            return GlasgowPlatformPort(io=self.io_port[key], oe=self.oe_port[key])
+
+    def __add__(self, other):
+        if type(other) is GlasgowPlatformPort:
+            if self.oe_port is None and other.oe_port is None:
+                return GlasgowPlatformPort(io=self.io_port + other.io_port)
+            elif self.oe_port is not None and other.oe_port is not None:
+                return GlasgowPlatformPort(io=self.io_port + other.io_port,
+                                           oe=self.oe_port + other.oe_port)
+            assert False
+        else:
+            return NotImplemented
+
+
+class GlasgowPlatformGeneric:
+    @property
+    def file_templates(self):
+        # Do not require yosys to be present for toolchain_prepare() to finish.
+        file_templates = dict(super().file_templates)
+        del file_templates["{{name}}.debug.v"]
+        return file_templates
+
+    def toolchain_program(self, products, name):
+        bitstream = products.get(f"{name}.bin")
+        async def do_program():
+            device = GlasgowHardwareDevice()
+            await device.download_bitstream(bitstream)
+            device.close()
+        asyncio.get_event_loop().run_until_complete(do_program())
+
+    def get_io_buffer(self, buffer):
+        if isinstance(buffer.port, GlasgowPlatformPort):
+            m = Module()
+            # Determine the domains that clocked buffers must belong to.
+            i_domain_kwarg, o_domain_kwarg = dict(), dict()
+            if isinstance(buffer, (io.FFBuffer, io.DDRBuffer)):
+                i_domain_kwarg = dict(i_domain=buffer.i_domain)
+                o_domain_kwarg = dict(o_domain=buffer.o_domain)
+            # Create an inner buffer of the same type driving `io_port`.
+            m.submodules.io = io_buffer = type(buffer)(buffer.direction, buffer.port.io_port,
+                                                       **i_domain_kwarg, **o_domain_kwarg)
+            wiring.connect(m, wiring.flipped(buffer), io_buffer)
+            # If necessary (on revC+), create another buffer driving `oe_port` while being careful
+            # to match the latency of `io_port`.
+            if buffer.port.oe_port is not None:
+                m.submodules.oe = oe_buffer = type(buffer)("o", buffer.port.oe_port,
+                                                           **o_domain_kwarg)
+                if buffer.direction in (io.Direction.Output, io.Direction.Bidir):
+                    if isinstance(buffer, (io.Buffer, io.FFBuffer)):
+                        m.d.comb += oe_buffer.o.eq(buffer.oe)
+                    elif isinstance(buffer, io.DDRBuffer):
+                        m.d.comb += oe_buffer.o.eq(buffer.oe.replicate(2))
+                    else:
+                        raise TypeError(f"I/O buffer {buffer!r} is not supported")
+            return m
+        else:
+            return super().get_io_buffer(buffer)

--- a/software/glasgow/platform/generic.py
+++ b/software/glasgow/platform/generic.py
@@ -47,7 +47,7 @@ class GlasgowPlatformPort(io.PortLike):
             return NotImplemented
 
 
-class GlasgowPlatformGeneric:
+class GlasgowGenericPlatform:
     @property
     def file_templates(self):
         # Do not require yosys to be present for toolchain_prepare() to finish.

--- a/software/glasgow/platform/ice40.py
+++ b/software/glasgow/platform/ice40.py
@@ -2,13 +2,13 @@ import asyncio
 from amaranth import *
 from amaranth.vendor import LatticeICE40Platform
 
-from .generic import GlasgowPlatformGeneric
+from .generic import GlasgowGenericPlatform
 
 
-__all__ = ["GlasgowPlatformICE40"]
+__all__ = ["GlasgowICE40Platform"]
 
 
-class GlasgowPlatformICE40(GlasgowPlatformGeneric, LatticeICE40Platform):
+class GlasgowICE40Platform(GlasgowGenericPlatform, LatticeICE40Platform):
     def get_pll(self, pll, simple_feedback=True):
         if not 10e6 <= pll.f_in <= 133e6:
             pll.logger.error("PLL: f_in (%.3f MHz) must be between 10 and 133 MHz",

--- a/software/glasgow/platform/ice40.py
+++ b/software/glasgow/platform/ice40.py
@@ -2,29 +2,13 @@ import asyncio
 from amaranth import *
 from amaranth.vendor import LatticeICE40Platform
 
-from ..device.hardware import *
-from ..gateware import GatewareBuildError
+from .generic import GlasgowPlatformGeneric
 
 
 __all__ = ["GlasgowPlatformICE40"]
 
 
-class GlasgowPlatformICE40(LatticeICE40Platform):
-    @property
-    def file_templates(self):
-        # Do not require yosys to be present for toolchain_prepare() to finish.
-        file_templates = dict(super().file_templates)
-        del file_templates["{{name}}.debug.v"]
-        return file_templates
-
-    def toolchain_program(self, products, name):
-        bitstream = products.get(f"{name}.bin")
-        async def do_program():
-            device = GlasgowHardwareDevice()
-            await device.download_bitstream(bitstream)
-            device.close()
-        asyncio.get_event_loop().run_until_complete(do_program())
-
+class GlasgowPlatformICE40(GlasgowPlatformGeneric, LatticeICE40Platform):
     def get_pll(self, pll, simple_feedback=True):
         if not 10e6 <= pll.f_in <= 133e6:
             pll.logger.error("PLL: f_in (%.3f MHz) must be between 10 and 133 MHz",

--- a/software/glasgow/platform/rev_ab.py
+++ b/software/glasgow/platform/rev_ab.py
@@ -3,10 +3,10 @@ from amaranth.build import *
 from .ice40 import *
 
 
-__all__ = ["GlasgowPlatformRevAB"]
+__all__ = ["GlasgowRevABPlatform"]
 
 
-class GlasgowPlatformRevAB(GlasgowPlatformICE40):
+class GlasgowRevABPlatform(GlasgowICE40Platform):
     device      = "iCE40UP5K"
     package     = "SG48"
     default_clk = "clk_if"

--- a/software/glasgow/platform/rev_c.py
+++ b/software/glasgow/platform/rev_c.py
@@ -3,10 +3,10 @@ from amaranth.build import *
 from .ice40 import *
 
 
-__all__ = ["GlasgowPlatformRevC0", "GlasgowPlatformRevC123"]
+__all__ = ["GlasgowRevC0Platform", "GlasgowRevC123Platform"]
 
 
-class _GlasgowPlatformRevC(GlasgowPlatformICE40):
+class _GlasgowRevCPlatform(GlasgowICE40Platform):
     device      = "iCE40HX8K"
     package     = "BG121"
     default_clk = "clk_if"
@@ -122,16 +122,16 @@ class _GlasgowPlatformRevC(GlasgowPlatformICE40):
     ]
 
 
-class GlasgowPlatformRevC0(_GlasgowPlatformRevC):
-    resources = _GlasgowPlatformRevC.resources + [
+class GlasgowRevC0Platform(_GlasgowRevCPlatform):
+    resources = _GlasgowRevCPlatform.resources + [
         Resource("port_s", 0,
                  Subsignal("io", Pins("A11")),
                  Attrs(IO_STANDARD="SB_LVCMOS33")),
     ]
 
 
-class GlasgowPlatformRevC123(_GlasgowPlatformRevC):
-    resources = _GlasgowPlatformRevC.resources + [
+class GlasgowRevC123Platform(_GlasgowRevCPlatform):
+    resources = _GlasgowRevCPlatform.resources + [
         Resource("port_s", 0,
                  Subsignal("io", Pins("A11"), Attrs(PULLUP=1)),
                  Subsignal("oe", Pins("B4", dir="o")),

--- a/software/glasgow/target/hardware.py
+++ b/software/glasgow/target/hardware.py
@@ -26,16 +26,16 @@ logger = logging.getLogger(__name__)
 class GlasgowHardwareTarget(Elaboratable):
     def __init__(self, revision, multiplexer_cls=None, with_analyzer=False):
         if revision in ("A0", "B0"):
-            from ..platform.rev_ab import GlasgowPlatformRevAB
-            self.platform = GlasgowPlatformRevAB()
+            from ..platform.rev_ab import GlasgowRevABPlatform
+            self.platform = GlasgowRevABPlatform()
             self.sys_clk_freq = 30e6
         elif revision in "C0":
-            from ..platform.rev_c import GlasgowPlatformRevC0
-            self.platform = GlasgowPlatformRevC0()
+            from ..platform.rev_c import GlasgowRevC0Platform
+            self.platform = GlasgowRevC0Platform()
             self.sys_clk_freq = 48e6
         elif revision in ("C1", "C2", "C3"):
-            from ..platform.rev_c import GlasgowPlatformRevC123
-            self.platform = GlasgowPlatformRevC123()
+            from ..platform.rev_c import GlasgowRevC123Platform
+            self.platform = GlasgowRevC123Platform()
             self.sys_clk_freq = 48e6
         else:
             raise ValueError("Unknown revision")

--- a/software/glasgow/target/hardware.py
+++ b/software/glasgow/target/hardware.py
@@ -13,7 +13,6 @@ from amaranth.build import ResourceError
 from ..gateware.i2c import I2CTarget
 from ..gateware.registers import I2CRegisters
 from ..gateware.fx2_crossbar import FX2Crossbar
-from ..platform.all import *
 from .analyzer import GlasgowAnalyzer
 from .toolchain import find_toolchain
 
@@ -27,12 +26,15 @@ logger = logging.getLogger(__name__)
 class GlasgowHardwareTarget(Elaboratable):
     def __init__(self, revision, multiplexer_cls=None, with_analyzer=False):
         if revision in ("A0", "B0"):
+            from ..platform.rev_ab import GlasgowPlatformRevAB
             self.platform = GlasgowPlatformRevAB()
             self.sys_clk_freq = 30e6
         elif revision in "C0":
+            from ..platform.rev_c import GlasgowPlatformRevC0
             self.platform = GlasgowPlatformRevC0()
             self.sys_clk_freq = 48e6
         elif revision in ("C1", "C2", "C3"):
+            from ..platform.rev_c import GlasgowPlatformRevC123
             self.platform = GlasgowPlatformRevC123()
             self.sys_clk_freq = 48e6
         else:


### PR DESCRIPTION
This marks the existing "Pads"/"get_pads" related infrastructure as explicitly deprecated, but the new infrastructure does not yet have the same degree of usability as the old one. To avoid excessive churn, do **not** bulk-migrate applets to the new I/O yet.

This PR experimentally migrates the `jtag-probe` and `jtag-openocd` applets, which can be used to test the new I/O and demonstrate its use.

This applet has also been tested with the (not yet merged; #586) `qspi-controller` applet to verify the `io.FFBuffer` functionality. `io.DDRBuffer` functionality is present but not validated yet; I will do that later.