### PR TITLE
Add FPGA/I2C health check after bitstream load

### DIFF
--- a/software/glasgow/target/hardware.py
+++ b/software/glasgow/target/hardware.py
@@ -52,6 +52,11 @@ class GlasgowHardwareTarget(Elaboratable):
         self.i2c_target = I2CTarget(self.platform.request("i2c", dir={"scl": "-", "sda": "-"}))
         self.registers = I2CRegisters(self.i2c_target)
 
+        # Always add a register at address 0x00, to be able to check that the FPGA configuration
+        # succeeded and that I2C communication works.
+        addr_health_check = self.registers.add_existing_ro(0xa5)
+        assert addr_health_check == 0x00
+
         self.fx2_crossbar = FX2Crossbar(self.platform.request("fx2", dir={
             "sloe": "-", "slrd": "-", "slwr": "-", "pktend": "-", "fifoadr": "-",
             "flag": "-", "fd": "-"


### PR DESCRIPTION
There have been reports of issues that are suspected to be manufacturing defects related to the I2C bus, for example #688. These issues cause a failure in one of the post-configuration code paths related to the I2C bus, where it's difficult to display a good error message. This commit adds a dedicated health check register and a dedicated error message:

    E: g.cli: FPGA health check failed; if you are using a newly
    manufactured device, ask the vendor of the device for return and
    replacement, else ask for support on community channels