### PR TITLE
manual: develop/firmware: add note to fedora tab about path

### DIFF
--- a/docs/manual/src/develop/firmware.rst
+++ b/docs/manual/src/develop/firmware.rst
@@ -75,6 +75,14 @@ The firmware can only be built on a Unix-like system; to develop the firmware on
 
         $ sudo dnf install -y make sdcc git python3-libusb1 libusb1
 
+    .. note ::
+
+        On Fedora, the `sdcc` package installs the tools into a different location, which must be added to the search path:
+
+        .. code:: console
+
+            export PATH="/usr/libexec/sdcc:$PATH"
+
 The source code of the chip support library `libfx2`_ used by the firmware is included in the Glasgow repository as a `git submodule`_. Make sure it is checked out at the appropriate revision and compiled:
 
 .. code:: console


### PR DESCRIPTION
For reference:
Fedora changelog:
![image](https://github.com/user-attachments/assets/ae4a8d03-be88-4a85-9322-456280bd712f)
Fedora readme for SDCC:
![image](https://github.com/user-attachments/assets/e7ed1571-7140-4ce9-a78a-929a9ef4082b)
