### PR TITLE
applet.interface.analyzer: set scope name to something not empty

### DIFF
--- a/software/glasgow/applet/interface/analyzer/__init__.py
+++ b/software/glasgow/applet/interface/analyzer/__init__.py
@@ -102,7 +102,7 @@ class AnalyzerApplet(GlasgowApplet):
         vcd_writer = VCDWriter(args.file, timescale="1 ns", check_values=False)
         signals = []
         for index in range(self._event_sources[0].width):
-            signals.append(vcd_writer.register_var(scope="", name=f"pin[{index}]",
+            signals.append(vcd_writer.register_var(scope="glasgow", name=f"pin[{index}]",
                 var_type="wire", size=1, init=0))
 
         try:


### PR DESCRIPTION
Some tools (namely libsigrok), expect non empty names

This fixes the following error when importing the output into pulseview.
```
sr: input/vcd: Cannot parse 'scope' directive
```

relevant code in libsigrok

https://github.com/sigrokproject/libsigrok/blob/f06f788118191d19fdbbb37046d3bd5cec91adb1/src/input/vcd.c#L661-L665