### PR TITLE
Optimize code size (and speed) by using bit access instructions when accessing IO* registers

### DIFF
--- a/firmware/adc_adc081c.c
+++ b/firmware/adc_adc081c.c
@@ -146,7 +146,7 @@ bool iobuf_get_alert_adc081c(uint8_t selector,
 }
 
 bool iobuf_is_alerted_adc081c() {
-  return !(IOA & (1<<PINA_ALERT_N));
+  return !(IO_ALERT_N);
 }
 
 bool iobuf_poll_alert_adc081c(__xdata uint8_t *mask, bool clear) {

--- a/firmware/dac_ldo.c
+++ b/firmware/dac_ldo.c
@@ -15,17 +15,19 @@ static const struct buffer_desc buffers[] = {
 
 void iobuf_init_dac_ldo() {
   // Configure I/O buffer pins as open-source/open-drain; they have 100k pulls
-  IOD  = IOD & ~((1<<PIND_ENVA)|(1<<PIND_ENVB)) | (1<<PIND_OEQ_N_REVAB);
+  IO_ENVA = 0;
+  IO_ENVB = 0;
+  IO_OEQ_N_REVAB = 1;
   OED |=        ((1<<PIND_ENVA)|(1<<PIND_ENVB)  | (1<<PIND_OEQ_N_REVAB));
 
   // Enable I/O buffers, just existing on revAB
-  IOD &= ~ (1<<PIND_OEQ_N_REVAB);
+  IO_OEQ_N_REVAB = 0;
 }
 
 void iobuf_enable(bool on) {
   // I/O buffers just existing on revAB, pin is unconnected on revC
-  if(on) IOD &= ~(1<<PIND_OEQ_N_REVAB);
-  else   IOD |=  (1<<PIND_OEQ_N_REVAB);
+  if(on) IO_OEQ_N_REVAB = 0;
+  else   IO_OEQ_N_REVAB = 1;
 }
 
 static bool dac_start(uint8_t mask, bool read) {

--- a/firmware/fpga.c
+++ b/firmware/fpga.c
@@ -10,13 +10,13 @@ void fpga_init() {
 
 // Also sets the LED status, for code size reasons.
 bool fpga_is_ready() {
-  if(IOA & (1 << PINA_CDONE)) {
+  if(IO_CDONE) {
     if (!test_leds)
-      IOD |=  (1<<PIND_LED_ICE);
+      IO_LED_ICE = 1;
     return true;
   } else {
     if (!test_leds)
-      IOD &= ~(1<<PIND_LED_ICE);
+      IO_LED_ICE = 0;
     return false;
   }
 }
@@ -27,9 +27,9 @@ void fpga_reset() {
     case GLASGOW_REV_B:
       // Reset the FPGA.
       OED |=  (1<<PIND_CRESET_N_REVAB);
-      IOD &= ~(1<<PIND_CRESET_N_REVAB);
+      IO_CRESET_N_REVAB = 0;
       delay_us(1);
-      IOD |=  (1<<PIND_CRESET_N_REVAB);
+      IO_CRESET_N_REVAB = 1;
       break;
 
     case GLASGOW_REV_C0:
@@ -52,10 +52,10 @@ void fpga_reset() {
       delay_ms(250);
 
       // Reset the FPGA now that it's safe to do so.
-      OEA |=  (1<<PINA_CRESET_N_REVC);
-      IOA &= ~(1<<PINA_CRESET_N_REVC);
+      OEA |= (1<<PINA_CRESET_N_REVC);
+      IO_CRESET_N_REVC = 0;
       delay_us(1);
-      IOA |=  (1<<PINA_CRESET_N_REVC);
+      IO_CRESET_N_REVC = 1;
       break;
     }
   }
@@ -69,8 +69,8 @@ void fpga_reset() {
   // Enable FPGA configuration interface.
   OEA &= ~(1<<PINA_CDONE);
   OEB |=  (1<<PINB_SCK)|(1<<PINB_SS_N)|(1<<PINB_SI);
-  IOB |=  (1<<PINB_SCK);
-  IOB &= ~(1<<PINB_SS_N);
+  IO_SCK = 1;
+  IO_SS_N = 0;
 
   // Wait for FPGA to initialize. This is specified as 800 us for the UP5K FPGA on revAB, and
   // 1200 us for the HX8K FPGA on revC.

--- a/firmware/glasgow.h
+++ b/firmware/glasgow.h
@@ -49,6 +49,30 @@ enum {
 #define PIND_ENVB             6
 #define PIND_OEQ_N_REVAB      7
 
+// Set up aliases for all of the GPIO pins accessible by `setb` and `clr`
+// to reduce code size.
+#define CONCAT(a, b) a ## b
+#define IO_A(number) CONCAT(PA, number)
+#define IO_B(number) CONCAT(PB, number)
+#define IO_D(number) CONCAT(PD, number)
+
+#define IO_ALERT_N        IO_A(PINA_ALERT_N)
+#define IO_CDONE          IO_A(PINA_CDONE)
+#define IO_CRESET_N_REVC  IO_A(PINA_CRESET_N_REVC)
+
+#define IO_SI             IO_B(PINB_SI)
+#define IO_SS_N           IO_B(PINB_SS_N)
+#define IO_SCK            IO_B(PINB_SCK)
+
+#define IO_ENVA           IO_D(PIND_ENVA)
+#define IO_CRESET_N_REVAB IO_D(PIND_CRESET_N_REVAB)
+#define IO_LED_FX2        IO_D(PIND_LED_FX2)
+#define IO_LED_ICE        IO_D(PIND_LED_ICE)
+#define IO_LED_ACT        IO_D(PIND_LED_ACT)
+#define IO_LED_ERR        IO_D(PIND_LED_ERR)
+#define IO_ENVB           IO_D(PIND_ENVB)
+#define IO_OEQ_N_REVAB    IO_D(PIND_OEQ_N_REVAB)
+
 enum {
   // I2C addresses (unshifted)
   I2C_ADDR_FPGA            = 0b0001000,


### PR DESCRIPTION
Saves 33 bytes.