### PR TITLE
docs: provide a more gentle introduction to applets

### DIFF
--- a/docs/manual/src/use/basic.rst
+++ b/docs/manual/src/use/basic.rst
@@ -62,12 +62,7 @@ Working with applets
 
 ``glasgow`` is based around the concept of `applets`, with each implementing a particular mode of operation or interface. For example, there are applets such as ``uart``, ``i2c`` and ``spi``---each implementing the gateware (which runs on the FPGA) and software (which runs on the host PC). The Glasgow software framework coordinates building, caching, and operating these applets for you.
 
-A list of available applets can be shown by running ``glasgow run --help``; the list of applets is retrieved from the |pypackage_toml|_.  (:ref:`Using applets from out-of-tree is experimental <applet>`, and not covered in the basic usage instructions.)
-
-.. |pypackage_toml| replace:: ``glasgow`` package's ``pyproject.toml``
-.. _pypackage_toml: https://github.com/GlasgowEmbedded/glasgow/blob/main/software/pyproject.toml
-
-You can interact with applets from the ``glasgow`` tool in one of four ways:
+A list of available applets [#applet_sources]_ can be shown by running ``glasgow run --help``.  You can interact with applets from the ``glasgow`` tool in one of four ways:
 
 * **Running an applet**.  Most applets come with command line programs that perform a specific task related to the gateware that they interface with; ``glasgow run`` ning an applet allows you to invoke one or more of these applet-associated programs.  This usage is described below.
 
@@ -173,3 +168,8 @@ The ``i2c-initiator`` applet implements an I²C initiator, which facilitates a s
     $ glasgow run i2c-initiator -V 3.3 --pulls scan
 
 Using the :ref:`repl or script modes <repl-script>`, it's possible to easily communicate with devices, obeying clock stretching and other factors that are often ignored with bit-banged interfaces.
+
+.. [#applet_sources] In the current Glasgow software, all applets are packaged as part of the Glasgow software distribution; future versions of Glasgow :ref:`may support out-of-tree applets <applet>`.  For the curious, the list of applets is retrieved from the `installed package's metadata <https://packaging.python.org/en/latest/guides/creating-and-discovering-plugins/#using-package-metadata>`_; this list, in turn, comes from the |pyproject_toml|_ file's ``project.entry-points."glasgow.applet"`` section.
+
+.. |pyproject_toml| replace:: ``glasgow`` package's ``pyproject.toml``
+.. _pyproject_toml: https://github.com/GlasgowEmbedded/glasgow/blob/main/software/pyproject.toml

--- a/docs/manual/src/use/basic.rst
+++ b/docs/manual/src/use/basic.rst
@@ -152,7 +152,7 @@ Aside from the ``tty`` mode, others are available (``pty``, ``socket``), which a
     $ glasgow run uart -V 3.3 --pin-tx 0 --pin-rx 1 -b 57600 tty
 
 
-SPI Controller
+SPI controller
 ##############
 
 The ``spi-controller`` applet implements an SPI controller, allowing full-duplex transfer to an SPI device. The following command will assert `CS#`, send the five bytes ``03 01 23 5f f5``, and then de-assert `CS#`, before printing the received data to the console.
@@ -163,7 +163,7 @@ The ``spi-controller`` applet implements an SPI controller, allowing full-duplex
         '0301235ff5'
 
 
-I²C Initiator
+I²C initiator
 #############
 
 The ``i2c-initiator`` applet implements an I²C initiator, which facilitates a simple bus scan from the command line, using the on-board pull-up resistors.

--- a/docs/manual/src/use/basic.rst
+++ b/docs/manual/src/use/basic.rst
@@ -43,7 +43,7 @@ To begin with, use the ``glasgow safe`` command to make sure that the ``glasgow`
 
     $ glasgow safe
 
-.. note:: This command has the same effect as pressing the physical `E-STOP / RESET` button that is present on ``revC3`` and later hardware revisions.
+.. note:: This command has the same effect as pressing the physical `E-STOP / RESET` button that is present on ``revC3`` and later hardware revisions.  You may prefer to get in the habit of using the physical button if you're sitting next to your Glasgow; the button gives you tactile feedback to indicate that the device has entered a safe state, in a way that ``glasgow`` cannot!
 
 You can use this command at any time to put your Glasgow hardware into a `safe` state; if it is successful, it will provide the output:
 

--- a/docs/manual/src/use/basic.rst
+++ b/docs/manual/src/use/basic.rst
@@ -43,7 +43,7 @@ To begin with, use the ``glasgow safe`` command to make sure that the ``glasgow`
 
     $ glasgow safe
 
-.. note:: This command has the same effect as pressing the physical `E-STOP / RESET` button that is present on ``revC3`` and later hardware revisions.  You may prefer to get in the habit of using the physical button if you're sitting next to your Glasgow; the button gives you tactile feedback to indicate that the device has entered a safe state, in a way that ``glasgow`` cannot!
+.. note:: This command has the same effect as pressing the physical `E-STOP / RESET` button that is present on ``revC3`` and later hardware revisions.  You may prefer to get in the habit of using the physical button if you're sitting next to your Glasgow; the button gives tactile feedback that the device has entered a safe state, in a way that ``glasgow safe`` cannot!
 
 You can use this command at any time to put your Glasgow hardware into a `safe` state; if it is successful, it will provide the output:
 

--- a/docs/manual/src/use/basic.rst
+++ b/docs/manual/src/use/basic.rst
@@ -103,14 +103,14 @@ Putting it together, the following command will run the ``uart`` applet, with an
 
 .. code:: console
 
-    $ glasgow run uart -V 3.3 --pin-tx 0 --pin-rx 1 tty
+    $ glasgow run uart -V 3.3 --pin-tx 0 --pin-rx 1 socket tcp:127.0.0.1:4321
     I: g.device.hardware: generating bitstream ID [...]
     I: g.cli: running handler for applet 'uart'
     I: g.applet.interface.uart: port(s) A, B voltage set to 3.3 V
     I: g.applet.interface.uart: port(s) A, B pull resistors configured
-    I: g.applet.interface.uart: running on a TTY; enter `Ctrl+\ q` to quit
+    I: g.applet.interface.uart: socket: listening at tcp:127.0.0.1:4321
 
-As the applet's output suggests, you can press Ctrl-``\`` followed by ``q`` to quit this specific program.
+As the applet's output suggests, you can connect to TCP port 4321 using a tool of your choice---``nc`` or PuTTY will both work.
 
 
 Specifying port numbers
@@ -124,7 +124,7 @@ In some cases, you may want to use ``B3`` without using port A, which can be ach
 
 .. code:: console
 
-    $ glasgow run uart -V 3.3 --port B --pin-tx 3 tty
+    $ glasgow run uart -V 3.3 --port B --pin-tx 3 socket tcp:127.0.0.1:4321
 
 
 Examples

--- a/docs/manual/src/use/basic.rst
+++ b/docs/manual/src/use/basic.rst
@@ -1,74 +1,125 @@
 Basic usage
 ===========
 
-How do I use Glasgow?
----------------------
 
-After :ref:`installing <initial-setup>` the Glasgow software, the ``glasgow`` utility should be operational:
+Getting started with Glasgow
+----------------------------
+
+After :ref:`installing <initial-setup>` the Glasgow software, the ``glasgow`` utility should be operational.  The ``glasgow`` utility is the most common (but not the only) way to interact with Glasgow hardware.  Test to see if ``glasgow`` is installed correctly with:
 
 .. code:: console
 
     $ glasgow --version
 
-Glasgow has a number of commands, the most basic being ``safe`` and ``run``. At all times, the ``--help`` argument may be appended for more details.
+``glasgow`` has a number of subcommands. At all times, the ``--help`` argument may be appended for more details.
 
-.. important::
+.. note::
 
-    Please be aware that a Glasgow device that is unable to establish a USB connection will slowly fade the `FX2` LED on and off to indicate a failure. This most commonly occurs if you use a power-only USB cable to connect the Glasgow device to your computer.
+  As you build up the ``glasgow`` tool's command line, the `context` changes---for example, the output of each of the following ``--help`` s are all different:
+
+  .. code:: console
+
+      $ glasgow --help
+      $ glasgow run --help
+      $ glasgow run uart --help
+
+  The upshot of this is that different arguments need to be placed at different positions in the command line. The help section at each level should clarify where each argument should be placed. For example, the ``--serial`` parameter is recognized by the top-level ``glasgow`` command, and not by the third-level ``glasgow run uart`` command.
+
+  .. code:: console
+
+      ## this is valid:
+      $ glasgow --serial ${my_serial} run uart -V 3.3 tty
+
+      ## this is invalid!
+      $ glasgow run uart --serial ${my_serial} -V 3.3 tty
 
 
-``glasgow safe``
-################
+Returning Glasgow to a safe state
+#################################
 
-.. note:: This command has the same effect as pressing the physical `E-STOP / RESET` button that is present on ``revC3`` and later hardware revisions.
-
-Set all I/O to a `safe` state---disable voltage outputs, and set all I/O pins to a high impedance state.
+To begin with, use the ``glasgow safe`` command to make sure that the ``glasgow`` utility can communicate with your Glasgow hardware.   The ``glasgow safe`` command sets all I/O to a `safe` state---it disables voltage outputs, and sets all I/O pins to a high impedance state.  Try it with:
 
 .. code:: console
 
     $ glasgow safe
 
+.. note:: This command has the same effect as pressing the physical `E-STOP / RESET` button that is present on ``revC3`` and later hardware revisions.
 
-``glasgow run ...``
-###################
+You can use this command at any time to put your Glasgow hardware into a `safe` state; if it is successful, it will provide the output:
 
-Glasgow is based around the concept of `applets`, with each implementing a particular mode of operation or interface. For example, there are applets such as ``uart``, ``i2c`` and ``spi``---each implementing the gateware (which runs on the FPGA) and software (which runs on the host PC). The Glasgow framework coordinates building, caching, and operating these applets for you.
+.. code:: console
 
-A common argument is ``-V ...``, which sets the I/O voltage, as well as the supply output voltage for the selected port(s). Be careful that you set the correct voltage for your connected devices.
+    $ glasgow safe
+    I: g.cli: all ports safe
 
-The following command will run the ``uart`` applet, with an I/O voltage of 3.3 V, and will configure pin ``A0`` to be `Tx` (Glasgow transmitting), and pin ``A1`` to be `Rx` (Glasgow receiving):
+.. tip::
+
+    If the ``glasgow`` tool cannot detect your connected Glasgow hardware, look at the LEDs.  A Glasgow device that is unable to establish a USB connection will slowly fade the `FX2` LED on and off to indicate a failure. This most commonly occurs if you use a power-only USB cable to connect the Glasgow device to your computer.
+
+
+Working with applets
+--------------------
+
+``glasgow`` is based around the concept of `applets`, with each implementing a particular mode of operation or interface. For example, there are applets such as ``uart``, ``i2c`` and ``spi``---each implementing the gateware (which runs on the FPGA) and software (which runs on the host PC). The Glasgow software framework coordinates building, caching, and operating these applets for you.
+
+A list of available applets can be shown by running ``glasgow run --help``; the list of applets is retrieved from the |pypackage_toml|_.  (:ref:`Running applets from out-of-tree is experimental <applet>`, and not covered in the basic usage instructions.)
+
+.. |pypackage_toml| replace:: ``glasgow`` package's ``pyproject.toml``
+.. _pypackage_toml: https://github.com/GlasgowEmbedded/glasgow/blob/main/software/pyproject.toml
+
+You can interact with applets from the ``glasgow`` tool in one of four ways:
+
+* **Running an applet**.  Most applets come with command line programs that perform a specific task related to the gateware that they interface with; ``glasgow run`` ning an applet allows you to invoke one or more of these applet-associated programs.  This usage is described below.
+
+* **Using an applet from the REPL.**  Applets provide a Python programming interface.  ``glasgow repl`` launches a Python prompt (a "REPL") that you can use to interactively explore the gateware implemented by an applet, and hardware connected to it.  This is described in the :ref:`REPL & script operation <repl-script>` section.
+
+* **Scripting an applet**.  It is often useful to use an applet's Python programming interface non-interactively, to run a stored set of operations using the Glasgow platform.  This is described in the :ref:`script usage <script-usage>` section.
+
+* **Using an offline tool**.  Some applets come with offline tools that do not use the Glasgow hardware at all.  For instance, the ``memory-floppy`` applet has a tool to manipulate raw disk images that may have been captured by ``glasgow run`` ning the applet.  This is not currently described in this document, but can be accessed with the ``glasgow tool`` command.
+
+In this basic usage, we describe only using ``glasgow run`` to run an applet.
+
+
+Using ``glasgow run``
+#####################
+
+Applets that have ``run`` nable programs often have `subcommands` to specify what task you would like to accomplish.  For instance, the ``uart`` applet has three subcommands -- ``tty``, which attaches the UART to stdin; ``pty``, which creates a UNIX pseudoterminal; and ``socket``, which attaches the UART to either a UNIX or TCP socket.  You can get a list of an applet's subcommands by using the ``--help`` argument; each subcommand may also have arguments of its own:
+
+.. code:: console
+
+    $ glasgow run uart --help
+    [...]
+    positional arguments:
+      OPERATION
+        tty                     connect UART to stdin/stdout
+        pty                     connect UART to a pseudo-terminal device file
+        socket                  connect UART to a socket
+    [...]
+    $ glasgow run socket --help
+    usage: glasgow run uart socket [-h] ENDPOINT
+    
+    positional arguments:
+      ENDPOINT    listen at ENDPOINT, either unix:PATH or tcp:HOST:PORT
+    [...]
+
+Applets also can have `build arguments` that specify how the gateware is constructed, and `run arguments` that modify the behavior of the applet as a whole; these are also listed in the ``--help`` output.  A common run argument is ``-V ...``, which sets the I/O voltage, as well as setting the supply output voltage for the selected port(s). Be careful that you set the correct voltage for your connected devices!
+
+Putting it together, the following command will run the ``uart`` applet, with an I/O voltage of 3.3 V, and will configure pin ``A0`` to be `Tx` (Glasgow transmitting), and pin ``A1`` to be `Rx` (Glasgow receiving).  It uses the ``tty`` subcommand to provide output from the UART directly to the console:
 
 .. code:: console
 
     $ glasgow run uart -V 3.3 --pin-tx 0 --pin-rx 1 tty
+    I: g.device.hardware: generating bitstream ID [...]
+    I: g.cli: running handler for applet 'uart'
+    I: g.applet.interface.uart: port(s) A, B voltage set to 3.3 V
+    I: g.applet.interface.uart: port(s) A, B pull resistors configured
+    I: g.applet.interface.uart: running on a TTY; enter `Ctrl+\ q` to quit
 
-A list of available applets can be retrieved by running ``glasgow run --help``.
-
-
-Command line format
--------------------
-
-As you build up the Glasgow command line, the `context` changes---for example the output of the following ``--help`` are all different.
-
-.. code:: console
-
-    $ glasgow --help
-    $ glasgow run --help
-    $ glasgow run uart --help
-
-The upshot of this is that different arguments need to be placed at different positions in the command line. The help section at each level should clarify where each argument should be placed. For example, the ``--serial`` parameter is recognized by the top-level ``glasgow`` command, and not by the third-level ``glasgow run uart`` command.
-
-.. code:: console
-
-    ## this is valid:
-    $ glasgow --serial ${my_serial} run uart -V 3.3 tty
-
-    ## this is invalid!
-    $ glasgow run uart --serial ${my_serial} -V 3.3 tty
+As the applet's output suggests, you can press Ctrl-``\`` followed by ``q`` to quit this specific program.
 
 
-Ports and pin numbering
------------------------
+Specifying port numbers
+#######################
 
 The ``revC`` hardware has two ports (A and B), each of which have 8× I/O pins. When running the ``glasgow`` utility, you will see reference to a ``--port`` argument, along with ``--pin-*``, as defined by each applet (e.g: ``--pin-tx`` for UART).
 

--- a/docs/manual/src/use/basic.rst
+++ b/docs/manual/src/use/basic.rst
@@ -60,7 +60,7 @@ You can use this command at any time to put your Glasgow hardware into a `safe` 
 Working with applets
 --------------------
 
-``glasgow`` is based around the concept of `applets`, with each implementing a particular mode of operation or interface. For example, there are applets such as ``uart``, ``i2c`` and ``spi``---each implementing the gateware (which runs on the FPGA) and software (which runs on the host PC). The Glasgow software framework coordinates building, caching, and operating these applets for you.
+``glasgow`` is based around the concept of `applets`, with each implementing a particular mode of operation or interface. For example, there are applets such as ``uart``, ``i2c-initiator``, and ``spi-controller``---each implementing the gateware (which runs on the FPGA) and software (which runs on the host PC). The Glasgow software framework coordinates building, caching, and operating these applets for you.
 
 A list of available applets [#applet_sources]_ can be shown by running ``glasgow run --help``.  You can interact with applets from the ``glasgow`` tool in one of four ways:
 

--- a/docs/manual/src/use/basic.rst
+++ b/docs/manual/src/use/basic.rst
@@ -62,7 +62,7 @@ Working with applets
 
 ``glasgow`` is based around the concept of `applets`, with each implementing a particular mode of operation or interface. For example, there are applets such as ``uart``, ``i2c`` and ``spi``---each implementing the gateware (which runs on the FPGA) and software (which runs on the host PC). The Glasgow software framework coordinates building, caching, and operating these applets for you.
 
-A list of available applets can be shown by running ``glasgow run --help``; the list of applets is retrieved from the |pypackage_toml|_.  (:ref:`Running applets from out-of-tree is experimental <applet>`, and not covered in the basic usage instructions.)
+A list of available applets can be shown by running ``glasgow run --help``; the list of applets is retrieved from the |pypackage_toml|_.  (:ref:`Using applets from out-of-tree is experimental <applet>`, and not covered in the basic usage instructions.)
 
 .. |pypackage_toml| replace:: ``glasgow`` package's ``pyproject.toml``
 .. _pypackage_toml: https://github.com/GlasgowEmbedded/glasgow/blob/main/software/pyproject.toml

--- a/docs/manual/src/use/basic.rst
+++ b/docs/manual/src/use/basic.rst
@@ -15,7 +15,7 @@ After :ref:`installing <initial-setup>` the Glasgow software, the ``glasgow`` ut
 
 .. note::
 
-  As you build up the ``glasgow`` tool's command line, the `context` changes---for example, the output of each of the following ``--help`` s are all different:
+  As you build up the ``glasgow`` tool's command line, the `context` changes --- for example, the output of each of the following ``--help`` s are all different:
 
   .. code:: console
 
@@ -37,7 +37,7 @@ After :ref:`installing <initial-setup>` the Glasgow software, the ``glasgow`` ut
 Returning Glasgow to a safe state
 #################################
 
-To begin with, use the ``glasgow safe`` command to make sure that the ``glasgow`` utility can communicate with your Glasgow hardware.   The ``glasgow safe`` command sets all I/O to a `safe` state---it disables voltage outputs, and sets all I/O pins to a high impedance state.  Try it with:
+To begin with, use the ``glasgow safe`` command to make sure that the ``glasgow`` utility can communicate with your Glasgow hardware.   The ``glasgow safe`` command sets all I/O to a `safe` state --- it disables voltage outputs, and sets all I/O pins to a high impedance state.  Try it with:
 
 .. code:: console
 
@@ -60,7 +60,7 @@ You can use this command at any time to put your Glasgow hardware into a `safe` 
 Working with applets
 --------------------
 
-``glasgow`` is based around the concept of `applets`, with each implementing a particular mode of operation or interface. For example, there are applets such as ``uart``, ``i2c-initiator``, and ``spi-controller``---each implementing the gateware (which runs on the FPGA) and software (which runs on the host PC). The Glasgow software framework coordinates building, caching, and operating these applets for you.
+``glasgow`` is based around the concept of `applets`, with each implementing a particular mode of operation or interface. For example, there are applets such as ``uart``, ``i2c-initiator``, and ``spi-controller`` --- each implementing the gateware (which runs on the FPGA) and software (which runs on the host PC). The Glasgow software framework coordinates building, caching, and operating these applets for you.
 
 A list of available applets [#applet_sources]_ can be shown by running ``glasgow run --help``.  You can interact with applets from the ``glasgow`` tool in one of four ways:
 
@@ -110,7 +110,7 @@ Putting it together, the following command will run the ``uart`` applet, with an
     I: g.applet.interface.uart: port(s) A, B pull resistors configured
     I: g.applet.interface.uart: socket: listening at tcp:127.0.0.1:4321
 
-As the applet's output suggests, you can connect to TCP port 4321 using a tool of your choice---``nc`` or PuTTY will both work.
+As the applet's output suggests, you can connect to TCP port 4321 using a tool of your choice --- ``nc`` or PuTTY will both work.
 
 
 Specifying port numbers
@@ -136,7 +136,7 @@ UART
 
 The ``uart`` applet provides a basic full-duplex UART interface that can operate at virtually any reasonable baudrate, and also supports automatically detecting the baudrate based on frames sent by the remote device. The transmit and receive signals can also be easily inverted.
 
-By running the applet using the ``tty`` mode, you will be delivered a direct pipe to the UART---characters you enter into the terminal will be transmitted by the Glasgow hardware, and characters received by the Glasgow hardware will appear in the terminal.
+By running the applet using the ``tty`` mode, you will be delivered a direct pipe to the UART --- characters you enter into the terminal will be transmitted by the Glasgow hardware, and characters received by the Glasgow hardware will appear in the terminal.
 
 The baud rate can be set using ``-b 57600``, and automatic baud rate detection can be enabled with ``-a``. Although reliable and particularly convenient for devices that change their baud rate as they boot, this detection mechanism is not perfect, and sometimes you may have to set the baud rate manually.
 

--- a/docs/manual/src/use/repl-script.rst
+++ b/docs/manual/src/use/repl-script.rst
@@ -177,6 +177,8 @@ And all off again, followed by a full power-down of the I/O:
 Hopefully this example starts to show you the power you have available.
 
 
+.. _script-usage:
+
 How do I use a script?
 ----------------------
 

--- a/software/glasgow/applet/__init__.py
+++ b/software/glasgow/applet/__init__.py
@@ -28,10 +28,10 @@ class GlasgowAppletError(Exception):
     """An exception raised when an applet encounters an error."""
 
 
-# A Glasgow applet is defined by a class; known applets are listed in the
-# `[project.entry-points."glasgow.applet"]` section of the pyproject.toml.
-# Experimentally, Glasgow applets can be "injected" from out-of-tree; see
-# `glasgow/examples/out_of_tree/README.md` for more discussion of this.
+# A Glasgow applet is defined by a class; known applets are taken from a
+# list of entry points in package metadata.  (In the Glasgow package, they
+# are enumerated in the `[project.entry-points."glasgow.applet"]` section of
+# the pyproject.toml.
 
 class GlasgowApplet(metaclass=ABCMeta):
     preview = False

--- a/software/glasgow/applet/__init__.py
+++ b/software/glasgow/applet/__init__.py
@@ -28,6 +28,11 @@ class GlasgowAppletError(Exception):
     """An exception raised when an applet encounters an error."""
 
 
+# A Glasgow applet is defined by a class; known applets are listed in the
+# `[project.entry-points."glasgow.applet"]` section of the pyproject.toml.
+# Experimentally, Glasgow applets can be "injected" from out-of-tree; see
+# `glasgow/examples/out_of_tree/README.md` for more discussion of this.
+
 class GlasgowApplet(metaclass=ABCMeta):
     preview = False
     help = "applet help missing"


### PR DESCRIPTION
I had some confusion in the Glasgow real-time chat channels recently around when it would be appropriate to write an applet vs. to write a subcommand; subsequently, I had more confusion when I was reading the source code around how applets were defined.  This pull request shores up the documentation in a few ways:

* Adjusts the getting started guide to now read as a suggested flow -- both a flow for first steps in using the device, and a suggested conceptual flow to understand applets (where they come from, and how they can be used).
* Tweaks usage to always refer to the command line tool as `glasgow`, but the hardware or environment as "Glasgow".
* Reorganizes the documentation to make the "applet" the central concept.
* Adds a link to how applets are enumerated, for silly people who are just reading the source and docs from a browser on a phone and not actually running `glasgow run --help` :-)

I've tried to keep this within the voice already used by Glasgow, and in the documentation style guidelines, but my documentation voice is also kind of opinionated.  In particular, I didn't really get a good sense for what voice the documentation preferred to use to describe itself; I half-heartedly used "we" and "you" rather than "the documentation" and "the user" because it seems friendlier (and because I am used to using the royal "we" in documentation), though I note also that the REPL page uses "I".  If you have other suggestions to homogenize the documentation voice I am happy to make those changes.

Feel free to request changes, provide nits or general comments, make changes on your own without my involvement, or even just shrug if you don't have time to think too hard about this right now!