### PR TITLE
platform.ice40: reset `odomain` if instantiated PLL is unlocked

### DIFF
--- a/software/glasgow/applet/video/vga_output/__init__.py
+++ b/software/glasgow/applet/video/vga_output/__init__.py
@@ -54,7 +54,7 @@ class VGAOutputSubtarget(Elaboratable):
 
         m.submodules.output = output = VGAOutput(self.pads)
 
-        m.domains.pix = cd_pix = ClockDomain(reset_less=True)
+        m.domains.pix = cd_pix = ClockDomain()
         m.submodules += PLL(f_in=platform.default_clk_frequency, f_out=self.pix_clk_freq, odomain="pix")
 
         h_total = self.h_front + self.h_sync + self.h_back + self.h_active

--- a/software/glasgow/platform/generic.py
+++ b/software/glasgow/platform/generic.py
@@ -1,7 +1,6 @@
 from amaranth import *
 from amaranth.lib import wiring, io
 
-from ..gateware import GatewareBuildError
 from ..device.hardware import GlasgowHardwareDevice
 
 


### PR DESCRIPTION
Without this the use of a PLL is completely unsound. The `ResetSynchronizer` is necessary since the `LOCK` signal is, as far as I can tell, not synchronized to the output clock.

