### PR TITLE
gateware.iostream.IOStreamer: fix bug for incorrect sampling DDR inputs

### DIFF
--- a/software/tests/gateware/test_iostream.py
+++ b/software/tests/gateware/test_iostream.py
@@ -96,6 +96,110 @@ class IOStreamTestCase(unittest.TestCase):
         with sim.write_vcd("test.vcd", fs_per_delta=1):
             sim.run()
 
+    def test_ddr_input_sampled_correctly(self):
+        """ This is a latency-agnostic test, that verifies that the IOStreamer samples the inputs at the same time as the output signals change """
+        ports = PortGroup()
+        ports.clk_out = io.SimulationPort("o", 1)
+        ports.data_in = io.SimulationPort("i", 8)
+
+        CLK_PERIOD = 1e-6
+
+        dut = IOStreamer({
+            "clk_out": ("o", 1),
+            "data_in": ("i", 8),
+        }, ports, ratio=2, meta_layout=4)
+
+        expected_sample = []
+        actually_sampled = []
+
+        async def input_generator_tb(ctx):
+            """
+            This generates input values at the the half-time between every falling/rising clock edge.
+            This is to make it very obvious what value should be sampled by each DDR edge.
+            Exactly which of these values will be sampled depends on the latency of the dut,
+            which this testcase is agnostic about.
+            """
+            cnt = 0xff
+            while True:
+                ctx.set(ports.data_in.i, cnt)
+                await ctx.tick()
+                await ctx.delay(CLK_PERIOD/4)
+                cnt = (cnt - 1) & 0xff
+                ctx.set(ports.data_in.i, cnt)
+                await ctx.delay(CLK_PERIOD/2) # half a clock cycle
+                cnt = (cnt - 1) & 0xff
+
+        async def save_expected_sample_values_tb(ctx):
+            """
+            This testbench looks at the clk_out port and when it sees a positive edge it knows that
+            IOStreamer is expected to sample the input signal, so the current state of the data_in port
+            becomes one of the expected sampled values. This is saved into expected_sample[] to be compared
+            later, when the sample actually arrives back on i_stream.
+            The way we look for the rising edge is a bit hairy, because the current implementation of
+            DDRBufferCanBeSimulated can generate glitches, so we wait DELAY_TO_AVOID_GLITCHES after
+            the clock edge, to make sure any glitches are resolved.
+            Because this is a DDR test, we also wait half a clock to save the other edge as well.
+            """
+            while True:
+                DELAY_TO_AVOID_GLITCHES = CLK_PERIOD/10
+
+                await ctx.posedge(ports.clk_out.o[0])
+                await ctx.delay(DELAY_TO_AVOID_GLITCHES)
+                while ctx.get(ports.clk_out.o[0]) == 0:
+                    await ctx.posedge(ports.clk_out.o[0])
+                    await ctx.delay(DELAY_TO_AVOID_GLITCHES)
+
+                value_phase_0 = ctx.get(ports.data_in.i)
+
+                await ctx.delay(CLK_PERIOD / 2)
+
+                value_phase_1 = ctx.get(ports.data_in.i)
+
+                expected_sample.append((value_phase_0, value_phase_1))
+
+        async def i_stream_consumer_tb(ctx):
+            """
+            This testbench saves all the samples coming in over i_stream
+            """
+            while True:
+                payload = await stream_get(ctx,dut.i_stream)
+                data = payload.port.data_in.i[0], payload.port.data_in.i[1]
+                actually_sampled.append(data)
+
+        async def main_testbench(ctx):
+            """
+            This testbench is the producer for o_stream, and it also serves as the main orchestrator
+            for the entire testcase. After it produces the stimulus, it waits a number of clock cycles
+            to make sure any input latency has passed, and then it verifies that the expected number
+            of bytes has been received, and that the expected values have been sampled.
+            """
+            await ctx.tick()
+
+            for i in range(0,8):
+                await stream_put(ctx, dut.o_stream, {"meta": i, "i_en": i % 2, "port": { "clk_out": {"o": (i % 2, 0)}}})
+
+            await stream_put(ctx, dut.o_stream, {"meta": 0, "i_en": 0, "port": { "clk_out": {"o": (0, 0)}}})
+
+            for i in range(20):
+                await ctx.tick()
+            assert len(actually_sampled) == 4 # This should be checked as well, because a possible failure mode is
+            # if IOStreamer never generates clock edges. We don't want to end up comparing two empty lists against
+            # eachother.
+
+            assert actually_sampled == expected_sample, (f"Expected [" +
+                    ", ".join(f"(0x{s0:02x}, 0x{s1:02x})" for s0, s1 in expected_sample) +
+                    "] Got [" +
+                    ", ".join(f"(0x{s0:02x}, 0x{s1:02x})" for s0, s1 in actually_sampled) + "]")
+
+        sim = Simulator(dut)
+        sim.add_clock(CLK_PERIOD)
+        sim.add_testbench(main_testbench)
+        sim.add_testbench(i_stream_consumer_tb, background = True)
+        sim.add_testbench(input_generator_tb, background=True)
+        sim.add_testbench(save_expected_sample_values_tb, background=True)
+        with sim.write_vcd("test.vcd", fs_per_delta=1):
+            sim.run()
+
     def test_basic(self):
         ports = PortGroup()
         ports.data = port = io.SimulationPort("io", 1)


### PR DESCRIPTION
This also adds a testcase to check the correct sampling time.