### PR TITLE
applet.program.avr: improve CLI experience for memory arguments

### DIFF
--- a/software/glasgow/applet/program/avr/spi/__init__.py
+++ b/software/glasgow/applet/program/avr/spi/__init__.py
@@ -200,7 +200,7 @@ class ProgramAVRSPIInterface(ProgramAVRInterface):
 class ProgramAVRSPIApplet(ProgramAVRApplet):
     logger = logging.getLogger(__name__)
     help = f"{ProgramAVRApplet.help} via SPI"
-    description = """
+    description = f"""
     Identify, program, and verify Microchip AVR microcontrollers using low-voltage serial (SPI)
     programming.
 
@@ -213,6 +213,8 @@ class ProgramAVRSPIApplet(ProgramAVRApplet):
         CIPO @ * VCC
          SCK * * COPI
         RST# * * GND
+
+    {ProgramAVRApplet.description}
     """
 
     __pins = ("reset", "sck", "cipo", "copi")

--- a/software/glasgow/applet/program/avr/spi/__init__.py
+++ b/software/glasgow/applet/program/avr/spi/__init__.py
@@ -244,9 +244,11 @@ class ProgramAVRSPIApplet(ProgramAVRApplet):
         )
 
         dut_reset, self.__addr_dut_reset = target.registers.add_rw(1)
-        subtarget = ProgramAVRSPISubtarget(controller, iface.pads.reset_t, dut_reset)
-
-        iface.add_subtarget(subtarget)
+        return iface.add_subtarget(ProgramAVRSPISubtarget(
+            controller=controller,
+            reset_t=iface.pads.reset_t,
+            dut_reset=dut_reset
+        ))
 
     async def run_lower(self, cls, device, args):
         iface = await device.demultiplexer.claim_interface(self, self.mux_interface, args)


### PR DESCRIPTION
Before this commit, it was not clear that the filename suffix determines the file format. After this commit this is made clear in the text, and also invalid filenames are rejected at argument parsing stage.

Inspired by, and supersedes, #623.