### PR TITLE
firmware: fix comment about power-only USB cables. NFC

### DIFF
--- a/firmware/main.c
+++ b/firmware/main.c
@@ -998,7 +998,7 @@ int main() {
       handle_pending_alert();
 
     // There are few things more frustrating than having your debug tools fail you.
-    // Data-only USB cables are regretfully common. If the device finds itself without
+    // Power-only USB cables are regretfully common. If the device finds itself without
     // an address it should indicate this unusual condition, though in a gentle way
     // because there are legitimate reasons for this to happen (PC in suspend, Glasgow
     // used 'offline', etc).


### PR DESCRIPTION
The comment talks about devices which find themselves without a USB address, which implies that power is present, but data isn't.