### PR TITLE
Isabelburgos/spi controller applets padless

### DIFF
--- a/software/glasgow/applet/display/pdi/__init__.py
+++ b/software/glasgow/applet/display/pdi/__init__.py
@@ -389,14 +389,18 @@ class DisplayPDIApplet(GlasgowApplet):
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
 
         ports = iface.get_port_group(
-            power=args.pin_power,
-            disch=args.pin_disch,
-            pwm=args.pin_pwm,
-            reset=args.pin_reset,
+            power = args.pin_power,
+            disch = args.pin_disch,
+            reset = args.pin_reset,
+            cs    = args.pin_cs,
+            sck   = args.pin_sck,
+            cipo  = args.pin_cipo,
+            copi  = args.pin_copi,
+            pwm   = args.pin_pwm,
         )
 
         controller = SPIControllerSubtarget(
-            pads=iface.get_deprecated_pads(args, pins=("cs", "sck", "cipo", "copi")),
+            ports=ports,
             out_fifo=iface.get_out_fifo(),
             in_fifo=iface.get_in_fifo(auto_flush=False),
             period_cyc=math.ceil(target.sys_clk_freq / 5e6),

--- a/software/glasgow/applet/interface/spi_controller/test.py
+++ b/software/glasgow/applet/interface/spi_controller/test.py
@@ -1,5 +1,6 @@
 import types
 from amaranth import *
+from amaranth.lib import io
 
 from ... import *
 from . import SPIControllerApplet
@@ -14,8 +15,9 @@ class SPIControllerAppletTestCase(GlasgowAppletTestCase, applet=SPIControllerApp
     def setup_loopback(self):
         self.build_simulated_applet()
         mux_iface = self.applet.mux_interface
+        ports = mux_iface._subtargets[0].ports
         m = Module()
-        m.d.comb += mux_iface.pads.cipo_t.i.eq(mux_iface.pads.copi_t.o)
+        m.d.comb += ports.cipo.i.eq(ports.copi.o)
         self.target.add_submodule(m)
 
     @applet_simulation_test("setup_loopback",
@@ -27,7 +29,8 @@ class SPIControllerAppletTestCase(GlasgowAppletTestCase, applet=SPIControllerApp
         mux_iface = self.applet.mux_interface
         spi_iface = yield from self.run_simulated_applet()
 
-        self.assertEqual((yield mux_iface.pads.cs_t.o), 1)
+        ports = mux_iface._subtargets[0].ports
+        self.assertEqual((yield ports.cs.o), 1)
         result = yield from spi_iface.exchange([0xAA, 0x55, 0x12, 0x34])
         self.assertEqual(result, bytearray([0xAA, 0x55, 0x12, 0x34]))
-        self.assertEqual((yield mux_iface.pads.cs_t.o), 1)
+        self.assertEqual((yield ports.cs.o), 1)


### PR DESCRIPTION
Part of #599.

The purpose of these changes is to
- modify `applet.interface.spi_controller` to use port groups
- modify applets that depend on spi_controller to also use port groups

Applets that were modified:
- program.avr.spi
- program.nrf24lx1
- program.ice40_sram
- radio.nrf24l01
- display.pdi

Points for discussion:

- which ports in SPIControllerBus are required, and which are optional? for example, the program.avr.spi applet does not use a "cs" pin argument, so I gated the creation of cs_buffer in spi-controller behind both `if hasattr(self.ports, "cs")` and `if self.ports.cs is not None`. 
- how to access ports from an applet simulation interface, since `iface.pads` is deprecated? the most minimal solution I could find is `ports = mux_iface._subtargets[0].ports`