### PR TITLE
applet.internal.selftest: label 'broken' tests as 'not supported' instead

### DIFF
--- a/software/glasgow/applet/internal/selftest/__init__.py
+++ b/software/glasgow/applet/internal/selftest/__init__.py
@@ -168,7 +168,7 @@ class SelfTestApplet(GlasgowApplet):
 
             if mode in ("pins-int", "pins-ext", "pins-pull"):
                 if device.revision >= "C0":
-                    raise GlasgowAppletError(f"mode {mode} is broken on device revision "
+                    raise GlasgowAppletError(f"mode {mode} is not supported on device revision "
                                              f"{device.revision}")
 
                 if mode == "pins-int":


### PR DESCRIPTION
Something I've noticed fairly often is users trying out the self-test and interpreting "broken" as a test fail. I think it'd be clearer to say those test modes are "not supported" instead.