### PR TITLE
gateware.clockgen: Fix off-by-one error

### DIFF
--- a/software/glasgow/applet/audio/dac/__init__.py
+++ b/software/glasgow/applet/audio/dac/__init__.py
@@ -174,7 +174,7 @@ class AudioDACApplet(GlasgowApplet):
     def build(self, target, args):
         self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
         if args.frequency is None:
-            pulse_cyc = 0
+            pulse_cyc = 1
         else:
             pulse_cyc = self.derive_clock(clock_name="modulation",
                 input_hz=target.sys_clk_freq, output_hz=args.frequency * 1e6)
@@ -182,7 +182,7 @@ class AudioDACApplet(GlasgowApplet):
             input_hz=target.sys_clk_freq, output_hz=args.sample_rate,
             # Drift of sampling clock is extremely bad, so ensure it only happens insofar as
             # the oscillator on the board is imprecise, and with no additional error.
-            max_deviation_ppm=0)
+            max_deviation_ppm=0) - 1
         subtarget = iface.add_subtarget(AudioDACSubtarget(
             ports=iface.get_port_group(o = args.pin_set_o),
             out_fifo=iface.get_out_fifo(),

--- a/software/glasgow/applet/interface/spi_controller/__init__.py
+++ b/software/glasgow/applet/interface/spi_controller/__init__.py
@@ -350,7 +350,7 @@ class SPIControllerApplet(GlasgowApplet):
                                          min_cyc=4),
             delay_cyc=self.derive_clock(input_hz=target.sys_clk_freq,
                                         output_hz=1e6,
-                                        clock_name="delay"),
+                                        clock_name="delay") - 1,
             sck_idle=args.sck_idle,
             sck_edge=args.sck_edge,
         )

--- a/software/glasgow/applet/interface/uart/__init__.py
+++ b/software/glasgow/applet/interface/uart/__init__.py
@@ -173,7 +173,7 @@ class UARTApplet(GlasgowApplet):
         # a build argument, even though the applet will never be rebuilt as long as you stay
         # above 9600.
         max_bit_cyc = self.derive_clock(
-            input_hz=target.sys_clk_freq, output_hz=min(9600, args.baud))
+            input_hz=target.sys_clk_freq, output_hz=min(9600, args.baud)) - 1
 
         self.__sys_clk_freq = target.sys_clk_freq
 
@@ -215,7 +215,7 @@ class UARTApplet(GlasgowApplet):
         # Load the manually set baud rate.
         manual_cyc = self.derive_clock(
             input_hz=self.__sys_clk_freq, output_hz=args.baud,
-            min_cyc=2, max_deviation_ppm=args.tolerance)
+            min_cyc=2, max_deviation_ppm=args.tolerance) - 1
         await device.write_register(self.__addr_manual_cyc, manual_cyc, width=4)
         await device.write_register(self.__addr_use_auto, 0)
 

--- a/software/glasgow/applet/program/m16c/__init__.py
+++ b/software/glasgow/applet/program/m16c/__init__.py
@@ -332,7 +332,7 @@ class ProgramM16CApplet(GlasgowApplet):
 
     def build(self, target, args):
         self.__bit_cyc_for_baud = {
-            baud: self.derive_clock(input_hz=target.sys_clk_freq, output_hz=baud)
+            baud: self.derive_clock(input_hz=target.sys_clk_freq, output_hz=baud) - 1
             for baud in BAUD_RATES
         }
         max_bit_cyc = max(self.__bit_cyc_for_baud.values())

--- a/software/glasgow/gateware/clockgen.py
+++ b/software/glasgow/gateware/clockgen.py
@@ -69,8 +69,8 @@ class ClockGen(Elaboratable):
                 self.clk.eq(~self.clk),
             ]
             m.d.comb += [
-                self.stb_r.eq(~self.clk),
-                self.stb_f.eq(self.clk),
+                self.stb_r.eq(self.clk),
+                self.stb_f.eq(~self.clk),
             ]
 
         if self.cyc >= 3:

--- a/software/tests/gateware/test_clockgen.py
+++ b/software/tests/gateware/test_clockgen.py
@@ -1,7 +1,25 @@
 import unittest
 import re
+import random
 
+from amaranth import Elaboratable, Module
+from amaranth.sim import Tick
+
+from glasgow.gateware import simulation_test
 from glasgow.gateware.clockgen import ClockGen
+
+
+class ClockGenTestbench(Elaboratable):
+    def __init__(self):
+        self.cyc = None
+
+    def elaborate(self, platform):
+        m = Module()
+
+        assert self.cyc is not None
+        m.submodules.dut = self.dut = ClockGen(self.cyc)
+
+        return m
 
 
 class ClockGenTestCase(unittest.TestCase):
@@ -27,3 +45,45 @@ class ClockGenTestCase(unittest.TestCase):
                 re.escape("output frequency 30000.000 kHz deviates from requested frequency "
                           "18000.000 kHz by 666666 ppm, which is higher than 50000 ppm")):
             ClockGen.calculate(input_hz=30e6, output_hz=18e6, max_deviation_ppm=50000)
+
+    def test_freq_exact(self):
+        cyc, actual_output_hz, deviation_ppm = ClockGen.calculate(input_hz=100, output_hz=2)
+        self.assertEqual(cyc, 50)
+        self.assertEqual(actual_output_hz, 2)
+        self.assertEqual(deviation_ppm, 0)
+
+
+class ClockGenSimTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tb = ClockGenTestbench()
+
+    def configure(self, tb, cyc):
+        tb.cyc = cyc
+
+    @simulation_test(cyc=2)
+    def test_half_freq(self, tb):
+        for _ in range(5):
+            yield Tick()
+            self.assertEqual((yield tb.dut.clk), 1)
+            self.assertEqual((yield tb.dut.stb_r), 1)
+            yield Tick()
+            self.assertEqual((yield tb.dut.clk), 0)
+            self.assertEqual((yield tb.dut.stb_f), 1)
+
+    @simulation_test(cyc=random.randrange(3, 101))
+    def test_freq_counter(self, tb):
+        while (yield tb.dut.clk) != 1:
+            yield Tick()
+
+        for _ in range(5):
+            self.assertEqual((yield tb.dut.stb_r), 1)
+            for _ in range(tb.cyc // 2):
+                self.assertEqual((yield tb.dut.clk), 1)
+                yield Tick()
+                self.assertEqual((yield tb.dut.stb_r), 0)
+
+            self.assertEqual((yield tb.dut.stb_f), 1)
+            for _ in range(tb.cyc - tb.cyc // 2):
+                self.assertEqual((yield tb.dut.clk), 0)
+                yield Tick()
+                self.assertEqual((yield tb.dut.stb_f), 0)


### PR DESCRIPTION
This addresses GlasgowEmbedded/glasgow#667.

- The off-by-one in `ClockGen.derive` and `ClockGen.calculate` is fixed.
- `stb_r` and `stb_f` in the half-frequency special case are fixed to behave identically to the general case.
  - I'm not sure whether this will break existing applets, so this change can be removed.
- Tests are added for the new behaviour.