### PR TITLE
docs: Complete list of firmware build dependencies

### DIFF
--- a/docs/manual/src/develop/firmware.rst
+++ b/docs/manual/src/develop/firmware.rst
@@ -73,7 +73,7 @@ The firmware can only be built on a Unix-like system; to develop the firmware on
 
     .. code:: console
 
-        $ sudo dnf install -y make sdcc git python3-libusb1
+        $ sudo dnf install -y make sdcc git python3-libusb1 libusb1
 
 The source code of the chip support library `libfx2`_ used by the firmware is included in the Glasgow repository as a `git submodule`_. Make sure it is checked out at the appropriate revision and compiled:
 

--- a/docs/manual/src/develop/firmware.rst
+++ b/docs/manual/src/develop/firmware.rst
@@ -61,19 +61,19 @@ The firmware can only be built on a Unix-like system; to develop the firmware on
 
     .. code:: console
 
-        $ sudo apt install -y --no-install-recommends make sdcc
+        $ sudo apt install -y --no-install-recommends make sdcc git python3-usb1
 
 .. tab:: Arch
 
     .. code:: console
 
-        $ sudo pacman -Sy make sdcc
+        $ sudo pacman -Sy make sdcc git python-libusb1
 
 .. tab:: Fedora
 
     .. code:: console
 
-        $ sudo dnf install -y make sdcc
+        $ sudo dnf install -y make sdcc git python3-libusb1
 
 The source code of the chip support library `libfx2`_ used by the firmware is included in the Glasgow repository as a `git submodule`_. Make sure it is checked out at the appropriate revision and compiled:
 


### PR DESCRIPTION
I have tested all three install commands in docker containers for each of those systems.
**Note that at the moment on fedora:latest it doesn't build because the name of the "sdcc" executable is "sdcc-sdcc".**
Fedora can be made to build by running `ln -s /usr/bin/sdcc-sdcc  /usr/bin/sdcc`
Not sure if we should mention that in the documentation, or make the libfx2 makefile autodetect it.