### PR TITLE
applet.memory.onfi: add an option to toggle internal pull-up for R/B#

### DIFF
--- a/software/glasgow/applet/memory/onfi/__init__.py
+++ b/software/glasgow/applet/memory/onfi/__init__.py
@@ -470,7 +470,7 @@ class MemoryONFIApplet(GlasgowApplet):
             help="select chip connected to CE# signal CHIP (one of: 1..4, default: 1)")
 
     async def run(self, device, args):
-        iface = await device.demultiplexer.claim_interface(self, self.mux_interface, args)
+        iface = await device.demultiplexer.claim_interface(self, self.mux_interface, args, pull_high={args.pin_r_b})
         onfi_iface = ONFIInterface(iface, self.logger)
 
         # Reset every target, to make sure all of them are in a defined state and aren't driving


### PR DESCRIPTION
Instead of using an external pull-up on R/B# (for instance as shown in this [blog post](https://colinoflynn.com/2024/04/dumping-parallel-nand-with-glasgow/)), it is more convenient to use an internal one.

This PR adds an option to do that and doesn't change default behaviour.

