### PR TITLE
software: Lock yosys to pre 0.48 relase.

### DIFF
--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -62,7 +62,7 @@ builtin-toolchain = [
   # the lowest that has features transitively required by Glasgow.
   "yowasp-runtime>=1.42",
   # Most versions of Yosys and nextpnr work; the minimum versions listed here are known good.
-  "yowasp-yosys>=0.31.0.13",
+  "yowasp-yosys>=0.31.0.13,<0.48",
   "yowasp-nextpnr-ice40>=0.1",
 ]
 


### PR DESCRIPTION
The 0.48 release of yosys is dropping the ilang alias. We have to wait for amaranth release with the appropriate fix to be released before we can remove this constraint.

For reference we are waiting for this patch to be included in an Amaranth release: https://github.com/amaranth-lang/amaranth/commit/ab3a355a54993dae164863d94816a2c5c0df7657 when that is the case we can remove this constraint again.