### PR TITLE
Add ATmega8 and fix some minor bugs with program-avr-spi applet

### DIFF
--- a/software/glasgow/database/microchip/avr.py
+++ b/software/glasgow/database/microchip/avr.py
@@ -37,6 +37,7 @@ devices = [
     ATtiny("45",   (0x1e, 0x92, 0x06), program_size=2048,  program_page=64,  eeprom_size=256),
     ATtiny("85",   (0x1e, 0x93, 0x0B), program_size=4096,  program_page=64,  eeprom_size=512),
     # ATmega series
+    ATmega("8",    (0x1e, 0x93, 0x07), program_size=8192,  program_page=64,  eeprom_size=512, erase_time=15),
     ATmega("48",   (0x1e, 0x92, 0x05), program_size=4096,  program_page=64,  eeprom_size=256),
     ATmega("48P",  (0x1e, 0x92, 0x0a), program_size=4096,  program_page=64,  eeprom_size=256),
     ATmega("88",   (0x1e, 0x93, 0x0a), program_size=8192,  program_page=64,  eeprom_size=512),


### PR DESCRIPTION
There are two changes here:

1. Adding the ATmega8 to the database of AVR microcontrollers. `erase_time` was chosen to match the other entry with an `erase_time`, since *not* having one seemed to lead to issues with verifying what had been written, and this one seems to work fine
2. Fixing up the `program-avr-spi` applet so it doesn't give a traceback whenever you're doing something with an unidentified device

For an explanation of the second one, see the following output I got before adding the ATmega8:
```
% glasgow run program-avr-spi -V 5 --pin-reset 0 --pin-sck 1 --pin-cipo 2 --pin-copi 3 identify
I: g.device.hardware: device already has bitstream ID 57b5cdebb6d0d20034246a56c317b332
I: g.cli: running handler for applet 'program-avr-spi'
I: g.applet.program.avr.spi: port(s) A, B voltage set to 5.0 V
I: g.applet.program.avr.spi: device signature: 1e 93 07 (unknown)
Traceback (most recent call last):
  File "/home/dave/.local/bin/glasgow", line 8, in <module>
    sys.exit(run_main())
             ~~~~~~~~^^
  File "/home/dave/git/glasgow/software/glasgow/cli.py", line 942, in run_main
    exit(asyncio.new_event_loop().run_until_complete(main()))
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "/usr/lib/python3.13/asyncio/base_events.py", line 720, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "/home/dave/git/glasgow/software/glasgow/cli.py", line 710, in main
    return applet_task.result()
           ~~~~~~~~~~~~~~~~~~^^
  File "/home/dave/git/glasgow/software/glasgow/cli.py", line 659, in run_applet
    return await applet.interact(device, args, iface)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dave/git/glasgow/software/glasgow/applet/program/avr/__init__.py", line 259, in interact
    if device.erase_time is not None:
       ^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'erase_time'
```

This is actually the result of two different things that needed to be fixed:
1. The code was attempting to use the `device` object before it checked to see if the device existed (so this change brings that further up)
2. The code that checks for the existence of the device explicitly excludes checking when either called with no action or with the "identify" action, which means that you would *still* get this error even with 1 being fixed

I don't know if a simple `return` is what's wanted here, but I assume the point of the check was to not error out on an unidentified device because it's already done everything that's needed for the `identify` command