### PR TITLE
firmware: move factored-out ep0 stall to end of fn (+13 bytes XRAM).

### DIFF
--- a/firmware/main.c
+++ b/firmware/main.c
@@ -779,10 +779,6 @@ void handle_pending_usb_setup() {
     }
 
     return;
-
-    // Factor out the stall exit to reduce code size.
-stall_ep0_return:
-    STALL_EP0();
   }
 
   // LED test mode request
@@ -833,6 +829,8 @@ stall_ep0_return:
     return;
   }
 
+  // Factor out the stall exit to reduce code size.
+stall_ep0_return:
   STALL_EP0();
 }
 


### PR DESCRIPTION
Whoops. 
I've introduced a bug here in https://github.com/GlasgowEmbedded/glasgow/pull/651
What happens when the goto path is taken is that EP0 is stalled twice, and HSNAK is cleared twice.
It's probably an almost zero probability that a new control transfer would arrive before the function returns,
but it's still a bug in my code, so apologies.