### PR TITLE
firmware: bugfix: rejected control transfer lingers (-2 bytes XRAM).

### DIFF
--- a/firmware/main.c
+++ b/firmware/main.c
@@ -816,6 +816,7 @@ void handle_pending_usb_setup() {
 
   // Factor out the stall exit to reduce code size.
 stall_ep0_return:
+  pending_setup = false;
   STALL_EP0();
 }
 


### PR DESCRIPTION
If a control transfer is rejected, in some cases `pending_setup` will remain true. Then the main loop will keep entering `handle_pending_usb_setup`, and there is a race condition with the `handle_usb_setup()` interrupt handler. Often the handle_usb_setup() interrupt handler will prevent follow-up correctly formed setup packets from completing.

note: This bug was present before my code size optimization patches too.