### PR TITLE
cli: speed up startup by not importing all test modules

### DIFF
--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -149,7 +149,10 @@ def get_argparser():
 
             applet_cls = metadata.applet_cls
 
-            if mode == "test" and applet_cls.tests() is None:
+            # Don't do `.tests() is None`, as this has the overhead of importing the tests module
+            # (about 5ms per applet, which adds up). Instead, check if the function was overridden,
+            # as it's pointless to override it just to return `None`.
+            if mode == "test" and applet_cls.tests is GlasgowApplet.tests:
                 continue
             if mode == "tool" and not hasattr(applet_cls, "tool_cls"):
                 continue


### PR DESCRIPTION
On my machine:

before:

    real    0m1.258s
    user    0m1.172s
    sys     0m0.077s

after:

    real    0m1.010s
    user    0m0.911s
    sys     0m0.096s

That's a 20% improvement essentially for free!