### PR TITLE
manual: exempt GitHub from anchor checking as a whole

### DIFF
--- a/docs/manual/src/conf.py
+++ b/docs/manual/src/conf.py
@@ -86,6 +86,6 @@ linkcheck_ignore = [
 linkcheck_anchors_ignore_for_url = [
     r"^https://matrix\.to/",
     r"^https://web\.libera\.chat/",
-    # React page with README content included as a JSON payload.
-    r"^https://github\.com/[^/]+/[^/]+/$",
+    # GitHub is a React-based SPA; even README content is included as a JSON payload.
+    r"^https://github\.com/",
 ]


### PR DESCRIPTION
This is currently breaking #669.