### PR TITLE
Refactor IOStreamer and QSPI

### DIFF
--- a/software/glasgow/applet/interface/qspi_controller/__init__.py
+++ b/software/glasgow/applet/interface/qspi_controller/__init__.py
@@ -32,8 +32,10 @@ class QSPIControllerSubtarget(Elaboratable):
         m = Module()
 
         m.submodules.qspi = qspi = QSPIController(self._ports, use_ddr_buffers=True,
-                                                  sample_delay_half_clocks = self._sample_delay_half_clocks)
+                                                  max_sample_delay_half_clocks=self._sample_delay_half_clocks,
+                                                  min_divisor=self._divisor)
         m.d.comb += qspi.divisor.eq(self._divisor)
+        m.d.comb += qspi.sample_delay_half_clocks.eq(self._sample_delay_half_clocks)
 
         o_fifo  = self._out_fifo.stream
         i_fifo  = self._in_fifo.stream

--- a/software/glasgow/gateware/iostream.py
+++ b/software/glasgow/gateware/iostream.py
@@ -191,12 +191,15 @@ class IOStreamer(wiring.Component):
         m.d.comb += skid[0].meta.eq(meta)
 
         skid_at = Signal(range(1 + latency))
+
+        with m.If(i_en):
+            for n_shift in range(latency):
+                m.d.sync += skid[n_shift + 1].eq(skid[n_shift])
+
         with m.If(i_en & ~self.i_stream.ready):
             # m.d.sync += Assert(skid_at != latency)
             m.d.sync += skid_at.eq(skid_at + 1)
-            for n_shift in range(latency):
-                m.d.sync += skid[n_shift + 1].eq(skid[n_shift])
-        with m.Elif((skid_at != 0) & self.i_stream.ready):
+        with m.Elif((skid_at != 0) & ~i_en & self.i_stream.ready):
             m.d.sync += skid_at.eq(skid_at - 1)
 
         m.d.comb += self.i_stream.payload.eq(skid[skid_at])

--- a/software/glasgow/gateware/iostream.py
+++ b/software/glasgow/gateware/iostream.py
@@ -129,8 +129,7 @@ class IOStreamer(wiring.Component):
         if self._ratio == 1:
             buffer_cls, latency = io.FFBuffer, 1 + self._sample_delay_half_clocks // 2
         if self._ratio == 2:
-            # FIXME: should this be 2 or 3? the latency differs between i[0] and i[1]
-            buffer_cls, latency = SimulatableDDRBuffer, 3 + (self._sample_delay_half_clocks // 2) + (self._sample_delay_half_clocks % 2)
+            buffer_cls, latency = SimulatableDDRBuffer, 2 + (self._sample_delay_half_clocks // 2) + (self._sample_delay_half_clocks % 2)
 
         if isinstance(self._ports, io.PortLike):
             m.submodules.buffer = buffer = buffer_cls("io", self._ports)

--- a/software/glasgow/gateware/iostream.py
+++ b/software/glasgow/gateware/iostream.py
@@ -5,7 +5,7 @@ from amaranth.lib.wiring import In, Out
 from glasgow.gateware.ports import PortGroup
 
 
-__all__ = ["IOStreamer"]
+__all__ = ["IOStreamerTop"]
 
 
 def _filter_ioshape(direction, ioshape):
@@ -65,8 +65,408 @@ class SimulatableDDRBuffer(io.DDRBuffer):
 
         return m
 
+def LaneLayout(actual_layout, /, *, meta_layout=0):
+    return data.StructLayout({
+        "actual": actual_layout,
+        "meta": meta_layout,
+    })
+
+def MetaLayoutWithTag(*, tag_layout, meta_layout=0):
+    return data.StructLayout({
+        "inner_meta": meta_layout,
+        "tag": tag_layout,
+        "last": 1,
+    })
+
+def IOOutputActualLayout(ioshape):
+    return data.StructLayout({
+        "port": _map_ioshape("o", ioshape, lambda width: data.StructLayout({
+            "o":  width,
+            "oe": 1,
+        })),
+        "i_en": 1,
+    })
+
+def IOOutputStreamSignature(ioshape, /, lane_count=2, *, meta_layout=0):
+    actual_layout = IOOutputActualLayout(ioshape)
+    return stream.Signature(
+        data.ArrayLayout(
+            LaneLayout(actual_layout, meta_layout=meta_layout),
+            lane_count
+        )
+    )
+
+def IOInputActualLayout(ioshape):
+    return data.StructLayout({
+        "port": _map_ioshape("i", ioshape, lambda width: data.StructLayout({
+            "i":  width,
+        })),
+        "i_valid": 1,
+    })
+
+def IOInputStreamSignature(ioshape, /, lane_count=2, *, meta_layout=0):
+    actual_layout = IOInputActualLayout(ioshape)
+    return stream.Signature(
+        data.ArrayLayout(
+            LaneLayout(actual_layout, meta_layout=meta_layout),
+            lane_count
+        )
+    )
 
 class IOStreamer(wiring.Component):
+    def __init__(self, ioshape, ports, /, *, ratio=1, meta_layout=0):
+        assert isinstance(ioshape, (int, dict))
+        assert ratio in (1, 2)
+
+        self._ioshape = ioshape
+        self._ratio   = ratio
+        self._ports   = ports
+
+        super().__init__({
+            "o_stream":  In(IOOutputStreamSignature(ioshape, lane_count=ratio, meta_layout=meta_layout)),
+            "i_stream": Out(IOInputStreamSignature(ioshape, lane_count=ratio, meta_layout=meta_layout)),
+        })
+
+        self.o_stream.valid = Const(1)
+        self.o_stream.ready = Const(1)
+        for lane_index in range(ratio):
+            self.o_stream.p[lane_index].actual.i_en = Const(1) # Must always sample!
+        # self.i_stream.valid = Const(1) # i_stream is not really valid for the first `latency` cycles after reset
+        self.i_stream.ready = Const(1)
+
+    def get_latency(self, platform):
+        # May be platform-dependent in the future
+        if self._ratio == 1:
+            return 1
+        if self._ratio == 2:
+            return 2
+
+    def elaborate(self, platform):
+        m = Module()
+
+        if self._ratio == 1:
+            buffer_cls = io.FFBuffer
+        if self._ratio == 2:
+            buffer_cls = SimulatableDDRBuffer
+
+        latency = self.get_latency(platform)
+
+        if isinstance(self._ports, io.PortLike):
+            m.submodules.buffer = buffer = buffer_cls("io", self._ports)
+        if isinstance(self._ports, PortGroup):
+            buffer = {}
+            for name, sub_port in self._ports.__dict__.items():
+                direction, _width = self._ioshape[name]
+                m.submodules[f"buffer_{name}"] = buffer[name] = buffer_cls(direction, sub_port)
+
+        for lane_index in range(self._ratio):
+            for _, buffer_parts, stream_parts in _iter_ioshape("o", self._ioshape,
+                    buffer, self.o_stream.p[lane_index].actual.port):
+                m.d.comb += buffer_parts.o[lane_index].eq(stream_parts.o)
+
+        for name, buffer_parts in _iter_ioshape("o", self._ioshape,
+                    buffer):
+            oe_any = self.o_stream.p[0].actual.port[name].oe
+            for lane_index in range(1, self._ratio):
+                oe_any |= self.o_stream.p[1].actual.port[name].oe
+            m.d.comb += buffer_parts.oe.eq(oe_any)
+
+        def delay(value, name):
+            delayed_values = []
+            for stage in range(latency):
+                next_value = Signal.like(value, name=f"{name}_{stage}")
+                m.d.sync += next_value.eq(value)
+                value = next_value
+                delayed_values.append(next_value)
+            return delayed_values
+
+        i_en = delay(Const(1), name="i_en")[-1] # We always output samples, except for `latency` cycles after reset
+        for lane_index in range(self._ratio):
+            for name, i_payload_parts, buffer_parts in _iter_ioshape("i", self._ioshape, self.i_stream.p[lane_index].actual.port, buffer):
+                if self._ratio > 1:
+                    m.d.comb += i_payload_parts.i.eq(buffer_parts.i[lane_index])
+                else:
+                    m.d.comb += i_payload_parts.i.eq(buffer_parts.i)
+            m.d.comb += self.i_stream.p[lane_index].actual.i_valid.eq(1)
+        m.d.comb += self.i_stream.valid.eq(i_en)
+
+        return m
+
+
+class StreamStretcher(wiring.Component):
+    """
+    This component makes sure that any stream is not allowed to transfer more often
+    than every `divisor` cycles. If `divisor` is 0 or 1, then the StreamStretcher has
+    no effect.
+    """
+    def __init__(self, stream_signature, *, divisor_width=16):
+        super().__init__({
+            "i_stream":  In(stream_signature),
+            "o_stream": Out(stream_signature),
+            "divisor": In(divisor_width),
+        })
+
+    def elaborate(self, platform):
+        m = Module()
+        timer = Signal.like(self.divisor)
+        timer_done = Signal()
+        m.d.comb += timer_done.eq((timer == 0) | (timer == 1))
+
+        m.d.comb += self.o_stream.p.eq(self.i_stream.p)
+        m.d.comb += self.o_stream.valid.eq(self.i_stream.valid & timer_done)
+        m.d.comb += self.i_stream.ready.eq(self.o_stream.ready & timer_done)
+
+        with m.If(timer_done):
+            with m.If(self.o_stream.ready & self.o_stream.valid):
+                m.d.sync += timer.eq(self.divisor)
+        with m.Else():
+            m.d.sync += timer.eq(timer - 1)
+
+        return m
+
+
+class IOLatcher(wiring.Component):
+    """
+    This component has an always valid, always ready output stream,
+    which passes through the "o" and "oe" fields when a transaction
+    is presented at the input stream, otherwise it keeps repeating the
+    last transaction, which it memorises.
+    Other fields such as i_en, and meta are dropped.
+    """
+    def __init__(self, ioshape, /, *, ratio=1, init=None, meta_layout=0):
+        assert isinstance(ioshape, (int, dict))
+        assert ratio in (1, 2)
+
+        self._ioshape = ioshape
+        self._ratio   = ratio
+        self._init    = init
+
+        super().__init__({
+            "i_stream":  In(IOOutputStreamSignature(ioshape, lane_count=ratio, meta_layout=meta_layout)),
+            "o_stream": Out(IOOutputStreamSignature(ioshape, lane_count=ratio, meta_layout=meta_layout)),
+        })
+
+        self.o_stream.valid = Const(1)
+        self.o_stream.ready = Const(1)
+        self.i_stream.ready = Const(1)
+
+    def elaborate(self, platform):
+        m = Module()
+
+        o_latch = Signal(_map_ioshape("o", self._ioshape, lambda width: data.StructLayout({
+            "o":  width,
+            "oe": 1,
+        })), init=self._init)
+        with m.If(self.i_stream.valid & self.i_stream.ready):
+            for lane_index in range(self._ratio):
+                m.d.comb += self.o_stream.p[lane_index].actual.port.eq(self.i_stream.p[lane_index].actual.port)
+
+            for _, latch_parts, stream_parts in _iter_ioshape("o", self._ioshape,
+                    o_latch, self.i_stream.p[-1].actual.port):
+                m.d.sync += latch_parts.eq(stream_parts)
+
+        with m.Else():
+            for lane_index in range(self._ratio):
+                for _, simple_stream_parts, latch_parts in _iter_ioshape("o", self._ioshape,
+                        self.o_stream.p[lane_index].actual.port, o_latch):
+                    m.d.comb += simple_stream_parts.eq(latch_parts)
+
+        return m
+
+class SkidBuffer(wiring.Component):
+    """
+    This component is a generic skid buffer.
+    It is essentially a `depth` deep FIFO with a stream interface.
+    """
+    def __init__(self, depth, stream_signature):
+        self._depth = depth
+        super().__init__({
+            "i_stream":  In(stream_signature),
+            "o_stream": Out(stream_signature),
+        })
+
+    def elaborate(self, platform):
+        m = Module()
+
+        # This skid buffer is organized as a shift register to avoid any uncertainties associated
+        # with the use of an async read memory. On platforms that have LUTRAM, this implementation
+        # may be slightly worse than using LUTRAM, and may have to be revisited in the future.
+        skid = Array(Signal(self.i_stream.p.shape(), name=f"skid_{stage}")
+                     for stage in range(1 + self._depth))
+
+        skid_at = Signal(range(1 + self._depth))
+
+        m.d.comb += skid[0].eq(self.i_stream.p)
+
+        with m.If(self.i_stream.valid):
+            for n_shift in range(self._depth):
+                m.d.sync += skid[n_shift + 1].eq(skid[n_shift])
+
+        not_full = Signal()
+        m.d.comb += not_full.eq(skid_at != self._depth)
+
+        m.d.comb += self.o_stream.p.eq(skid[skid_at])
+        m.d.comb += self.o_stream.valid.eq(self.i_stream.valid | (skid_at != 0))
+        m.d.comb += self.i_stream.ready.eq(self.o_stream.ready | not_full)
+
+        with m.If(self.i_stream.valid & self.i_stream.ready & ~self.o_stream.ready):
+            m.d.sync += skid_at.eq(skid_at + 1)
+        with m.Elif(~self.i_stream.valid & self.o_stream.valid & self.o_stream.ready):
+            m.d.sync += skid_at.eq(skid_at - 1)
+
+        return m
+
+class SampleRequestDelayer(wiring.Component):
+    def __init__(self, /, *, ratio, meta_layout, min_latency, max_sample_delay_half_clocks, min_divisor):
+        self._ratio = ratio
+        self._min_latency = min_latency
+        self._max_sample_delay_half_clocks = max_sample_delay_half_clocks
+        self._min_divisor = min_divisor
+        self._max_latency_except_hcyc = min_latency + self._max_sample_delay_half_clocks // 2
+
+        super().__init__({
+            "i_en": In(data.ArrayLayout(1, ratio)),
+            "meta": In(data.ArrayLayout(meta_layout, ratio)),
+            "sample_delay_half_clocks": In(range(max_sample_delay_half_clocks + 1)),
+            "i_en_delayed": Out(data.ArrayLayout(1, ratio)),
+            "meta_delayed": Out(data.ArrayLayout(meta_layout, ratio)),
+            "reads_in_flight": Out(1),
+        })
+
+    def elaborate(self, platform):
+        m = Module()
+
+        def delay(value, name, cycles):
+            delayed_values = Array(Signal(value.shape(), name=f"delayed_{name}_{stage}")
+                     for stage in range(cycles))
+            m.d.sync += delayed_values[0].eq(value)
+            for stage in range(1, cycles):
+                m.d.sync += delayed_values[stage].eq(delayed_values[stage-1])
+            return delayed_values
+
+        i_en_delayed_except_half_cyc = Signal.like(self.i_en_delayed)
+        meta_delayed_except_half_cyc = Signal.like(self.meta_delayed)
+        reads_in_flight_except_half_cyc = Signal.like(self.reads_in_flight)
+
+        # Following are two implementations: the second one is really simple, using only shift registers,
+        # while the first one relies on a `min_divisor` setting to use a counter for the first part of the
+        # delay mechanism.
+
+        # Some statistics using the memory-25x applet:
+        # divisor=24  sample_delay=0   => simple:  810 ICESTORM_LCs, optimized: 811 ICESTORM_LCs
+        # divisor=24  sample_delay=1   => simple:  830 ICESTORM_LCs, optimized: 832 ICESTORM_LCs
+        # divisor=24  sample_delay=2   => simple:  823 ICESTORM_LCs, optimized: 825 ICESTORM_LCs
+        # divisor=24  sample_delay=3   => simple:  832 ICESTORM_LCs, optimized: 824 ICESTORM_LCs
+        # divisor=24  sample_delay=6   => simple:  836 ICESTORM_LCs, optimized: 823 ICESTORM_LCs
+        # divisor=24  sample_delay=12  => simple:  849 ICESTORM_LCs, optimized: 825 ICESTORM_LCs
+        # divisor=24  sample_delay=24  => simple:  888 ICESTORM_LCs, optimized: 830 ICESTORM_LCs
+        # divisor=24  sample_delay=36  => simple:  928 ICESTORM_LCs, optimized: 833 ICESTORM_LCs
+        # divisor=24  sample_delay=47  => simple: 1001 ICESTORM_LCs, optimized: 877 ICESTORM_LCs
+        # divisor=3   sample_delay=0   => simple:  813 ICESTORM_LCs, optimized: 820 ICESTORM_LCs
+        # divisor=3   sample_delay=3   => simple:  859 ICESTORM_LCs, optimized: 860 ICESTORM_LCs
+        # divisor=3   sample_delay=6   => simple:  872 ICESTORM_LCs, optimized: 858 ICESTORM_LCs
+        # divisor=3   sample_delay=12  => simple:  894 ICESTORM_LCs, optimized: 901 ICESTORM_LCs
+        # divisor=3   sample_delay=24  => simple:  980 ICESTORM_LCs, optimized: 970 ICESTORM_LCs
+        # divisor=4   sample_delay=8   => simple:  874 ICESTORM_LCs, optimized: 866 ICESTORM_LCs
+        # divisor=4   sample_delay=16  => simple:  903 ICESTORM_LCs, optimized: 893 ICESTORM_LCs
+        # divisor=4   sample_delay=32  => simple:  999 ICESTORM_LCs, optimized: 988 ICESTORM_LCs
+        # divisor=5   sample_delay=10  => simple:  868 ICESTORM_LCs, optimized: 858 ICESTORM_LCs
+        # divisor=8   sample_delay=6   => simple:  836 ICESTORM_LCs, optimized: 830 ICESTORM_LCs
+        # divisor=8   sample_delay=16  => simple:  886 ICESTORM_LCs, optimized: 866 ICESTORM_LCs
+        # divisor=240 sample_delay=100 => simple: 1114 ICESTORM_LCs, optimized: 826 ICESTORM_LCs
+        # divisor=240 sample_delay=238 => simple: 1528 ICESTORM_LCs, optimized: 830 ICESTORM_LCs
+
+        #if self._min_divisor >= 1: # The optimized implementation works correctly as long as _min_divisor >= 1
+        if self._min_divisor >= 4:  # however it may not make sense to use it when min_divisor is a low number
+            # Optimized implementaiton using a counter as a first-stage delay mechanism
+            assert self._min_divisor >= 1, "with a divisor of less than 1, the counter logic wouldn't work"
+            assert self._min_latency >= 1, "with a min latency less then 1, and sample delay of zero, the counter logic wouldn't work"
+            counting = Signal()
+            counter = Signal(range(min(self._min_divisor, self._max_latency_except_hcyc)))
+            i_en_cached = Signal.like(self.i_en)
+            meta_cached = Signal.like(self.meta)
+            i_en_delay_chain_input = Signal.like(self.i_en)
+
+            latency_minus_1 = self._min_latency - 1 + self.sample_delay_half_clocks // 2
+
+            with m.If(counting):
+                with m.If((counter == self._min_divisor - 1) | 
+                          (counter == latency_minus_1)):
+                    m.d.sync += counting.eq(0)
+                    m.d.comb += i_en_delay_chain_input.eq(i_en_cached)
+                with m.Else():
+                    m.d.sync += counter.eq(counter + 1)
+
+            with m.If(Signal.cast(self.i_en).any()):
+                m.d.sync += (
+                    counting.eq(1),
+                    i_en_cached.eq(self.i_en),
+                    meta_cached.eq(self.meta),
+                    counter.eq(0),
+                )
+
+            m.d.comb += (
+                i_en_delayed_except_half_cyc.eq(i_en_delay_chain_input),
+                meta_delayed_except_half_cyc.eq(meta_cached),
+                reads_in_flight_except_half_cyc.eq(counting),
+            )
+
+            if self._max_latency_except_hcyc > self._min_divisor:
+                delay_chain_cycles = self._max_latency_except_hcyc - self._min_divisor
+                i_en_delays = delay(i_en_delay_chain_input, name=f"i_en", cycles=delay_chain_cycles)
+                meta_delays = delay(meta_cached, name=f"meta", cycles=delay_chain_cycles)
+
+                delay_selector = latency_minus_1 - self._min_divisor
+
+                i_en_in_flight_up_to = Array(Signal(1, name=f"i_en_in_flight_{stage}") for stage in range(delay_chain_cycles))
+                m.d.comb += i_en_in_flight_up_to[0].eq(Signal.cast(i_en_delays[0]).any())
+                for stage in range(1, delay_chain_cycles):
+                    value = Signal.cast(i_en_delays[stage]).any() | i_en_in_flight_up_to[stage - 1]
+                    m.d.comb += i_en_in_flight_up_to[stage].eq(value)
+
+                with m.If(latency_minus_1 >= self._min_divisor):
+                    m.d.comb += i_en_delayed_except_half_cyc.eq(i_en_delays[delay_selector])
+                    m.d.comb += meta_delayed_except_half_cyc.eq(meta_delays[delay_selector])
+                    m.d.comb += reads_in_flight_except_half_cyc.eq(counting | i_en_in_flight_up_to[delay_selector])
+
+        else: # Simple shift-register-only based implementation
+            meta, i_en_delays, i_en  = [], [], []
+            delay_selector = self._min_latency - 1 + self.sample_delay_half_clocks // 2
+
+            i_en_delays = delay(self.i_en, name=f"i_en", cycles=self._max_latency_except_hcyc)
+            meta_delays = delay(self.meta, name=f"meta", cycles=self._max_latency_except_hcyc)
+
+            m.d.comb += i_en_delayed_except_half_cyc.eq(i_en_delays[delay_selector])
+            m.d.comb += meta_delayed_except_half_cyc.eq(meta_delays[delay_selector])
+
+            i_en_in_flight_up_to = Array(Signal(1, name=f"i_en_in_flight_{stage}") for stage in range(self._max_latency_except_hcyc))
+            m.d.comb += i_en_in_flight_up_to[0].eq(Signal.cast(i_en_delays[0]).any())
+            for stage in range(1, self._max_latency_except_hcyc):
+                value = Signal.cast(i_en_delays[stage]).any() | i_en_in_flight_up_to[stage - 1]
+                m.d.comb += i_en_in_flight_up_to[stage].eq(value)
+
+            m.d.comb += reads_in_flight_except_half_cyc.eq(i_en_in_flight_up_to[delay_selector])
+
+        # Here follows code common to both implementations, that handles half a cycle delays.
+        # Half-cycle delays are handled as an additional delay step. (The sample payload will
+        # be combined from two different clock cycles.) We're using an additional shift
+        # register stage to avoid having to calculate a dynamic delay of
+        # (sample_delay // 2 + sample_delay % 2)
+        m.d.comb += self.i_en_delayed.eq(i_en_delayed_except_half_cyc)
+        m.d.comb += self.meta_delayed.eq(meta_delayed_except_half_cyc)
+        m.d.comb += self.reads_in_flight.eq(reads_in_flight_except_half_cyc)
+
+        if self._ratio == 2:
+            i_en_hcyc = delay(i_en_delayed_except_half_cyc, name=f"i_en_hcyc", cycles=1)[0]
+            meta_hcyc = delay(meta_delayed_except_half_cyc, name=f"meta_hcyc", cycles=1)[0]
+            with m.If(self.sample_delay_half_clocks % 2):
+                m.d.comb += self.i_en_delayed.eq(i_en_hcyc)
+                m.d.comb += self.meta_delayed.eq(meta_hcyc)
+                m.d.comb += self.reads_in_flight.eq(reads_in_flight_except_half_cyc | Signal.cast(i_en_hcyc).any())
+
+        return m
+
+class IOStreamerTop(wiring.Component):
     """I/O buffer to stream adapter.
 
     This adapter instantiates I/O buffers for a port (FF or DDR) and connects them to a pair of
@@ -86,29 +486,7 @@ class IOStreamer(wiring.Component):
     polarity.
     """
 
-    @staticmethod
-    def o_stream_signature(ioshape, /, *, ratio=1, meta_layout=0):
-        return stream.Signature(data.StructLayout({
-            "port": _map_ioshape("o", ioshape, lambda width: data.StructLayout({
-                "o":  width if ratio == 1 else data.ArrayLayout(width, ratio),
-                "oe": 1,
-            })),
-            "i_en": 1,
-            "meta": meta_layout,
-        }))
-
-    @staticmethod
-    def i_stream_signature(ioshape, /, *, ratio=1, meta_layout=0):
-        return stream.Signature(data.StructLayout({
-            "port": _map_ioshape("i", ioshape, lambda width: data.StructLayout({
-                "i":  width if ratio == 1 else data.ArrayLayout(width, ratio),
-            })),
-            "meta": meta_layout,
-        }))
-
-    def __init__(self, ioshape, ports, /, *, ratio=1, init=None, meta_layout=0, sample_delay_half_clocks=0):
-        if ratio == 1:
-            assert (sample_delay_half_clocks % 2) == 0
+    def __init__(self, ioshape, ports, /, *, ratio=1, init=None, meta_layout=0, divisor_width=16, max_sample_delay_half_clocks=0, min_divisor=0):
         assert isinstance(ioshape, (int, dict))
         assert ratio in (1, 2)
 
@@ -116,206 +494,330 @@ class IOStreamer(wiring.Component):
         self._ports   = ports
         self._ratio   = ratio
         self._init    = init
-        self._sample_delay_half_clocks = sample_delay_half_clocks
+        self._divisor_width = divisor_width
+        self._max_sample_delay_half_clocks = max_sample_delay_half_clocks
+        self._meta_layout = meta_layout
+        self._min_divisor = min_divisor
 
         super().__init__({
-            "o_stream":  In(self.o_stream_signature(ioshape, ratio=ratio, meta_layout=meta_layout)),
-            "i_stream": Out(self.i_stream_signature(ioshape, ratio=ratio, meta_layout=meta_layout)),
+            "o_stream":  In(IOOutputStreamSignature(ioshape, lane_count=ratio, meta_layout=meta_layout)),
+            "i_stream": Out(IOInputStreamSignature(ioshape, lane_count=ratio, meta_layout=meta_layout)),
+            "divisor": In(divisor_width),
+            "sample_delay_half_clocks": In(range(max_sample_delay_half_clocks + 1)),
         })
 
     def elaborate(self, platform):
         m = Module()
 
+        if self._min_divisor:
+            m.d.sync += Assert(self.divisor >= self._min_divisor)
+
         if self._ratio == 1:
-            buffer_cls, latency = io.FFBuffer, 1 + self._sample_delay_half_clocks // 2
+            m.d.sync += Assert(self.sample_delay_half_clocks % 2 == 0)
+
+        m.submodules.stream_stretcher = stream_stretcher = StreamStretcher(
+            IOOutputStreamSignature(self._ioshape, lane_count=self._ratio, meta_layout=self._meta_layout),
+            divisor_width = self._divisor_width)
+        m.d.comb += stream_stretcher.divisor.eq(self.divisor)
+        wiring.connect(m, io_streamer=wiring.flipped(self.o_stream), stream_strecher=stream_stretcher.i_stream)
+
+        m.submodules.io_streamer = io_streamer = IOStreamer(self._ioshape, self._ports, ratio=self._ratio, meta_layout=0)
+        m.submodules.io_latcher = io_latcher = IOLatcher(self._ioshape, ratio=self._ratio, init=self._init, meta_layout=0)
+        wiring.connect(m, io_latcher=io_latcher.o_stream, io_streamer=io_streamer.o_stream)
+        for lane_index in range(self._ratio):
+            m.d.comb += io_latcher.i_stream.p[lane_index].actual.port.eq(stream_stretcher.o_stream.p[lane_index].actual.port)
+        m.d.comb += io_latcher.i_stream.valid.eq(stream_stretcher.o_stream.valid & stream_stretcher.o_stream.ready)
+        #  ^ note: the above makes sure IOLatcher doesn't take a new transaction if we're blocking the input
+
+        min_latency = io_streamer.get_latency(platform)
+        max_latency = min_latency + self._max_sample_delay_half_clocks // 2 + self._max_sample_delay_half_clocks % 2
+
+        m.submodules.sample_request_delayer = sample_request_delayer = SampleRequestDelayer(ratio=self._ratio,
+                                                                                            meta_layout=self._meta_layout,
+                                                                                            min_latency=min_latency,
+                                                                                            max_sample_delay_half_clocks=self._max_sample_delay_half_clocks,
+                                                                                            min_divisor=self._min_divisor)
+        m.d.comb += sample_request_delayer.sample_delay_half_clocks.eq(self.sample_delay_half_clocks)
+        for lane_index in range(self._ratio):
+            m.d.comb += sample_request_delayer.i_en[lane_index].eq(stream_stretcher.o_stream.valid &
+                                                                   stream_stretcher.o_stream.ready &
+                                                                   stream_stretcher.o_stream.p[lane_index].actual.i_en)
+            m.d.comb += sample_request_delayer.meta[lane_index].eq(stream_stretcher.o_stream.p[lane_index].meta)
+
+        skid_buffer_depth = max_latency
+        if self._min_divisor > 1:
+            # This is an optimisation we can apply if we know at elaboration time that divisor can never be larger than min_divisor
+            skid_buffer_depth = (max_latency + self._min_divisor - 1) // self._min_divisor
+
+        m.submodules.skid_buffer = skid_buffer = SkidBuffer(
+            skid_buffer_depth,
+            IOInputStreamSignature(self._ioshape, lane_count=self._ratio, meta_layout=self._meta_layout),
+        )
+        m.d.comb += skid_buffer.i_stream.valid.eq(Signal.cast(sample_request_delayer.i_en_delayed).any())
+        with m.If(skid_buffer.i_stream.valid):
+            m.d.sync += Assert(skid_buffer.i_stream.ready)
+
+        for lane_index in range(self._ratio):
+            m.d.comb += skid_buffer.i_stream.p[lane_index].actual.port.eq(io_streamer.i_stream.p[lane_index].actual.port)
+
         if self._ratio == 2:
-            buffer_cls, latency = SimulatableDDRBuffer, 2 + (self._sample_delay_half_clocks // 2) + (self._sample_delay_half_clocks % 2)
+            with m.If(self.sample_delay_half_clocks % 2):
+                m.d.comb += skid_buffer.i_stream.p[1].actual.port.eq(io_streamer.i_stream.p[0].actual.port)
+                i1_delayed = Signal.like(io_streamer.i_stream.p[1].actual.port, name=f"i1_delayed")
+                m.d.sync += i1_delayed.eq(io_streamer.i_stream.p[1].actual.port)
+                m.d.comb += skid_buffer.i_stream.p[0].actual.port.eq(i1_delayed)
 
-        if isinstance(self._ports, io.PortLike):
-            m.submodules.buffer = buffer = buffer_cls("io", self._ports)
-        if isinstance(self._ports, PortGroup):
-            buffer = {}
-            for name, sub_port in self._ports.__dict__.items():
-                direction, _width = self._ioshape[name]
-                m.submodules[f"buffer_{name}"] = buffer[name] = buffer_cls(direction, sub_port)
+        for lane_index in range(self._ratio):
+            m.d.comb += skid_buffer.i_stream.p[lane_index].meta.eq(sample_request_delayer.meta_delayed[lane_index])
+            m.d.comb += skid_buffer.i_stream.p[lane_index].actual.i_valid.eq(sample_request_delayer.i_en_delayed[lane_index])
 
-        o_latch = Signal(_map_ioshape("o", self._ioshape, lambda width: data.StructLayout({
-            "o":  width,
-            "oe": 1,
-        })), init=self._init)
-        with m.If(self.o_stream.valid & self.o_stream.ready):
-            for _, buffer_parts, stream_parts in _iter_ioshape("o", self._ioshape,
-                    buffer, self.o_stream.p.port):
-                m.d.comb += buffer_parts.o.eq(stream_parts.o)
-                m.d.comb += buffer_parts.oe.eq(stream_parts.oe)
-            for _, latch_parts, stream_parts in _iter_ioshape("o", self._ioshape,
-                    o_latch, self.o_stream.p.port):
-                if self._ratio == 1:
-                    m.d.sync += latch_parts.o.eq(stream_parts.o)
-                else:
-                    m.d.sync += latch_parts.o.eq(stream_parts.o[-1])
-                m.d.sync += latch_parts.oe.eq(stream_parts.oe)
-        with m.Else():
-            for _, buffer_parts, latch_parts in _iter_ioshape("o", self._ioshape,
-                    buffer, o_latch):
-                if self._ratio == 1:
-                    m.d.comb += buffer_parts.o.eq(latch_parts.o)
-                else:
-                    m.d.comb += buffer_parts.o.eq(latch_parts.o.replicate(self._ratio))
-                m.d.comb += buffer_parts.oe.eq(latch_parts.oe)
+        wiring.connect(m, skid_buffer=skid_buffer.o_stream, io_streamer_top=wiring.flipped(self.i_stream))
 
-        def delay(value, name):
-            delayed_values = []
-            for stage in range(latency):
-                next_value = Signal.like(value, name=f"{name}_{stage}")
-                m.d.sync += next_value.eq(value)
-                value = next_value
-                delayed_values.append(next_value)
-            return delayed_values
+        m.d.comb += stream_stretcher.o_stream.ready.eq(self.i_stream.ready | (~skid_buffer.o_stream.valid & ~sample_request_delayer.reads_in_flight))
 
-        i_en_delays = delay(self.o_stream.valid & self.o_stream.ready &
-                            self.o_stream.p.i_en, name="i_en")
-        i_en = i_en_delays[-1]
-        meta = delay(self.o_stream.p.meta, name="meta")[-1]
+        return m
 
-        # This skid buffer is organized as a shift register to avoid any uncertainties associated
-        # with the use of an async read memory. On platforms that have LUTRAM, this implementation
-        # may be slightly worse than using LUTRAM, and may have to be revisited in the future.
-        skid = Array(Signal(self.i_stream.payload.shape(), name=f"skid_{stage}")
-                     for stage in range(1 + latency))
-        for name, skid_parts, buffer_parts in _iter_ioshape("i", self._ioshape, skid[0].port, buffer):
-            if self._sample_delay_half_clocks % 2:
-                m.d.comb += skid_parts.i[1].eq(buffer_parts.i[0])
-                i1_delayed = Signal.like(buffer_parts.i[1], name=f"{name}_i1_delayed")
-                m.d.sync += i1_delayed.eq(buffer_parts.i[1])
-                m.d.comb += skid_parts.i[0].eq(i1_delayed)
-            else:
-                m.d.comb += skid_parts.i.eq(buffer_parts.i)
-        m.d.comb += skid[0].meta.eq(meta)
 
-        skid_at = Signal(range(1 + latency))
+class IO2LaneTo1Lane(wiring.Component):
+    """
+    This component down-converts a 2-lane stream to a 1-lane stream, while adding
+    information to the metadata, which includes:
+        tag: the index of the lane the original data belonged to
+        last: a flag signifying if a second beat is expected in the case of later up-conversion
+    The last fields is optionally determined using the supplied is_beat_0_last argument
+    to the constructor, which must be a function that returns an amaranth expression
+    """
+    @staticmethod
+    def i_stream_signature(actual_layout, /, *, meta_layout=0):
+        return stream.Signature(
+            data.ArrayLayout(
+                LaneLayout(actual_layout, meta_layout=meta_layout),
+                2
+            )
+        )
 
-        with m.If(i_en):
-            for n_shift in range(latency):
-                m.d.sync += skid[n_shift + 1].eq(skid[n_shift])
+    @staticmethod
+    def o_stream_signature(actual_layout, /, *, meta_layout=0):
+        return stream.Signature(
+            data.ArrayLayout(
+                LaneLayout(actual_layout, meta_layout=MetaLayoutWithTag(tag_layout=range(2), meta_layout=meta_layout)),
+                1
+            )
+        )
 
-        with m.If(i_en & ~self.i_stream.ready):
-            # m.d.sync += Assert(skid_at != latency)
-            m.d.sync += skid_at.eq(skid_at + 1)
-        with m.Elif((skid_at != 0) & ~i_en & self.i_stream.ready):
-            m.d.sync += skid_at.eq(skid_at - 1)
+    def __init__(self, actual_layout, *, meta_layout=0, is_beat_0_last=lambda payload: 0):
+        self._is_beat_0_last = is_beat_0_last
+        super().__init__({
+            "i_stream":  In(self.i_stream_signature(actual_layout, meta_layout=meta_layout)),
+            "o_stream": Out(self.o_stream_signature(actual_layout, meta_layout=meta_layout)),
+        })
 
-        m.d.comb += self.i_stream.payload.eq(skid[skid_at])
-        m.d.comb += self.i_stream.valid.eq(i_en | (skid_at != 0))
-        m.d.comb += self.o_stream.ready.eq(self.i_stream.ready | ~((skid_at!=0) | Cat(*i_en_delays).any()))
+    def elaborate(self, platform):
+        m = Module()
+
+        phase = Signal()
+        m.d.comb += self.o_stream.p[0].actual.eq(self.i_stream.p[phase].actual)
+        m.d.comb += self.o_stream.p[0].meta.inner_meta.eq(self.i_stream.p[phase].meta)
+        m.d.comb += self.o_stream.p[0].meta.tag.eq(phase)
+        m.d.comb += self.o_stream.p[0].meta.last.eq(1)
+        with m.If((phase == 0) & ~self._is_beat_0_last(self.i_stream.p)):
+            m.d.comb += self.o_stream.p[0].meta.last.eq(0)
+
+        m.d.comb += self.o_stream.valid.eq(self.i_stream.valid)
+        with m.If(self.o_stream.ready):
+            with m.If(phase == 0):
+                with m.If(self.i_stream.valid):
+                    m.d.sync += phase.eq(1)
+
+            with m.Else(): # phase == 1
+                m.d.comb += self.i_stream.ready.eq(1)
+                m.d.sync += phase.eq(0)
 
         return m
 
 
 class IOClocker(wiring.Component):
+    """
+    In case of ratio=1:
+        This component down-converts (serializes) 2 lanes to 1 lane, while adding metadata to identify which lane each beat belonged to.
+    In case of ratio=2, divisor=0:
+        This component adds useless metadata, but is otherwise a pass-through. Adding the metadata is necessary, because divisor is not a compile-time parameter
+    In case of ratio=2, divisor!=0:
+        This component down-converts (serializes) 2 lanes to 1 lane, just like in the ratio=1 case above, except, it duplicates the resulting lane, while also making
+        sure to force `i_en` of the second resulting lane to 0. This means that one `i_en` bit high doesn't result in two samples.
+        ratio=2, divisor!=0 is designed to behave exactly like ratio=1, divisor!=0, so the read samples associated with output lane 0 are the only ones we care about.
+    """
     @staticmethod
-    def i_stream_signature(ioshape, /, *, _ratio=1, meta_layout=0):
-        # Currently the only supported ratio is 1, but this will change in the future for
-        # interfaces like HyperBus.
-        return stream.Signature(data.StructLayout({
-            "bypass": 1,
-            "port": _map_ioshape("o", ioshape, lambda width: data.StructLayout({
-                "o":  width if _ratio == 1 else data.ArrayLayout(width, _ratio),
-                "oe": 1,
-            })),
-            "i_en": 1,
-            "meta": meta_layout,
-        }))
+    def i_stream_signature(ioshape, /, *, _ratio=2, meta_layout=0):
+        # Currently the only supported ratio is 2
+        return IOOutputStreamSignature(ioshape, lane_count=_ratio, meta_layout=meta_layout)
 
     @staticmethod
     def o_stream_signature(ioshape, /, *, ratio=1, meta_layout=0):
-        return IOStreamer.o_stream_signature(ioshape, ratio=ratio, meta_layout=meta_layout)
+        return IOOutputStreamSignature(ioshape, lane_count=ratio, meta_layout=MetaLayoutWithTag(tag_layout=range(2), meta_layout=meta_layout))
 
-    def __init__(self, ioshape, *, clock, o_ratio=1, meta_layout=0, divisor_width=16):
+    def __init__(self, ioshape, *, o_ratio=1, meta_layout=0, divisor_width=16):
         assert isinstance(ioshape, dict)
-        assert isinstance(clock, str)
         assert o_ratio in (1, 2)
-        assert clock in ioshape
 
-        self._clock   = clock
         self._ioshape = ioshape
         self._o_ratio = o_ratio
+        self._meta_layout = meta_layout
 
         super().__init__({
             "i_stream":  In(self.i_stream_signature(ioshape,
                 meta_layout=meta_layout)),
             "o_stream": Out(self.o_stream_signature(ioshape,
                 ratio=o_ratio, meta_layout=meta_layout)),
-
-            # f_clk = f_sync if (o_ratio == 2 and divisor == 0) else f_sync / (2 * max(1, divisor))
             "divisor": In(divisor_width),
         })
 
     def elaborate(self, platform):
         m = Module()
 
-        # Forward the inputs to the outputs as-is. This includes the clock; it is overridden below
-        # if the clocker is used (not bypassed).
-        for _, i_parts, o_parts in _iter_ioshape("io", self._ioshape,
-                self.i_stream.p.port, self.o_stream.p.port):
-            m.d.comb += o_parts.o .eq(i_parts.o.replicate(self._o_ratio))
-            m.d.comb += o_parts.oe.eq(i_parts.oe)
-        m.d.comb += self.o_stream.p.i_en.eq(self.i_stream.p.i_en)
-        m.d.comb += self.o_stream.p.meta.eq(self.i_stream.p.meta)
+        m.submodules.io_2to1_lane = io_2to1_lane = IO2LaneTo1Lane(IOOutputActualLayout(self._ioshape), meta_layout=self._meta_layout,
+                is_beat_0_last = lambda payload: payload[1].actual.i_en==0)
 
         phase = Signal()
-        # If the clocker is used...
-        with m.If(~self.i_stream.p.bypass):
-            # ... ignore the clock in the inputs and replace it with the generated one...
-            if self._o_ratio == 1:
-                m.d.comb += self.o_stream.p.port[self._clock].o.eq(phase)
-            if self._o_ratio == 2:
-                with m.If(self.divisor == 0):
-                    m.d.comb += self.o_stream.p.port[self._clock].o.eq(Cat(~phase, phase))
-                with m.Else():
-                    m.d.comb += self.o_stream.p.port[self._clock].o.eq(Cat(phase, phase))
-            m.d.comb += self.o_stream.p.port[self._clock].oe.eq(1)
-            # ... while requesting input sampling only for the rising edge. (Interfaces triggering
-            # transfers on falling edge will be inverting the clock at the `IOPort` level.)
-            m.d.comb += self.o_stream.p.i_en.eq(self.i_stream.p.i_en & phase)
+        if self._o_ratio == 1:
+            wiring.connect(m, ioclocker=wiring.flipped(self.i_stream), io_2to1_lane=io_2to1_lane.i_stream)
+            wiring.connect(m, ioclocker=wiring.flipped(self.o_stream), io_2to1_lane=io_2to1_lane.o_stream)
+        if self._o_ratio == 2:
+            with m.If(self.divisor == 0):
+                # Just pass-through, we're doing nothing, but adding currently-useless tag metadata
+                for lane_index in range(self._o_ratio):
+                    m.d.comb += self.o_stream.p[lane_index].actual.eq(self.i_stream.p[lane_index].actual)
+                    m.d.comb += self.o_stream.p[lane_index].meta.inner_meta.eq(self.i_stream.p[lane_index].meta)
+                    m.d.comb += self.o_stream.p[lane_index].meta.tag.eq(lane_index)
+                    m.d.comb += self.o_stream.p[lane_index].meta.last.eq(~self.i_stream.p[1].actual.i_en)
+                m.d.comb += self.o_stream.valid.eq(self.i_stream.valid)
+                m.d.comb += self.i_stream.ready.eq(self.o_stream.ready)
+            with m.Else():
+                wiring.connect(m, ioclocker=wiring.flipped(self.i_stream), io_2to1_lane=io_2to1_lane.i_stream)
+                for olane_index in range(2):
+                    m.d.comb += self.o_stream.p[olane_index].eq(io_2to1_lane.o_stream.p[0])
+                m.d.comb += self.o_stream.p[1].actual.i_en.eq(0) # Override i_en, to only sample once
+                m.d.comb += self.o_stream.valid.eq(io_2to1_lane.o_stream.valid)
+                m.d.comb += io_2to1_lane.o_stream.ready.eq(self.o_stream.ready)
 
-        timer = Signal.like(self.divisor)
-        with m.If((timer == 0) | (timer == 1)):
-            # Only produce output when the timer has expired. This ensures that no clock pulse
-            # exceeds the frequency set by `divisor`, except the ones that bypass the clocker.
+        return m
+
+
+class IO1LaneTo2Lane(wiring.Component):
+    """
+    This component up-converts a 1-lane stream to a 2-lane stream, using
+    information from the metadata, to determine which lane to put each beat in:
+        tag: the index of the lane the data should be put on
+        last: a flag signifying if a second beat is expected
+    An output stream transaction occurs only when the last bit is high for an
+    input-stream transaction.
+    """
+    @staticmethod
+    def o_stream_signature(actual_layout, /, *, meta_layout=0):
+        return stream.Signature(
+            data.ArrayLayout(
+                LaneLayout(actual_layout, meta_layout=meta_layout),
+                2
+            )
+        )
+
+    @staticmethod
+    def i_stream_signature(actual_layout, /, *, meta_layout=0):
+        return stream.Signature(
+            data.ArrayLayout(
+                LaneLayout(actual_layout, meta_layout=MetaLayoutWithTag(tag_layout=range(2), meta_layout=meta_layout)),
+                1
+            )
+        )
+
+    def __init__(self, actual_layout, *, meta_layout=0):
+        super().__init__({
+            "i_stream":  In(self.i_stream_signature(actual_layout, meta_layout=meta_layout)),
+            "o_stream": Out(self.o_stream_signature(actual_layout, meta_layout=meta_layout)),
+        })
+
+    def elaborate(self, platform):
+        m = Module()
+
+        untagged_istream_lane = Signal.like(self.o_stream.p[0])
+        m.d.comb += untagged_istream_lane.actual.eq(self.i_stream.p[0].actual)
+        m.d.comb += untagged_istream_lane.meta.eq(self.i_stream.p[0].meta.inner_meta)
+
+        phase_0_stored = Signal.like(untagged_istream_lane)
+
+        m.d.comb += self.i_stream.ready.eq(self.o_stream.ready)
+        with m.If(self.i_stream.valid):
+            with m.If(self.i_stream.p[0].meta.last):
+                m.d.comb += self.o_stream.p[self.i_stream.p[0].meta.tag].eq(untagged_istream_lane)
+                with m.If(self.i_stream.p[0].meta.tag != 0):
+                    m.d.comb += self.o_stream.p[0].eq(phase_0_stored)
+                m.d.comb += self.o_stream.valid.eq(1)
+                with m.If(self.i_stream.ready):
+                    m.d.sync += phase_0_stored.eq(0)
+            with m.Else():
+                with m.If(self.i_stream.ready):
+                    m.d.sync += phase_0_stored.eq(untagged_istream_lane)
+
+        return m
+
+
+class IOClockerDeframer(wiring.Component):
+    """
+    In case of ratio=1:
+        This component up-converts (deserializes) 1-lane samples to 2-lane.
+    In case of ratio=2, divisor=0:
+        This component is a simple pass-through, doing nothing
+    In case of ratio=2, divisor!=0:
+        This component throws away lane[1] of the input, and up-converts (deserializes) lane[0] to 2 lanes
+    See IO1LaneTo2Lane subcomponent for more details
+    """
+    @staticmethod
+    def o_stream_signature(ioshape, /, *, _ratio=1, meta_layout=0):
+        # Currently the only supported ratio is 1, but this will change in the future for
+        # interfaces like HyperBus.
+        return IOInputStreamSignature(ioshape, lane_count=2, meta_layout=meta_layout)
+
+    @staticmethod
+    def i_stream_signature(ioshape, /, *, ratio=1, meta_layout=0):
+        return IOInputStreamSignature(ioshape, lane_count=ratio, meta_layout=MetaLayoutWithTag(tag_layout=range(2), meta_layout=meta_layout))
+
+    def __init__(self, ioshape, *, i_ratio=1, meta_layout=0, divisor_width=16):
+        assert isinstance(ioshape, dict)
+        assert i_ratio in (1, 2)
+
+        self._ioshape = ioshape
+        self._i_ratio = i_ratio
+        self._meta_layout = meta_layout
+
+        super().__init__({
+            "i_stream":  In(self.i_stream_signature(ioshape,
+                ratio=i_ratio, meta_layout=meta_layout)),
+            "o_stream": Out(self.o_stream_signature(ioshape,
+                meta_layout=meta_layout)),
+            "divisor": In(divisor_width),
+        })
+
+    def elaborate(self, platform):
+        m = Module()
+
+        m.submodules.io_1to2_lane = io_1to2_lane = IO1LaneTo2Lane(IOInputActualLayout(self._ioshape), meta_layout=self._meta_layout)
+
+        with m.If((self.divisor == 0) & (self._i_ratio == 2)):
+            # Just pass-through everyting
+            for lane_index in range(self._i_ratio):
+                m.d.comb += self.o_stream.p[lane_index].actual.eq(self.i_stream.p[lane_index].actual)
+                m.d.comb += self.o_stream.p[lane_index].meta.eq(self.i_stream.p[lane_index].meta.inner_meta)
             m.d.comb += self.o_stream.valid.eq(self.i_stream.valid)
-
-            with m.FSM():
-                with m.State("Falling"):
-                    with m.If(self.i_stream.p.bypass): # Bypass the clocker entirely.
-                        m.d.comb += self.i_stream.ready.eq(self.o_stream.ready)
-
-                    with m.Else(): # Produce a falling edge at the output.
-                        # Whenever DDR output is used, with `divisor == 0`, we output a low state
-                        # on the first half of the clock cycle, and a high state on the second half.
-                        # This mode allows clocking the peripheral at the `sync` frequency.
-                        # In this case the signal sampled at the rising edge will be output on i[1]
-                        # (if sample_delay was set to zero)
-                        # In all other cases the signal sampled at the rising edge will be output on i[0]
-                        # (if sample_delay was set to zero)
-                        with m.If((self._o_ratio == 2) & (self.divisor == 0)):
-                            m.d.comb += phase.eq(1)
-                            with m.If(self.o_stream.ready):
-                                m.d.comb += self.i_stream.ready.eq(1)
-                        with m.Else():
-                            m.d.comb += phase.eq(0)
-                            with m.If(self.o_stream.ready & self.i_stream.valid):
-                                m.d.sync += timer.eq(self.divisor)
-                                m.next = "Rising"
-
-                with m.State("Rising"):
-                    m.d.comb += phase.eq(1)
-                    with m.If(self.o_stream.ready):
-                        m.d.comb += self.i_stream.ready.eq(1)
-                        m.d.sync += timer.eq(self.divisor)
-                        m.next = "Falling"
-
+            m.d.comb += self.i_stream.ready.eq(self.o_stream.ready)
         with m.Else():
-            m.d.sync += timer.eq(timer - 1)
+            m.d.comb += io_1to2_lane.i_stream.valid.eq(self.i_stream.valid)
+            m.d.comb += self.i_stream.ready.eq(io_1to2_lane.i_stream.ready)
+            m.d.comb += io_1to2_lane.i_stream.p[0].eq(self.i_stream.p[0])
+            # ^ `wiring.connect` won't work here in case of i_ratio=2, we're explicitly
+            # throwing away the second lane here, cause we know IOClocker always sends
+            # sample requests on lane 0, (when divisor != 0). In case of i_ratio=1,
+            # this is equivalent to `wiring.connect`
+
+            wiring.connect(m, io_1to2_lane=io_1to2_lane.o_stream, io_clocker_deframer=wiring.flipped(self.o_stream))
 
         return m

--- a/software/glasgow/gateware/qspi.py
+++ b/software/glasgow/gateware/qspi.py
@@ -216,6 +216,15 @@ class QSPIController(wiring.Component):
             io_streamer.i_stream.ready.eq(deframer.frames.ready),
         ]
 
+        if self._ddr:
+            with m.If(self.divisor == 0):
+                m.d.comb += [
+                    deframer.frames.p.port.io0.i.eq(io_streamer.i_stream.p.port.io0.i[1]),
+                    deframer.frames.p.port.io1.i.eq(io_streamer.i_stream.p.port.io1.i[1]),
+                    deframer.frames.p.port.io2.i.eq(io_streamer.i_stream.p.port.io2.i[1]),
+                    deframer.frames.p.port.io3.i.eq(io_streamer.i_stream.p.port.io3.i[1]),
+                ]
+
         connect(m, deframer=deframer.octets, controller=flipped(self.i_octets))
 
         return m

--- a/software/tests/gateware/test_iostream.py
+++ b/software/tests/gateware/test_iostream.py
@@ -12,18 +12,33 @@ async def stream_get(ctx, stream):
     ctx.set(stream.ready, 0)
     return payload
 
+async def stream_get_maybe(ctx, stream):
+    ctx.set(stream.ready, 1)
+    _, _, payload, stream_valid = await ctx.tick().sample(stream.payload, stream.valid)
+    ctx.set(stream.ready, 0)
+    if stream_valid:
+        return payload
+    else:
+        return None
+
 async def stream_put(ctx, stream, payload):
     ctx.set(stream.payload, payload)
     ctx.set(stream.valid, 1)
     await ctx.tick().until(stream.ready)
     ctx.set(stream.valid, 0)
 
+class IOStreamTimeoutError(Exception):
+    pass
+
 class IOStreamTestCase(unittest.TestCase):
-    def test_sdr_input_sampled_correctly(self):
+    def _subtest_sdr_input_sampled_correctly(self, o_valid_bits, i_en_bits, i_ready_bits, timeout_clocks=None):
         """ This is a latency-agnostic test, that verifies that the IOStreamer samples the inputs at the same time as the output signals change """
         ports = PortGroup()
         ports.clk_out = io.SimulationPort("o", 1)
         ports.data_in = io.SimulationPort("i", 8)
+
+        if timeout_clocks is None:
+            timeout_clocks = len(o_valid_bits) + len(i_ready_bits) + 20
 
         dut = IOStreamer({
             "clk_out": ("o", 1),
@@ -32,6 +47,7 @@ class IOStreamTestCase(unittest.TestCase):
 
         expected_sample = []
         actually_sampled = []
+        i_stream_consumer_finished = False
 
         async def input_generator_tb(ctx):
             """
@@ -62,9 +78,20 @@ class IOStreamTestCase(unittest.TestCase):
             """
             This testbench saves all the samples coming in over i_stream
             """
-            while True:
-                payload = await stream_get(ctx,dut.i_stream)
-                actually_sampled.append(payload.port.data_in.i)
+            nonlocal i_stream_consumer_finished
+            for i_ready_bit in i_ready_bits:
+                if i_ready_bit == "1":
+                    payload = await stream_get_maybe(ctx,dut.i_stream)
+                    if payload is not None:
+                        actually_sampled.append(payload.port.data_in.i)
+                else:
+                    await ctx.tick()
+            i_stream_consumer_finished = True
+
+
+        async def check_timeout_tb(ctx):
+            await ctx.tick().repeat(timeout_clocks)
+            raise IOStreamTimeoutError("Testcase timeout")
 
         async def main_testbench(ctx):
             """
@@ -75,32 +102,61 @@ class IOStreamTestCase(unittest.TestCase):
             """
             await ctx.tick()
 
-            for i in range(0,8):
-                await stream_put(ctx, dut.o_stream, {"meta": i, "i_en": i % 2, "port": { "clk_out": {"o": i % 2}}})
+            expected_samples_count = 0
 
-            await stream_put(ctx, dut.o_stream, {"meta": 0, "i_en": 0, "port": { "clk_out": {"o": 0}}})
+            for i in range(len(o_valid_bits)):
+                o_valid_bit = 1 if o_valid_bits[i] == "1" else 0
+                i_en_bit = 1 if i_en_bits[i] == "1" else 0
+                if o_valid_bit:
+                    if i_en_bit:
+                        expected_samples_count += 1
+                    await stream_put(ctx, dut.o_stream, {
+                        "meta": i,
+                        "i_en": i_en_bit,
+                        "port": {
+                            "clk_out": {
+                                "o": i_en_bit,
+                            }
+                        }
+                    })
+                else:
+                    await ctx.tick()
 
-            for i in range(20):
+            while not i_stream_consumer_finished:
                 await ctx.tick()
-            assert len(actually_sampled) == 4 # This should be checked as well, because a possible failure mode is
-            # if IOStreamer never generates clock edges. We don't want to end up comparing two empty lists against
-            # eachother.
-            assert actually_sampled == expected_sample
+
+            assert len(actually_sampled) == expected_samples_count # This should be checked as well, because a
+            # possible failure mode is if IOStreamer never generates clock edges. We don't want to end up
+            # comparing two empty lists against eachother.
+            assert actually_sampled == expected_sample, (f"Expected [" +
+                    ", ".join(f"0x{s:02x}" for s in expected_sample) +
+                    "] Got [" +
+                    ", ".join(f"0x{s:02x}" for s in actually_sampled) + "]")
 
         sim = Simulator(dut)
         sim.add_clock(1e-6)
         sim.add_testbench(main_testbench)
-        sim.add_testbench(i_stream_consumer_tb, background = True)
+        sim.add_testbench(i_stream_consumer_tb, background=True)
         sim.add_testbench(input_generator_tb, background=True)
         sim.add_testbench(save_expected_sample_values_tb, background=True)
+        sim.add_testbench(check_timeout_tb, background=True)
         with sim.write_vcd("test.vcd", fs_per_delta=1):
             sim.run()
 
-    def test_ddr_input_sampled_correctly(self):
+    def test_sdr_input_sampled_correctly(self):
+        self._subtest_sdr_input_sampled_correctly(
+            o_valid_bits = "111111111",
+            i_en_bits    = "010101010",
+            i_ready_bits = "111111111" + ("1"*20))
+
+    def _subtest_ddr_input_sampled_correctly(self, o_valid_bits, i_en_bits, i_ready_bits, timeout_clocks=None):
         """ This is a latency-agnostic test, that verifies that the IOStreamer samples the inputs at the same time as the output signals change """
         ports = PortGroup()
         ports.clk_out = io.SimulationPort("o", 1)
         ports.data_in = io.SimulationPort("i", 8)
+
+        if timeout_clocks is None:
+            timeout_clocks = len(o_valid_bits) + len(i_ready_bits) + 20
 
         CLK_PERIOD = 1e-6
 
@@ -111,6 +167,7 @@ class IOStreamTestCase(unittest.TestCase):
 
         expected_sample = []
         actually_sampled = []
+        i_stream_consumer_finished = False
 
         async def input_generator_tb(ctx):
             """
@@ -161,10 +218,20 @@ class IOStreamTestCase(unittest.TestCase):
             """
             This testbench saves all the samples coming in over i_stream
             """
-            while True:
-                payload = await stream_get(ctx,dut.i_stream)
-                data = payload.port.data_in.i[0], payload.port.data_in.i[1]
-                actually_sampled.append(data)
+            nonlocal i_stream_consumer_finished
+            for i_ready_bit in i_ready_bits:
+                if i_ready_bit == "1":
+                    payload = await stream_get_maybe(ctx,dut.i_stream)
+                    if payload is not None:
+                        data = payload.port.data_in.i[0], payload.port.data_in.i[1]
+                        actually_sampled.append(data)
+                else:
+                    await ctx.tick()
+            i_stream_consumer_finished = True
+
+        async def check_timeout_tb(ctx):
+            await ctx.tick().repeat(timeout_clocks)
+            raise IOStreamTimeoutError("Testcase timeout")
 
         async def main_testbench(ctx):
             """
@@ -175,16 +242,32 @@ class IOStreamTestCase(unittest.TestCase):
             """
             await ctx.tick()
 
-            for i in range(0,8):
-                await stream_put(ctx, dut.o_stream, {"meta": i, "i_en": i % 2, "port": { "clk_out": {"o": (i % 2, 0)}}})
+            expected_samples_count = 0
 
-            await stream_put(ctx, dut.o_stream, {"meta": 0, "i_en": 0, "port": { "clk_out": {"o": (0, 0)}}})
+            for i in range(len(o_valid_bits)):
+                o_valid_bit = 1 if o_valid_bits[i] == "1" else 0
+                i_en_bit = 1 if i_en_bits[i] == "1" else 0
+                if o_valid_bit:
+                    if i_en_bit:
+                        expected_samples_count += 1
+                    await stream_put(ctx, dut.o_stream, {
+                        "meta": i,
+                        "i_en": i_en_bit,
+                        "port": {
+                            "clk_out": {
+                                "o": (i_en_bit, 0),
+                            }
+                        }
+                    })
+                else:
+                    await ctx.tick()
 
-            for i in range(20):
+            while not i_stream_consumer_finished:
                 await ctx.tick()
-            assert len(actually_sampled) == 4 # This should be checked as well, because a possible failure mode is
-            # if IOStreamer never generates clock edges. We don't want to end up comparing two empty lists against
-            # eachother.
+
+            assert len(actually_sampled) == expected_samples_count # This should be checked as well, because a
+            # possible failure mode is if IOStreamer never generates clock edges. We don't want to end up
+            # comparing two empty lists against eachother.
 
             assert actually_sampled == expected_sample, (f"Expected [" +
                     ", ".join(f"(0x{s0:02x}, 0x{s1:02x})" for s0, s1 in expected_sample) +
@@ -194,11 +277,18 @@ class IOStreamTestCase(unittest.TestCase):
         sim = Simulator(dut)
         sim.add_clock(CLK_PERIOD)
         sim.add_testbench(main_testbench)
-        sim.add_testbench(i_stream_consumer_tb, background = True)
+        sim.add_testbench(i_stream_consumer_tb, background=True)
         sim.add_testbench(input_generator_tb, background=True)
         sim.add_testbench(save_expected_sample_values_tb, background=True)
+        sim.add_testbench(check_timeout_tb, background=True)
         with sim.write_vcd("test.vcd", fs_per_delta=1):
             sim.run()
+
+    def test_ddr_input_sampled_correctly(self):
+        self._subtest_ddr_input_sampled_correctly(
+            o_valid_bits = "111111111",
+            i_en_bits    = "010101010",
+            i_ready_bits = "111111111" + ("1"*20))
 
     def test_basic(self):
         ports = PortGroup()

--- a/software/tests/gateware/test_iostream.py
+++ b/software/tests/gateware/test_iostream.py
@@ -70,7 +70,7 @@ class IOStreamTestCase(unittest.TestCase):
             later, when the sample actually arrives back on i_stream.
             """
             while True:
-                await ctx.posedge(ports.clk_out.o[0])
+                await ctx.changed(ports.clk_out.o)
                 value = ctx.get(ports.data_in.i)
                 expected_sample.append(value)
 
@@ -103,6 +103,7 @@ class IOStreamTestCase(unittest.TestCase):
             await ctx.tick()
 
             expected_samples_count = 0
+            o_bit = 0
 
             for i in range(len(o_valid_bits)):
                 o_valid_bit = 1 if o_valid_bits[i] == "1" else 0
@@ -110,12 +111,13 @@ class IOStreamTestCase(unittest.TestCase):
                 if o_valid_bit:
                     if i_en_bit:
                         expected_samples_count += 1
+                        o_bit ^= 1
                     await stream_put(ctx, dut.o_stream, {
                         "meta": i,
                         "i_en": i_en_bit,
                         "port": {
                             "clk_out": {
-                                "o": i_en_bit,
+                                "o": o_bit,
                             }
                         }
                     })

--- a/software/tests/gateware/test_iostream.py
+++ b/software/tests/gateware/test_iostream.py
@@ -8,12 +8,23 @@ from glasgow.gateware.ports import PortGroup
 from glasgow.gateware.iostream import IOStreamer
 
 async def stream_get(ctx, stream):
+    """
+    This helper coroutine takes one payload from the stream.
+    If a payload is not available it waits as many clocks cycles as
+    needed stream.valid goes high.
+    """
     ctx.set(stream.ready, 1)
     payload, = await ctx.tick().sample(stream.payload).until(stream.valid)
     ctx.set(stream.ready, 0)
     return payload
 
 async def stream_get_maybe(ctx, stream):
+    """
+    This helper coroutine takes one payload from the stream,
+    if it is available at the next clock cycle. If a payload is not
+    available, then time is advanced by only a single clock cycle,
+    and this coroutine returns None.
+    """
     ctx.set(stream.ready, 1)
     _, _, payload, stream_valid = await ctx.tick().sample(stream.payload, stream.valid)
     ctx.set(stream.ready, 0)
@@ -23,17 +34,53 @@ async def stream_get_maybe(ctx, stream):
         return None
 
 async def stream_put(ctx, stream, payload):
+    """
+    This helper coroutine presents a payload to the specified stream,
+    and waits as many clock cycles as it takes for the payload to be accepted.
+    """
     ctx.set(stream.payload, payload)
     ctx.set(stream.valid, 1)
     await ctx.tick().until(stream.ready)
     ctx.set(stream.valid, 0)
 
 class IOStreamTimeoutError(Exception):
+    """
+    Custom exception class to make it easy to catch just this exception, for tests
+    that are expected to fail with a timeout.
+    """
     pass
 
 class IOStreamTestCase(unittest.TestCase):
     def _subtest_sdr_input_sampled_correctly(self, o_valid_bits, i_en_bits, i_ready_bits, timeout_clocks=None):
-        """ This is a latency-agnostic test, that verifies that the IOStreamer samples the inputs at the same time as the output signals change """
+        """
+        This is a latency-agnostic test, that verifies that the IOStreamer samples the inputs at the same time as the output signals change.
+
+        o_valid_bits: is a string of "1"s and "0"s. Each character refers to one (or more) clock cycles. "1" means to send a payload,
+            and "0" means to leave o_stream idle for 1 clock cycle. When sending a payload o_stream is waited upon if it's not ready, so
+            each "1" might take more than one clock cycle. A "0" always takes a single clock cycle. During the test all the
+            payloads with "1" are guaranteed to be sent, unless the testcase raises an IOStreamTimeoutError.
+
+        i_en_bits: is a string of "1"s and "0"s, and it specifies for each payload, whether to send it with i_en high. The index of the
+            character in the i_en_bits string matches the index of the character in the o_valid_bits. That is o_valid_bits, and i_en_bits
+            never go out of sync. Setting i_en_bits high for the positions on which o_valid_bits is low has no effect. The value of i_en_bits
+            only matters when we're actually sending a payload. Note that having i_en_bits high for a payload also has an effect on the "clock_out"
+            pin, to allow the testcase to determine what data is expected to be sampled when it comes back o i_stream. In the case of an SDR test,
+            clk_out toggles every time inputs are sampled.
+
+        i_ready_bits: is a string of "1"s and "0"s, and it specifies on which clock cycle the i_stream is ready or not. Each character refers
+            to a single clock cycle, and if the stream does not have a payload available at the releavant clock cycle, then the coroutine that
+            consumes i_stream payloads moves on to the next character in this string. Make sure to have sufficient "1"s in this string so that all
+            sample requests (o_stream payloads with i_en high) that have been launched are collected, otherwise the testcase may fail, in one of two ways:
+              - back-pressure on i_stream may result in back-pressure on o_stream, never allowing the full o_valid_bits string to be completely played back,
+                and resulting in a timeout.
+              - the playback of the o_valid_bits string may complete, however it's possible a number of sample requests that are in flight remain stuck
+                in the IOStreamer, pending for them to be extracted from the i_stream, and that could result in the testcase declaring that the final
+                samples have been lost.
+            To make sure a testcase completes, you will see some testcases have a large number of "1"s in this string past the length of o_valid_bits.
+
+        timeout_clocks: The number of clock cycles we expect the testcase to complete. If None (default), then an appropriate amount of clock cycles is
+            calculated.
+        """
         ports = PortGroup()
         ports.clk_out = io.SimulationPort("o", 1)
         ports.data_in = io.SimulationPort("i", 8)
@@ -65,12 +112,13 @@ class IOStreamTestCase(unittest.TestCase):
 
         async def save_expected_sample_values_tb(ctx):
             """
-            This testbench looks at the clk_out port and when it sees a positive edge it knows that
+            This testbench looks at the clk_out port and when it sees a positive or negative edge it knows that
             IOStreamer is expected to sample the input signal, so the current state of the data_in port
             becomes one of the expected sampled values. This is saved into expected_sample[] to be compared
             later, when the sample actually arrives back on i_stream.
             """
             while True:
+                # in the case of SDR tests there are no glitches on the clock_out simulation, so we case safely use ctx.changed:
                 await ctx.changed(ports.clk_out.o)
                 value = ctx.get(ports.data_in.i)
                 expected_sample.append(value)
@@ -91,15 +139,19 @@ class IOStreamTestCase(unittest.TestCase):
 
 
         async def check_timeout_tb(ctx):
+            """
+            This testbench ends the testcase if the given number of timeout clock cycles has elapsed.
+            """
             await ctx.tick().repeat(timeout_clocks)
             raise IOStreamTimeoutError("Testcase timeout")
 
         async def main_testbench(ctx):
             """
             This testbench is the producer for o_stream, and it also serves as the main orchestrator
-            for the entire testcase. After it produces the stimulus, it waits a number of clock cycles
-            to make sure any input latency has passed, and then it verifies that the expected number
-            of bytes has been received, and that the expected values have been sampled.
+            for the entire testcase. After it produces the stimulus, it waits for the i_stream_consumer_tb
+            to finish (which may take longer to potentially consume in-flight sampled payloads due to the
+            latency of the dut). and then it verifies that the expected number of bytes has been received,
+            and that the expected values have been sampled.
             """
             await ctx.tick()
 
@@ -153,7 +205,37 @@ class IOStreamTestCase(unittest.TestCase):
             i_ready_bits = "111111111" + ("1"*20))
 
     def _subtest_ddr_input_sampled_correctly(self, o_valid_bits, i_en_bits, i_ready_bits, timeout_clocks=None):
-        """ This is a latency-agnostic test, that verifies that the IOStreamer samples the inputs at the same time as the output signals change """
+        """
+        This is a latency-agnostic test, that verifies that the IOStreamer samples the inputs at the same time as the output signals change.
+
+        o_valid_bits: is a string of "1"s and "0"s. Each character refers to one (or more) internal clock cycles. "1" means to send a payload,
+            and "0" means to leave o_stream idle for 1 clock cycle. When sending a payload o_stream is waited upon if it's not ready, so
+            each "1" might take more than one internal clock cycle. A "0" always takes a single internal clock cycle. During the test all the
+            payloads with "1" are guaranteed to be sent, unless the testcase raises an IOStreamTimeoutError.
+
+        i_en_bits: is a string of "1"s and "0"s, and it specifies for each payload, whether to send it with i_en high. The index of the
+            character in the i_en_bits string matches the index of the character in the o_valid_bits. That is o_valid_bits, and i_en_bits
+            never go out of sync. Setting i_en_bits high for the positions on which o_valid_bits is low has no effect. The value of i_en_bits
+            only matters when we're actually sending a payload. Note that having i_en_bits high for a payload also has an effect on the "clock_out"
+            pin, to allow the testcase to determine what data is expected to be sampled when it comes back o i_stream. In the case of a DDR test,
+            clk_out toggles twice every time inputs are sampled, and the edges on which it toggles specify exactly at what time the inputs
+            are sampled.
+
+        i_ready_bits: is a string of "1"s and "0"s, and it specifies on which internal clock cycle the i_stream is ready or not. Each character refers
+            to a single clock cycle, and if the stream does not have a payload available at the releavant clock cycle, then the coroutine that
+            consumes i_stream payloads moves on to the next character in this string. Make sure to have sufficient "1"s in this string so that all
+            sample requests (o_stream payloads with i_en high) that have been launched are collected, otherwise the testcase may fail, in one of two ways:
+              - back-pressure on i_stream may result in back-pressure on o_stream, never allowing the full o_valid_bits string to be completely played back,
+                and resulting in a timeout.
+              - the playback of the o_valid_bits string may complete, however it's possible a number of sample requests that are in flight remain stuck
+                in the IOStreamer, pending for them to be extracted from the i_stream, and that could result in the testcase declaring that the final
+                samples have been lost.
+            To make sure a testcase completes, you will see some testcases have a large number of "1"s in this string past the length of o_valid_bits.
+
+        timeout_clocks: The number of clock cycles we expect the testcase to complete. If None (default), then an appropriate amount of clock cycles is
+            calculated.
+        """
+
         ports = PortGroup()
         ports.clk_out = io.SimulationPort("o", 1)
         ports.data_in = io.SimulationPort("i", 8)
@@ -233,15 +315,19 @@ class IOStreamTestCase(unittest.TestCase):
             i_stream_consumer_finished = True
 
         async def check_timeout_tb(ctx):
+            """
+            This testbench ends the testcase if the given number of timeout clock cycles has elapsed.
+            """
             await ctx.tick().repeat(timeout_clocks)
             raise IOStreamTimeoutError("Testcase timeout")
 
         async def main_testbench(ctx):
             """
             This testbench is the producer for o_stream, and it also serves as the main orchestrator
-            for the entire testcase. After it produces the stimulus, it waits a number of clock cycles
-            to make sure any input latency has passed, and then it verifies that the expected number
-            of bytes has been received, and that the expected values have been sampled.
+            for the entire testcase. After it produces the stimulus, it waits for the i_stream_consumer_tb
+            to finish (which may take longer to potentially consume in-flight sampled payloads due to the
+            latency of the dut). and then it verifies that the expected number of bytes has been received,
+            and that the expected values have been sampled.
             """
             await ctx.tick()
 

--- a/software/tests/gateware/test_iostream.py
+++ b/software/tests/gateware/test_iostream.py
@@ -96,6 +96,110 @@ class IOStreamTestCase(unittest.TestCase):
         with sim.write_vcd("test.vcd", fs_per_delta=1):
             sim.run()
 
+    def test_ddr_input_sampled_correctly(self):
+        """ This is a latency-agnostic test, that verifies that the IOStreamer samples the inputs at the same time as the output signals change """
+        ports = PortGroup()
+        ports.clk_out = io.SimulationPort("o", 1)
+        ports.data_in = io.SimulationPort("i", 8)
+
+        CLK_PERIOD = 1e-6
+
+        dut = IOStreamer({
+            "clk_out": ("o", 1),
+            "data_in": ("i", 8),
+        }, ports, ratio=2, meta_layout=4)
+
+        expected_sample = []
+        actually_sampled = []
+
+        async def input_generator_tb(ctx):
+            """
+            This generates input values at the the half-time between every falling/rising clock edge.
+            This is to make it very obvious what value should be sampled by each DDR edge.
+            Exactly which of these values will be sampled depends on the latency of the dut,
+            which this testcase is agnostic about.
+            """
+            cnt = 0xff
+            while True:
+                ctx.set(ports.data_in.i, cnt)
+                await ctx.tick()
+                await ctx.delay(CLK_PERIOD/4)
+                cnt = (cnt - 1) & 0xff
+                ctx.set(ports.data_in.i, cnt)
+                await ctx.delay(CLK_PERIOD/2) # half a clock cycle
+                cnt = (cnt - 1) & 0xff
+
+        async def save_expected_sample_values_tb(ctx):
+            """
+            This testbench looks at the clk_out port and when it sees a positive edge it knows that
+            IOStreamer is expected to sample the input signal, so the current state of the data_in port
+            becomes one of the expected sampled values. This is saved into expected_sample[] to be compared
+            later, when the sample actually arrives back on i_stream.
+            The way we look for the rising edge is a bit hairy, because the current implementation of
+            DDRBufferCanBeSimulated can generate glitches, so we wait DELAY_TO_AVOID_GLITCHES after
+            the clock edge, to make sure any glitches are resolved.
+            Because this is a DDR test, we also wait half a clock to save the other edge as well.
+            """
+            while True:
+                DELAY_TO_AVOID_GLITCHES = CLK_PERIOD/10
+
+                await ctx.posedge(ports.clk_out.o[0])
+                await ctx.delay(DELAY_TO_AVOID_GLITCHES)
+                while ctx.get(ports.clk_out.o[0]) == 0:
+                    await ctx.posedge(ports.clk_out.o[0])
+                    await ctx.delay(DELAY_TO_AVOID_GLITCHES)
+
+                value_phase_0 = ctx.get(ports.data_in.i)
+
+                await ctx.delay(CLK_PERIOD / 2)
+
+                value_phase_1 = ctx.get(ports.data_in.i)
+
+                expected_sample.append((value_phase_0, value_phase_1))
+
+        async def i_stream_consumer_tb(ctx):
+            """
+            This testbench saves all the samples coming in over i_stream
+            """
+            while True:
+                payload = await stream_get(ctx,dut.i_stream)
+                data = payload.port.data_in.i[0], payload.port.data_in.i[1]
+                actually_sampled.append(data)
+
+        async def main_testbench(ctx):
+            """
+            This testbench is the producer for o_stream, and it also serves as the main orchestrator
+            for the entire testcase. After it produces the stimulus, it waits a number of clock cycles
+            to make sure any input latency has passed, and then it verifies that the expected number
+            of bytes has been received, and that the expected values have been sampled.
+            """
+            await ctx.tick()
+
+            for i in range(0,8):
+                await stream_put(ctx, dut.o_stream, {"meta": i, "i_en": i % 2, "port": { "clk_out": {"o": (i % 2, 0)}}})
+
+            await stream_put(ctx, dut.o_stream, {"meta": 0, "i_en": 0, "port": { "clk_out": {"o": (0, 0)}}})
+
+            for i in range(20):
+                await ctx.tick()
+            assert len(actually_sampled) == 4 # This should be checked as well, because a possible failure mode is
+            # if IOStreamer never generates clock edges. We don't want to end up comparing two empty lists against
+            # eachother.
+
+            assert actually_sampled == expected_sample, (f"Expected [" +
+                    ", ".join(f"(0x{s0:02x}, 0x{s1:02x})" for s0, s1 in expected_sample) +
+                    "] Got [" +
+                    ", ".join(f"(0x{s0:02x}, 0x{s1:02x})" for s0, s1 in actually_sampled) + "]")
+
+        sim = Simulator(dut)
+        sim.add_clock(CLK_PERIOD)
+        sim.add_testbench(main_testbench)
+        sim.add_testbench(i_stream_consumer_tb, background = True)
+        sim.add_testbench(input_generator_tb, background=True)
+        sim.add_testbench(save_expected_sample_values_tb, background=True)
+        with sim.write_vcd("test.vcd", fs_per_delta=1):
+            sim.run()
+
     def test_basic(self):
         ports = PortGroup()
         ports.data = port = io.SimulationPort("io", 1)

--- a/software/tests/gateware/test_qspi.py
+++ b/software/tests/gateware/test_qspi.py
@@ -1,4 +1,5 @@
 import unittest
+from collections import deque
 from amaranth import *
 from amaranth.sim import Simulator, BrokenTrigger
 from amaranth.lib import io
@@ -21,9 +22,12 @@ async def stream_put(ctx, stream, payload):
     ctx.set(stream.valid, 0)
 
 
-def simulate_flash(ports, memory=b"nya nya nya nya nyaaaaan"):
+def simulate_flash(ports, memory=b"nya nya nya nya nyaaaaan", roundtrip_time_s=0):
     class CSDeasserted(Exception):
         pass
+
+    delayed_roundtrip_set = deque()
+    trigger_delayed_set = Signal()
 
     async def watch_cs(cs_o, triggers):
         try:
@@ -71,20 +75,46 @@ def simulate_flash(ports, memory=b"nya nya nya nya nyaaaaan"):
         for _ in range(0, 8, x):
             if ctx.get(sck.o):
                 await watch_cs(cs.o, ctx.negedge(sck.o))
+
+            if roundtrip_time_s == 0:
+                if x == 1:
+                    ctx.set(Cat(io1.i), (word >> 7))
+                if x == 2:
+                    ctx.set(Cat(io0.i, io1.i), (word >> 6))
+                if x == 4:
+                    ctx.set(Cat(io0.i, io1.i, io2.i, io3.i), (word >> 4))
+            else:
+                delayed_roundtrip_set.append((ctx._engine.now + roundtrip_time_s * 1e15, x, word))
+                ctx.set(trigger_delayed_set, 1 ^ ctx.get(trigger_delayed_set))
+
             if x == 1:
-                ctx.set(Cat(io1.i), (word >> 7))
                 word = (word << 1) & 0xff
             if x == 2:
-                ctx.set(Cat(io0.i, io1.i), (word >> 6))
                 word = (word << 2) & 0xff
             if x == 4:
-                ctx.set(Cat(io0.i, io1.i, io2.i, io3.i), (word >> 4))
                 word = (word << 4) & 0xff
             _, io0_oe, io1_oe, io2_oe, io3_oe = \
                 await watch_cs(cs.o, ctx.posedge(sck.o).sample(io0.oe, io1.oe, io2.oe, io3.oe))
             assert (io0_oe, io1_oe, io2_oe, io3_oe) == (x == 1, 0, 0, 0)
 
-    async def testbench(ctx):
+    async def delayed_set_testbench(ctx):
+        io0, io1, io2, io3 = ports.io
+        while True:
+            await ctx.changed(trigger_delayed_set)
+            while delayed_roundtrip_set:
+                attime, x, word = delayed_roundtrip_set.popleft()
+                if attime >= ctx._engine.now:
+                    await ctx.delay((attime - ctx._engine.now) * 1e-15)
+                    if x == 1:
+                        ctx.set(Cat(io1.i), (word >> 7))
+                    if x == 2:
+                        ctx.set(Cat(io0.i, io1.i), (word >> 6))
+                    if x == 4:
+                        ctx.set(Cat(io0.i, io1.i, io2.i, io3.i), (word >> 4))
+                else:
+                    assert False, "Error: trying to change signal in the past?"
+
+    async def main_flash_testbench(ctx):
         await ctx.negedge(ports.cs.o)
         while True:
             try:
@@ -114,7 +144,7 @@ def simulate_flash(ports, memory=b"nya nya nya nya nyaaaaan"):
                 await ctx.negedge(ports.cs.o)
                 continue
 
-    return testbench
+    return main_flash_testbench, delayed_set_testbench
 
 
 class QSPITestCase(unittest.TestCase):
@@ -253,13 +283,14 @@ class QSPITestCase(unittest.TestCase):
         with sim.write_vcd("test.vcd"):
             sim.run()
 
-    def subtest_qspi_controller(self, *, use_ddr_buffers:bool, divisor:int):
+    QSPI_CONTROLLER_SUBTEST_CLK_PERIOD = 1e-6
+    def subtest_qspi_controller(self, *, use_ddr_buffers:bool, divisor:int, roundtrip_time_s:float=0, sample_delay_half_clocks:int=0):
         ports = PortGroup()
         ports.sck = io.SimulationPort("o",  1)
         ports.io  = io.SimulationPort("io", 4)
         ports.cs  = io.SimulationPort("o",  1)
 
-        dut = QSPIController(ports, use_ddr_buffers=use_ddr_buffers)
+        dut = QSPIController(ports, use_ddr_buffers=use_ddr_buffers, sample_delay_half_clocks=sample_delay_half_clocks)
 
         async def testbench_controller(ctx):
             async def ctrl_idle():
@@ -315,12 +346,13 @@ class QSPITestCase(unittest.TestCase):
 
             await ctrl_idle()
 
-        testbench_flash = simulate_flash(ports, memory=b"nya nya awa!nya nyaaaaan")
+        testbench_flash = simulate_flash(ports, memory=b"nya nya awa!nya nyaaaaan", roundtrip_time_s=roundtrip_time_s)
 
         sim = Simulator(dut)
-        sim.add_clock(1e-6)
+        sim.add_clock(self.QSPI_CONTROLLER_SUBTEST_CLK_PERIOD)
         sim.add_testbench(testbench_controller)
-        sim.add_testbench(testbench_flash, background=True)
+        for sub_testbench in testbench_flash:
+            sim.add_testbench(sub_testbench, background=True)
         with sim.write_vcd("test.vcd"):
             sim.run()
 
@@ -341,3 +373,65 @@ class QSPITestCase(unittest.TestCase):
 
     def test_qspi_controller_ddr_div2(self):
         self.subtest_qspi_controller(use_ddr_buffers=True, divisor=2)
+
+    def test_qspi_controller_needs_sample_delay_ddr_div0_max_turnaround(self):
+        for sample_delay_half_clocks in range(5):
+            self.subtest_qspi_controller(use_ddr_buffers=True,
+                                         divisor=0,
+                                         roundtrip_time_s=self.QSPI_CONTROLLER_SUBTEST_CLK_PERIOD * (0.49 + 0.5 * sample_delay_half_clocks),
+                                         sample_delay_half_clocks=sample_delay_half_clocks)
+
+    def test_qspi_controller_needs_sample_delay_ddr_div0_too_much_turnaround(self):
+        for sample_delay_half_clocks in range(5):
+            try:
+                self.subtest_qspi_controller(use_ddr_buffers=True,
+                                             divisor=0,
+                                             roundtrip_time_s=self.QSPI_CONTROLLER_SUBTEST_CLK_PERIOD * (0.51 + 0.5 * sample_delay_half_clocks),
+                                             sample_delay_half_clocks = sample_delay_half_clocks)
+            except AssertionError:
+                pass
+            else:
+                assert False, "QSPI controller should have failed with too much turnaround time"
+
+    def test_qspi_controller_needs_sample_delay_ddr_div0_too_little_turnaround(self):
+        for sample_delay_half_clocks in range(2, 5):
+            try:
+                self.subtest_qspi_controller(use_ddr_buffers=True,
+                                             divisor=0,
+                                             roundtrip_time_s=self.QSPI_CONTROLLER_SUBTEST_CLK_PERIOD * (0.49 + 0.5 * (sample_delay_half_clocks - 2)),
+                                             sample_delay_half_clocks = sample_delay_half_clocks)
+            except AssertionError:
+                pass
+            else:
+                assert False, "QSPI controller should have failed with too little turnaround time"
+
+    def test_qspi_controller_needs_sample_delay_sdr_div0_max_turnaround(self):
+        for sample_delay_half_clocks in range(0, 9, 2):
+            self.subtest_qspi_controller(use_ddr_buffers=False,
+                                         divisor=0,
+                                         roundtrip_time_s=self.QSPI_CONTROLLER_SUBTEST_CLK_PERIOD * (0.99 + (0.5 * sample_delay_half_clocks)),
+                                         sample_delay_half_clocks=sample_delay_half_clocks)
+
+    def test_qspi_controller_needs_sample_delay_sdr_div0_too_much_turnaround(self):
+        for sample_delay_half_clocks in range(0, 9, 2):
+            try:
+                self.subtest_qspi_controller(use_ddr_buffers=False,
+                                             divisor=0,
+                                             roundtrip_time_s=self.QSPI_CONTROLLER_SUBTEST_CLK_PERIOD * (1.01 + (0.5 * sample_delay_half_clocks)),
+                                             sample_delay_half_clocks = sample_delay_half_clocks)
+            except AssertionError:
+                pass
+            else:
+                assert False, "QSPI controller should have failed with too much turnaround time"
+
+    def test_qspi_controller_needs_sample_delay_sdr_div0_too_little_turnaround(self):
+        for sample_delay_half_clocks in range(4, 9, 2):
+            try:
+                self.subtest_qspi_controller(use_ddr_buffers=False,
+                                             divisor=0,
+                                             roundtrip_time_s=self.QSPI_CONTROLLER_SUBTEST_CLK_PERIOD * (0.99 + 0.5 * (sample_delay_half_clocks - 4)),
+                                             sample_delay_half_clocks = sample_delay_half_clocks)
+            except AssertionError:
+                pass
+            else:
+                assert False, "QSPI controller should have failed with too little turnaround time"


### PR DESCRIPTION
This refactors the entire IOStreamer infrastructure and how it's used with QSPI.

Here's a rough sketch of what the structure looks like:
![image](https://github.com/user-attachments/assets/c65403ba-60f3-4b5d-9e2c-a3d6c4962303)

This PR is correct with respect to all of the pending bugs that the existing IOStreamer and QSPI controller has, that is:
- DDR sampling latency is correct
- Supports sample delay functionality (with the applet auto-calculating some reasonable defaults)
- QSPI controller now always samples and drives on the correct edge (or relative to the correct edge)
- There is no more risk of losing a sample when the skid buffer both receives and sends a sample on the same clock cycle
- A combinatorial i_stream.ready will not block

In addition what's new in the PR:
- `sample_delay_half_clocks` is runtime-configurable, with `max_sample_delay_half_clocks` allows IOStreamer to configure the right amount of resources
- We have discussed how we can avoid having a shift register stage, and a skid buffer stage for every sample delay step. I came to the concolusion that:
   - `divisor` must be known by `IOStreamerTop` in order to make optimizations like that, so I have integrated IOStretcher into IOStreamerTop.
   - `divisor` is a runtime setting, so we cannot minimize logic based on its value, so I have added a `min_divisor` configuration option. `divisor` must always be `>= min_divisor`. The `min_divisor` option can be used to optimize away skid buffer stages, and to optimize the shift register stages that delay samples from entering the skid buffer.
   - the size of the skid buffer can be made as small as `ceil(max_latency / min_divisor)`, which can sometimes end up being as small as a single stage.
   - the shift registers that are used to delay the samples and `meta` from entering the skid buffer, can be implemented more  efficiently by using a counter. Unfortunately if the maximum latency is large, then the counter will only count up to `min_divisor`, and beyond that the rest of the latency will be implemented with shift registers. However if the maximum latency is small, The counter will suffice.
   - If we don't constrain divisor with a `min_divisor` configuration option, then I don't think that we can make any kind of optimization and we are forced to have max_latency shift register stages for `i_en`/`meta` and max_latency skid buffer stages as well. 
- when it comes to the 1-lane to 2-lane conversion (i.e. having two 1-lane transactions be merged into a single two-lane transaction) it's a bit complicated, and one of the following options must be chosen:
  - 1-lane transactions could always come in pairs. So the first would always belong to lane 0 and the second would always belong to lane 1. I have chosen to not implement this solution, because we need to have `i_en` individually for each lane. And that means that `i_en` can be set high only for one lane, so while on 2-to-1-lane conversion we always get pairs, the returning samples will not be paired anymore. One way we could handle that would be to have i_en be an attribute outside of lanes, or to have i_en be or-ed together, and overridden to be the same for all lanes, before 2-to-1 conversion, but this is undesireable.
  - Another option would be to always convert a 1-lane transaction to a 2-lane transaction where the second lane is an empty lane. This is undesirable, because QSPIController now has to be aware if we're in the DDR+divisor=0 case, in which case samples will return on lane [1], and in all other cases samples would return on lane [0]. I seems very hackish from the perspective of the QSPIController. Samples should always return on the same lane independent of speed configuration. We can't just return ddr+divisor=0 lane[1] samples on lane[0], because that's not a generic solution, sometimes we care about samples taken during the rising edge, and sometimes for other protocols we may actually want to sample on both edges. So this option is undesirable.
  - What I have implemented, is that IOClockers's `IO2LaneTo1Lane` converter adds extra information to `meta`, that identifies which lane each transaction originally belonged to. Then then entire IOStreamerTop structure processes the transaction with the expanded `meta` field, and when samples come back to IOClockerDeframer, they have the corresponding fields `tag` and `last`.
    - `tag` will tell the `IO1LaneTo2Lane` upconverter, to which lane each sample belongs to
    - `last` will tell the `IO1LaneTo2Lane` upconverter, if it needs to wait for another sample before assembling the 2-lane transaction and sending it to QSPIDeframer.
    - Note that `last` is generated in `IO2LaneTo1Lane` by looking at lane 1's i_en. If `lane[1].i_en` is high, than `lane[0].meta.last` is low, and `lane[1].meta.last` is high, otherwise `lane[0].meta.last` is high.
    - This schema results in:
      - QSPIController simply sees lane[0] as clock falling edge, and lane[1] as clock rising edge. It will simply set i_en high for the edge(s) for which it's interested in receiving a sample, and the sample will come back on the same lane number(s) as on which i_en was set high. This makes things generic for future protocols.