### PR TITLE
applet.interface.swd_openocd: improve formatting of help text

### DIFF
--- a/software/glasgow/applet/interface/swd_openocd/__init__.py
+++ b/software/glasgow/applet/interface/swd_openocd/__init__.py
@@ -115,9 +115,8 @@ class SWDOpenOCDApplet(GlasgowApplet):
     description = """
     Expose SWD via a socket using the OpenOCD remote bitbang protocol.
 
-    Note: As of 2024-07-10, SWD remote bitbang support is not part of a released version of OpenOCD,
-          so this requires a manual build to work.
-          See https://github.com/GlasgowEmbedded/glasgow/issues/616 for more information.
+    Note (2024-07-22): SWD remote bitbang support has not yet been a part of an OpenOCD release,
+    and OpenOCD must be built from source to use this applet.
 
     Usage with TCP sockets:
 


### PR DESCRIPTION
This is pretty ugly:
![Screenshot_20240722_220818](https://github.com/user-attachments/assets/f330d6af-3a0c-4463-a5ec-fe98bb6474ba)
