### PR TITLE
applet.interface.i2c_{initiator,target}: modify to use port groups

### DIFF
--- a/software/glasgow/applet/interface/i2c_target/__init__.py
+++ b/software/glasgow/applet/interface/i2c_target/__init__.py
@@ -18,8 +18,8 @@ class Event(enum.IntEnum):
 
 
 class I2CTargetSubtarget(Elaboratable):
-    def __init__(self, pads, out_fifo, in_fifo, address):
-        self.pads       = pads
+    def __init__(self, ports, out_fifo, in_fifo, address):
+        self.ports      = ports
         self.out_fifo   = out_fifo
         self.in_fifo    = in_fifo
         self.address    = address
@@ -27,7 +27,7 @@ class I2CTargetSubtarget(Elaboratable):
     def elaborate(self, platform):
         m = Module()
 
-        m.submodules.i2c_target = i2c_target = I2CTarget(self.pads)
+        m.submodules.i2c_target = i2c_target = I2CTarget(self.ports)
         m.d.comb += i2c_target.address.eq(self.address)
 
         with m.FSM():
@@ -204,15 +204,14 @@ class I2CTargetApplet(GlasgowApplet):
     """
     required_revision = "C0"
 
-    __pins = ("scl", "sda")
     interface_cls = _DummyI2CTargetInterface
 
     @classmethod
     def add_build_arguments(cls, parser, access):
         super().add_build_arguments(parser, access)
 
-        for pin in cls.__pins:
-            access.add_pin_argument(parser, pin, default=True)
+        access.add_pin_argument(parser, "scl", default=True)
+        access.add_pin_argument(parser, "sda", default=True)
 
         def i2c_address(arg):
             return int(arg, 0)
@@ -223,7 +222,7 @@ class I2CTargetApplet(GlasgowApplet):
     def build(self, target, args):
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
         iface.add_subtarget(I2CTargetSubtarget(
-            pads=iface.get_deprecated_pads(args, pins=self.__pins),
+            ports=iface.get_port_group(scl=args.pin_scl, sda=args.pin_sda),
             out_fifo=iface.get_out_fifo(),
             in_fifo=iface.get_in_fifo(),
             address=args.address,

--- a/software/tests/gateware/test_i2c.py
+++ b/software/tests/gateware/test_i2c.py
@@ -8,12 +8,12 @@ from glasgow.gateware.i2c import I2CInitiator, I2CTarget
 
 class I2CTestbench(Elaboratable):
     def __init__(self):
-        self.scl_t = io.Buffer.Signature(direction="io", width=1).create()
-        self.sda_t = io.Buffer.Signature(direction="io", width=1).create()
+        self.scl = io.SimulationPort("io", 1)
+        self.sda = io.SimulationPort("io", 1)
 
-        self.scl_i = self.scl_t.i
+        self.scl_i = self.scl.i
         self.scl_o = Signal(init=1)
-        self.sda_i = self.sda_t.i
+        self.sda_i = self.sda.i
         self.sda_o = Signal(init=1)
 
         self.period_cyc = 16
@@ -24,8 +24,8 @@ class I2CTestbench(Elaboratable):
         m.submodules.dut = self.dut
 
         m.d.comb += [
-            self.scl_t.i.eq((self.scl_t.o | ~self.scl_t.oe) & self.scl_o),
-            self.sda_t.i.eq((self.sda_t.o | ~self.sda_t.oe) & self.sda_o),
+            self.scl.i.eq((self.scl.o | ~self.scl.oe) & self.scl_o),
+            self.sda.i.eq((self.sda.o | ~self.sda.oe) & self.sda_o),
         ]
 
         return m


### PR DESCRIPTION
Also, update the I2C core to handle the same.

Part of https://github.com/GlasgowEmbedded/glasgow/issues/599.