### PR TITLE
Introduce a concept of gateware port groups

### DIFF
--- a/software/glasgow/access/__init__.py
+++ b/software/glasgow/access/__init__.py
@@ -3,6 +3,7 @@ from amaranth import *
 from amaranth.lib import io
 import argparse
 
+from ..gateware.ports import PortGroup
 from ..gateware.pads import Pads
 
 
@@ -67,6 +68,11 @@ class AccessMultiplexerInterface(Elaboratable, metaclass=ABCMeta):
     @abstractmethod
     def get_port(self, pin, *, name):
         pass
+
+    def get_port_group(self, **kwargs):
+        return PortGroup(**{
+            name: self.get_port(pin_or_pins, name=name) for name, pin_or_pins in kwargs.items()
+        })
 
     @abstractmethod
     def _build_pad_tristate(self, pin, oe, o, i):

--- a/software/glasgow/gateware/pads.py
+++ b/software/glasgow/gateware/pads.py
@@ -6,31 +6,7 @@ __all__ = ['Pads']
 
 
 class Pads:
-    """
-    Pad adapter.
-
-    Provides a common interface to device pads, wrapping either a Migen platform request,
-    or a Glasgow I/O port slice.
-
-    Construct a pad adapter providing pins; name may
-    be specified explicitly with keyword arguments. For each
-    pin with name ``n``, the pad adapter will have an attribute ``n_t`` containing
-    a ``Pin``.
-
-    For example, if a Migen platform file contains the definitions ::
-
-        _io = [
-            ("i2c", 0,
-                Subsignal("scl", Pins("39")),
-                Subsignal("sda", Pins("40")),
-            ),
-            # ...
-        ]
-
-    then a pad adapter constructed as ``Pads(platform.request("i2c"))`` will have
-    attributes ``scl_t`` and ``sda_t`` containing ``Pin`` objects for their respective
-    pins.
-    """
+    """Deprecated in favor of :class:`glasgow.gateware.ports.PortGroup`."""
     def __init__(self, **kwargs):
         for name, pin in kwargs.items():
             if hasattr(pin, "signature"):

--- a/software/glasgow/gateware/ports.py
+++ b/software/glasgow/gateware/ports.py
@@ -1,0 +1,16 @@
+from amaranth.lib import io
+
+
+__all__ = ["PortGroup"]
+
+
+class PortGroup:
+    """Group of Amaranth library I/O ports.
+
+    This object is a stand-in for the object returned by the Amaranth :py:`platform.request()`
+    function, as expected by the I/O cores.
+    """
+    def __init__(self, **kwargs):
+        for name, port in kwargs.items():
+            assert port is None or isinstance(port, io.PortLike)
+        self.__dict__.update(kwargs)


### PR DESCRIPTION
Unlike the old `Pads` mechanism, the new `PortGroup` is a proper drop-in replacement for the object returned by `platform.request(..., dir={...: "-"})` and so any gateware built for Glasgow should be usable also outside of it.

Yay for interoperability! :tada: 

This interface can and should be used to upgrade all of the other applets, now.