### PR TITLE
access.direct.multiplexer: accept empty list in `get_port()`

### DIFF
--- a/software/glasgow/access/direct/multiplexer.py
+++ b/software/glasgow/access/direct/multiplexer.py
@@ -212,10 +212,10 @@ class DirectMultiplexerInterface(AccessMultiplexerInterface):
         return f"{port}{bit}"
 
     def get_port(self, pin_or_pins, *, name):
-        if pin_or_pins is None:
-            self.logger.debug("not assigning applet port %r to any device pin", name)
-            return None
-        elif isinstance(pin_or_pins, list):
+        if isinstance(pin_or_pins, list):
+            if pin_or_pins == []:
+                self.logger.debug("not assigning applet ports '%s[]' to any device pins", name)
+                return None
             port = None
             for index, subpin in enumerate(pin_or_pins):
                 subport = self.get_port(subpin, name=f"{name}[{index}]")
@@ -226,8 +226,11 @@ class DirectMultiplexerInterface(AccessMultiplexerInterface):
             assert port is not None
             return port
         else:
+            if pin_or_pins is None:
+                self.logger.debug("not assigning applet port '%s' to any device pin", name)
+                return None
             port, bit, request = self._pins[pin_or_pins]
-            self.logger.debug("assigning applet port %r to device pin %s",
+            self.logger.debug("assigning applet port '%s' to device pin %s",
                 name, self.get_pin_name(pin_or_pins))
             pin_subports = request(bit)
             if hasattr(pin_subports, "oe"):


### PR DESCRIPTION
This can come up when a `--pins-x ''` argument (or no argument at all) is provided, and zero pins are accepted by the applet for it.

In principle, `PortLike` can have a zero length. However, instead, `None` is returned. This is for two reasons:
- Constructing an empty `GlasgowPlatformPort` is surprisingly annoying.
- Handling a case of a zero length port separately from a case of no port being provided at all seems like making I/O cores more complex with no upside to it.