### PR TITLE
manual: increase retry count for linkcheck

### DIFF
--- a/docs/manual/src/conf.py
+++ b/docs/manual/src/conf.py
@@ -87,3 +87,9 @@ linkcheck_anchors_ignore_for_url = [
     # React page with README content included as a JSON payload.
     r"^https://github\.com/[^/]+/[^/]+/$",
 ]
+
+# Defaults to one, which is a bit harsh and results in flakiness. This can be
+# probably bumped up even further if needed, but at some point this might not
+# enough and linkcheck would likely require some changes to work better in a CI
+# scenario (better controlled backoff, a degree of liveness caching, etc).
+linkcheck_retries = 3


### PR DESCRIPTION
`linkcheck_retries` defaults to 1 [1], which isn't great for running checks across the Internet, on a few dozen different servers, across thousands of CI runs.

This wasn't tested, but my naïve expectation is that the option works as documented. Not knowing what retry timeout is used is a bit unsettling, but I guess we'll just see if this helps.

[1] - https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-linkcheck_retries