### PR TITLE
Implement selective pin inversion with `--pin-x 0#` CLI options

### DIFF
--- a/software/glasgow/access/direct/multiplexer.py
+++ b/software/glasgow/access/direct/multiplexer.py
@@ -198,18 +198,18 @@ class DirectMultiplexerInterface(AccessMultiplexerInterface):
         return m
 
     def get_pin_name(self, pin):
-        port, bit, request = self._pins[pin]
+        port, bit, request = self._pins[pin.number]
         return f"{port}{bit}"
 
     def get_port_impl(self, pin, *, name):
-        port, bit, request = self._pins[pin]
-        self.logger.debug("assigning applet port '%s' to device pin %s",
-            name, self.get_pin_name(pin))
+        port, bit, request = self._pins[pin.number]
+        self.logger.debug("assigning applet port '%s' to device pin %s%s",
+            name, self.get_pin_name(pin), " (inverted)" if pin.invert else "")
         pin_components = request(bit)
-        if hasattr(pin_components, "oe"):
-            return GlasgowPlatformPort(io=pin_components.io, oe=pin_components.oe)
-        else:
-            return GlasgowPlatformPort(io=pin_components.io)
+        return GlasgowPlatformPort(
+            io=~pin_components.io if pin.invert else pin_components.io,
+            oe=getattr(pin_components, "oe", None)
+        )
 
     def get_in_fifo(self, **kwargs):
         fifo = self._fx2_crossbar.get_in_fifo(self._pipe_num, **kwargs, reset=self.reset)

--- a/software/glasgow/applet/display/pdi/__init__.py
+++ b/software/glasgow/applet/display/pdi/__init__.py
@@ -403,7 +403,6 @@ class DisplayPDIApplet(GlasgowApplet):
             delay_cyc=math.ceil(target.sys_clk_freq / 1e6),
             sck_idle=0,
             sck_edge="rising",
-            cs_active=0,
         )
 
         cog_power, self.__addr_cog_power = target.registers.add_rw(1)

--- a/software/glasgow/applet/interface/spi_flashrom/__init__.py
+++ b/software/glasgow/applet/interface/spi_flashrom/__init__.py
@@ -183,7 +183,7 @@ class SPIFlashromApplet(SPIControllerApplet):
             hold_t = self.mux_interface.get_deprecated_pad(args.pin_hold)
         else:
             hold_t = None
-        return Memory25xSubtarget(subtarget, hold_t, args.cs_active)
+        return Memory25xSubtarget(subtarget, hold_t)
 
     async def run(self, device, args):
         spi_iface = await self.run_lower(SPIFlashromApplet, device, args)

--- a/software/glasgow/applet/memory/_25x/__init__.py
+++ b/software/glasgow/applet/memory/_25x/__init__.py
@@ -28,17 +28,16 @@ BIT_ERR  = 0b10000000
 
 # This is also used in SPIFlashromApplet.
 class Memory25xSubtarget(Elaboratable):
-    def __init__(self, controller, hold_t, cs_active):
+    def __init__(self, controller, hold_t):
         self.controller = controller
         self.hold_t = hold_t
-        self.cs_active = cs_active
 
     def elaborate(self, platform):
         m = Module()
 
         m.submodules.controller = self.controller
 
-        m.d.comb += self.controller.bus.oe.eq(self.controller.bus.cs == self.cs_active)
+        m.d.comb += self.controller.bus.oe.eq(self.controller.bus.cs == 1)
 
         if self.hold_t is not None:
             m.d.comb += [
@@ -288,7 +287,7 @@ class Memory25xApplet(SPIControllerApplet):
             hold_t = self.mux_interface.get_deprecated_pad(args.pin_hold)
         else:
             hold_t = None
-        return Memory25xSubtarget(subtarget, hold_t, args.cs_active)
+        return Memory25xSubtarget(subtarget, hold_t)
 
     async def run(self, device, args):
         spi_iface = await self.run_lower(Memory25xApplet, device, args)

--- a/software/glasgow/applet/program/avr/spi/__init__.py
+++ b/software/glasgow/applet/program/avr/spi/__init__.py
@@ -242,7 +242,6 @@ class ProgramAVRSPIApplet(ProgramAVRApplet):
             delay_cyc=math.ceil(target.sys_clk_freq / 1e6),
             sck_idle=0,
             sck_edge="rising",
-            cs_active=0,
         )
 
         dut_reset, self.__addr_dut_reset = target.registers.add_rw(1)

--- a/software/glasgow/applet/program/nrf24lx1/__init__.py
+++ b/software/glasgow/applet/program/nrf24lx1/__init__.py
@@ -212,7 +212,6 @@ class ProgramNRF24Lx1Applet(GlasgowApplet):
             delay_cyc=math.ceil(target.sys_clk_freq / 1e6),
             sck_idle=0,
             sck_edge="rising",
-            cs_active=0,
         )
 
         return iface.add_subtarget(ProgramNRF24Lx1Subtarget(

--- a/software/glasgow/applet/radio/nrf24l01/__init__.py
+++ b/software/glasgow/applet/radio/nrf24l01/__init__.py
@@ -230,7 +230,6 @@ class RadioNRF24L01Applet(GlasgowApplet):
             delay_cyc=math.ceil(target.sys_clk_freq / 1e6),
             sck_idle=0,
             sck_edge="rising",
-            cs_active=0,
         )
 
         subtarget = RadioNRF24L01Subtarget(controller, pads.ce_t, dut_ce)

--- a/software/glasgow/gateware/uart.py
+++ b/software/glasgow/gateware/uart.py
@@ -11,10 +11,7 @@ class UARTBus(Elaboratable):
 
     Provides synchronization.
     """
-    def __init__(self, pads, invert_rx, invert_tx):
-        self.invert_rx = invert_rx
-        self.invert_tx = invert_tx
-
+    def __init__(self, pads):
         self.has_rx = hasattr(pads, "rx_t")
         if self.has_rx:
             self.rx_t = pads.rx_t
@@ -30,16 +27,10 @@ class UARTBus(Elaboratable):
 
         if self.has_tx:
             m.d.comb += self.tx_t.oe.eq(1)
-            if self.invert_tx:
-                m.d.comb += self.tx_t.o.eq(~self.tx_o)
-            else:
-                m.d.comb += self.tx_t.o.eq(self.tx_o)
+            m.d.comb += self.tx_t.o.eq(self.tx_o)
 
         if self.has_rx:
-            if self.invert_rx:
-                m.submodules += FFSynchronizer(~self.rx_t.i, self.rx_i, init=1)
-            else:
-                m.submodules += FFSynchronizer(self.rx_t.i, self.rx_i, init=1)
+            m.submodules += FFSynchronizer(self.rx_t.i, self.rx_i, init=1)
 
         return m
 
@@ -63,12 +54,6 @@ class UART(Elaboratable):
     :type max_bit_cyc: int
     :param max_bit_cyc:
         Maximum possible value for ``bit_cyc`` that can be configured at runtime.
-    :type invert_rx: bool
-    :param invert_rx:
-        Invert the line signal (=idle low) for RX
-    :type invert_tx: bool
-    :param invert_tx:
-        Invert the line signal (=idle low) for TX
 
     :attr bit_cyc:
         Register with the current value for bit time, minus one.
@@ -100,8 +85,7 @@ class UART(Elaboratable):
         Transmit acknowledgement. If active when ``tx_rdy`` is active, ``tx_rdy`` is reset,
         ``tx_data`` is sampled, and the transmit state machine starts transmitting a frame.
     """
-    def __init__(self, pads, bit_cyc, data_bits=8, parity="none", max_bit_cyc=None,
-                 invert_rx=False, invert_tx=False):
+    def __init__(self, pads, bit_cyc, data_bits=8, parity="none", max_bit_cyc=None):
         if max_bit_cyc is not None:
             self.max_bit_cyc = max_bit_cyc
         else:
@@ -124,7 +108,7 @@ class UART(Elaboratable):
         self.tx_rdy  = Signal()
         self.tx_ack  = Signal()
 
-        self.bus = UARTBus(pads, invert_rx=invert_rx, invert_tx=invert_tx)
+        self.bus = UARTBus(pads)
 
     def elaborate(self, platform):
         m = Module()


### PR DESCRIPTION
Amaranth supports inversion for any pin and for any I/O core on the I/O buffer level. This mechanism obviates the need for ad-hoc inversion in any applets, but was not exposed until now. Any pin can now be inverted via the command-line interface using one of the following syntaxes:

* single pin: `--pin-x 0#`
* pin range:  `--pins-x 0:8#`      (inverts all of them)
* pin list:   `--pins-x 0,1#,2#,3` (inverts only specified pins)

Pull-ups configured for a pin with inversion get converted to pull-downs and vice versa.

The ad-hoc inversion functionality is now removed from all other applets, since it is not needed, rather sparsely tested, and complicates upstreaming to amaranth-stdio (which has no need for ad-hoc inversion and will not accept it).