### PR TITLE
Expose gateware-side FIFO ports as Amaranth streams

### DIFF
--- a/software/glasgow/access/direct/multiplexer.py
+++ b/software/glasgow/access/direct/multiplexer.py
@@ -1,6 +1,6 @@
 import logging
 from amaranth import *
-from amaranth.lib import io
+from amaranth.lib import stream, io
 
 from ...platform.generic import GlasgowPlatformPort
 from .. import AccessMultiplexer, AccessMultiplexerInterface
@@ -32,6 +32,11 @@ class _FIFOReadPort(Elaboratable):
         self.r_en   = Signal()
         self.r_rdy  = Signal()
         self.r_data = fifo.r_data
+
+        self.stream = stream.Signature(8).create()
+        self.stream.payload = self.r_data
+        self.stream.valid = self.r_rdy
+        self.stream.ready = self.r_en
 
     def elaborate(self, platform):
         fifo = self._fifo
@@ -71,6 +76,11 @@ class _FIFOWritePort(Elaboratable):
         self.w_rdy  = Signal()
         self.w_data = fifo.w_data
         self.flush  = fifo.flush
+
+        self.stream = stream.Signature(8).flip().create()
+        self.stream.payload = self.w_data
+        self.stream.valid = self.w_en
+        self.stream.ready = self.w_rdy
 
     def elaborate(self, platform):
         fifo = self._fifo


### PR DESCRIPTION
This PR alters the object returned by `get_{in,out,inout}_fifo()` to also have a `.stream` property, containing an Amaranth stream object whose ports are the `.[rw]_{rdy,en,data}` signals of the FIFO port. It is a part of our gradual migration to the new infrastructure in Amaranth 0.5.

An alternative to this design is to make the FIFO port object itself an interface object that can be connected to Amaranth streams. This was not done because of the `in_fifo.flush` signal, which is sampled regardless of the `in_fifo.stream.valid` (aka `in_fifo.r_en`) signal, and which therefore cannot be a part of the payload. (Even if it was, it would be inconvenient to connect to the IN FIFO port stream if it always included packetization; the closest stream equivalent of `flush` is the `end`/`last` signal.)