### PR TITLE
Greatly improve quality of life for viewing bitstream logs

### DIFF
--- a/docs/manual/src/conf.py
+++ b/docs/manual/src/conf.py
@@ -79,6 +79,8 @@ linkcheck_ignore = [
     r"^http://127\.0\.0\.1:8000$",
     # Doesn't like the linkcheck User-Agent.
     r"^https://mouser\.com/",
+    # For unknown reasons, is (mostly) unreachable from GitHub CI runners.
+    r"^https://chaos\.social/",
 ]
 
 linkcheck_anchors_ignore_for_url = [
@@ -87,9 +89,3 @@ linkcheck_anchors_ignore_for_url = [
     # React page with README content included as a JSON payload.
     r"^https://github\.com/[^/]+/[^/]+/$",
 ]
-
-# Defaults to one, which is a bit harsh and results in flakiness. This can be
-# probably bumped up even further if needed, but at some point this might not
-# enough and linkcheck would likely require some changes to work better in a CI
-# scenario (better controlled backoff, a degree of liveness caching, etc).
-linkcheck_retries = 3

--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -464,7 +464,7 @@ class SubjectFilter:
     def filter(self, record):
         levelno = record.levelno
         for subject in self.subjects:
-            if record.msg.startswith(subject + ": "):
+            if isinstance(record.msg, str) and record.msg.startswith(subject + ": "):
                 levelno = logging.DEBUG
         return levelno >= self.level
 

--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -936,7 +936,7 @@ async def main():
 
 # This entry point is invoked via `project.scripts.glasgow` when installing the package with `pipx`.
 def run_main():
-    exit(asyncio.run(main()))
+    exit(asyncio.new_event_loop().run_until_complete(main()))
 
 
 # This entry point is invoked when running `python -m glasgow.cli`.

--- a/software/glasgow/target/hardware.py
+++ b/software/glasgow/target/hardware.py
@@ -81,6 +81,7 @@ class GlasgowHardwareTarget(Elaboratable):
         m.domains.sync = ClockDomain()
         m.submodules.clk_buffer = clk_buffer = io.Buffer("i", platform.request("clk_if", dir="-"))
         m.d.comb += ClockSignal().eq(clk_buffer.i)
+        platform.add_clock_constraint(clk_buffer.i, platform.default_clk_frequency)
 
         m.submodules.i2c_target = self.i2c_target
         m.submodules.registers = self.registers


### PR DESCRIPTION
- Bitstreams are now always built in verbose mode (what previously required `AMARANTH_verbose=1`).
- Instead of going to stdout/stderr, Yosys and nextpnr output is now captured by Python host and directed to the normal log at TRACE level. This can be viewed with `-vv` or `-v -F build` CLI options.
- Build logs are considered a product and are cached together with the built bitstream. Absence of a build log (e.g. for bitstreams built before this change) triggers a full rebuild.
- If a bitstream is retrieved from the cache, the build log is logged in the same way as if the build was executed anew.
- If a build fails, the build log is (instantly) output at INFO level, with an error message indicating either this or that `-q` needs to be removed.
- Like the bitstream itself, the build log is protected by a checksum. Any discrepancy causes a rebuild.

As a result, bitstream build should feel like an integral component of the Glasgow framework rather than an external subprocess.

This PR also fixes a papercut related to SIGINT (one of many, sadly).

This PR also migrates REPL history file to the platform state directory instead of putting it in `$HOME`.

This PR also fixes a critical issue causing unsound bitstream builds (with no clock constraints).
