### PR TITLE
gateware.iostream.IOClocker: Fix phase and state keeps flipping.

### DIFF
--- a/software/glasgow/gateware/iostream.py
+++ b/software/glasgow/gateware/iostream.py
@@ -285,7 +285,7 @@ class IOClocker(wiring.Component):
                                 m.d.comb += self.i_stream.ready.eq(1)
                         with m.Else():
                             m.d.comb += phase.eq(0)
-                            with m.If(self.o_stream.ready):
+                            with m.If(self.o_stream.ready & self.i_stream.valid):
                                 m.d.sync += timer.eq(self.divisor)
                                 m.next = "Rising"
 


### PR DESCRIPTION
When i_stream is idle, there is currently nothing that prevents the state machine from changing state between Falling/Rising, toggling phase, and restarting the timer.

This results in lost power, and sometimes shortened clock pulses after an idle period.

Here is what IOClocker output looks like without this PR:
![image](https://github.com/user-attachments/assets/9e751cad-fa69-4438-8c1c-0bb474f5c36a)

Here is what it looks like with this PR:
![image](https://github.com/user-attachments/assets/6b6980b1-9a2f-45f4-968a-99776ec04b74)
Note: I have circled with green the countdown that _is_ expected to complete.

Here's an example of a shortened clock pulse I've seen:
![image](https://github.com/user-attachments/assets/9e00bf31-475d-4782-b68f-18ae116a2217)

With fix in PR:
![image](https://github.com/user-attachments/assets/0979332b-986c-4165-839d-1aa98d514cbb)
