### PR TITLE
Improve QSPI tests

### DIFF
--- a/software/glasgow/gateware/iostream.py
+++ b/software/glasgow/gateware/iostream.py
@@ -27,6 +27,45 @@ def _map_ioshape(direction, ioshape, fn): # actually filter+map
     })
 
 
+class SimulatableDDRBuffer(io.DDRBuffer):
+    def elaborate(self, platform):
+        if not isinstance(self._port, io.SimulationPort):
+            return super().elaborate(platform)
+
+        # At the time of writing Amaranth DDRBuffer doesn't allow for simulation, this implements
+        # ICE40 semantics for simulation.
+        m = Module()
+
+        m.submodules.io_buffer = io_buffer = io.Buffer(self.direction, self.port)
+
+        if self.direction is not io.Direction.Output:
+            m.domains.i_domain_negedge = ClockDomain("i_domain_negedge", local=True)
+            m.d.comb += ClockSignal("i_domain_negedge").eq(~ClockSignal(self.i_domain))
+            i_ff = Signal(len(self.port), reset_less=True)
+            i_negedge_ff = Signal(len(self.port), reset_less=True)
+            i_final_ff = Signal(data.ArrayLayout(len(self.port), 2), reset_less=True)
+            m.d[self.i_domain] += i_ff.eq(io_buffer.i)
+            m.d["i_domain_negedge"] += i_negedge_ff.eq(io_buffer.i)
+            m.d[self.i_domain] += i_final_ff.eq(Cat(i_ff, i_negedge_ff))
+            m.d.comb += self.i.eq(i_final_ff)
+
+        if self.direction is not io.Direction.Input:
+            m.domains.o_domain_negedge = ClockDomain("o_domain_negedge", local=True)
+            m.d.comb += ClockSignal("o_domain_negedge").eq(~ClockSignal(self.o_domain))
+            o_ff = Signal(len(self.port), reset_less=True)
+            o_negedge_ff = Signal(len(self.port), reset_less=True)
+            oe_ff = Signal(reset_less=True)
+            m.d[self.o_domain] += o_ff.eq(self.o[0] ^ o_negedge_ff)
+            o1_ff = Signal(len(self.port), reset_less=True)
+            m.d[self.o_domain] += o1_ff.eq(self.o[1])
+            m.d["o_domain_negedge"] += o_negedge_ff.eq(o1_ff ^ o_ff)
+            m.d[self.o_domain] += oe_ff.eq(self.oe)
+            m.d.comb += io_buffer.o.eq(o_ff ^ o_negedge_ff)
+            m.d.comb += io_buffer.oe.eq(oe_ff)
+
+        return m
+
+
 class IOStreamer(wiring.Component):
     """I/O buffer to stream adapter.
 
@@ -88,7 +127,7 @@ class IOStreamer(wiring.Component):
             buffer_cls, latency = io.FFBuffer, 1
         if self._ratio == 2:
             # FIXME: should this be 2 or 3? the latency differs between i[0] and i[1]
-            buffer_cls, latency = io.DDRBuffer, 3
+            buffer_cls, latency = SimulatableDDRBuffer, 3
 
         if isinstance(self._ports, io.PortLike):
             m.submodules.buffer = buffer = buffer_cls("io", self._ports)

--- a/software/tests/gateware/test_qspi.py
+++ b/software/tests/gateware/test_qspi.py
@@ -249,13 +249,13 @@ class QSPITestCase(unittest.TestCase):
         with sim.write_vcd("test.vcd"):
             sim.run()
 
-    def test_qspi_controller(self):
+    def subtest_qspi_controller(self, *, use_ddr_buffers:bool, divisor:int):
         ports = PortGroup()
         ports.sck = io.SimulationPort("o",  1)
         ports.io  = io.SimulationPort("io", 4)
         ports.cs  = io.SimulationPort("o",  1)
 
-        dut = QSPIController(ports)
+        dut = QSPIController(ports, use_ddr_buffers=use_ddr_buffers)
 
         async def testbench_controller(ctx):
             async def ctrl_idle():
@@ -286,6 +286,8 @@ class QSPITestCase(unittest.TestCase):
                             assert not ctx.get(dut.o_octets.valid)
                             break
                 return words
+            if divisor is not None:
+                ctx.set(dut.divisor, divisor)
 
             await ctrl_idle()
 
@@ -317,3 +319,21 @@ class QSPITestCase(unittest.TestCase):
         sim.add_testbench(testbench_flash, background=True)
         with sim.write_vcd("test.vcd"):
             sim.run()
+
+    def test_qspi_controller_sdr_div0(self):
+        self.subtest_qspi_controller(use_ddr_buffers=False, divisor=0)
+
+    def test_qspi_controller_sdr_div1(self):
+        self.subtest_qspi_controller(use_ddr_buffers=False, divisor=1)
+
+    def test_qspi_controller_sdr_div2(self):
+        self.subtest_qspi_controller(use_ddr_buffers=False, divisor=2)
+
+    def test_qspi_controller_ddr_div0(self):
+        self.subtest_qspi_controller(use_ddr_buffers=True, divisor=0)
+
+    def test_qspi_controller_ddr_div1(self):
+        self.subtest_qspi_controller(use_ddr_buffers=True, divisor=1)
+
+    def test_qspi_controller_ddr_div2(self):
+        self.subtest_qspi_controller(use_ddr_buffers=True, divisor=2)


### PR DESCRIPTION
This changeset:

- Re-Adds just the SimulatableDDRBuffer to IOStreamer (without fixing the wrong latency)
   - this time SimulatableDDRBuffer is glitchless thanks to Wanda's idea
- Adds QSPI testcases that test (SDR, DDR) X (divisor=0, divisor=1, divisor=2)
- Makes QSPI testcases more robust by listening on the falling edge of CS as well, instead of sampling it

All newly added tests pass successfully.

This changeset is independent of my other work