### PR TITLE
Add a 24 series I2C EEPROM emulator

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake . --impure

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@
 /*.bit
 /*.json
 /*.csv
+
+.direnv
+
+# Nix build outputs
+/result
+/result-*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,76 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1737469691,
+        "narHash": "sha256-nmKOgAU48S41dTPIXAq0AHZSehWUn6ZPrUKijHAMmIk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9e4d5190a9482a1fb9d18adf0bdb83c6e506eaab",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,7 @@
           glasgow = pkgs.glasgow.overrideAttrs {
             version = "0+unstable-memory-24x-emu";
             src = ./.;
+            doInstallCheck = false;
           };
           default = glasgow;
         };

--- a/flake.nix
+++ b/flake.nix
@@ -21,12 +21,8 @@
 
         devShell = pkgs.mkShell {
           packages = with pkgs; [
-            yosys
-            icestorm
-            nextpnr
-
-            sdcc
-
+            # Must come before yosys in this array, so it has precedence
+            # over the propagatedBuildInput python3 from yosys.
             (python3.withPackages (pypkgs: with pypkgs; [
               typing-extensions
               amaranth
@@ -39,6 +35,13 @@
 
               unittestCheckHook
             ]))
+
+            yosys
+            icestorm
+            nextpnr
+
+            sdcc
+
           ];
 
           YOSYS="${lib.getBin pkgs.yosys}/bin/yosys";

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,52 @@
+{
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    flake-compat.url = "github:edolstra/flake-compat";
+  };
+  outputs = { nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        lib = pkgs.lib;
+      in
+      {
+        packages = rec {
+          glasgow = pkgs.glasgow.overrideAttrs {
+            version = "";
+            src = ./.;
+          };
+          default = glasgow;
+        };
+
+        devShell = pkgs.mkShell {
+          packages = with pkgs; [
+            yosys
+            icestorm
+            nextpnr
+
+            sdcc
+
+            (python3.withPackages (pypkgs: with pypkgs; [
+              typing-extensions
+              amaranth
+              packaging
+              platformdirs
+              fx2
+              libusb1
+              pyvcd
+              aiohttp
+
+              unittestCheckHook
+            ]))
+          ];
+
+          YOSYS="${lib.getBin pkgs.yosys}/bin/yosys";
+          ICEPACK="${lib.getBin pkgs.icestorm}/bin/icepack";
+          NEXTPNR_ICE40="${lib.getBin pkgs.nextpnr}/bin/nextpnr-ice40";
+        };
+
+        formatter = pkgs.nixfmt-rfc-style;
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -4,8 +4,10 @@
     flake-utils.url = "github:numtide/flake-utils";
     flake-compat.url = "github:edolstra/flake-compat";
   };
-  outputs = { nixpkgs, flake-utils, ... }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    { nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
         lib = pkgs.lib;
@@ -23,18 +25,20 @@
           packages = with pkgs; [
             # Must come before yosys in this array, so it has precedence
             # over the propagatedBuildInput python3 from yosys.
-            (python3.withPackages (pypkgs: with pypkgs; [
-              typing-extensions
-              amaranth
-              packaging
-              platformdirs
-              fx2
-              libusb1
-              pyvcd
-              aiohttp
+            (python3.withPackages (
+              pypkgs: with pypkgs; [
+                typing-extensions
+                amaranth
+                packaging
+                platformdirs
+                fx2
+                libusb1
+                pyvcd
+                aiohttp
 
-              unittestCheckHook
-            ]))
+                unittestCheckHook
+              ]
+            ))
 
             yosys
             icestorm
@@ -44,9 +48,9 @@
 
           ];
 
-          YOSYS="${lib.getBin pkgs.yosys}/bin/yosys";
-          ICEPACK="${lib.getBin pkgs.icestorm}/bin/icepack";
-          NEXTPNR_ICE40="${lib.getBin pkgs.nextpnr}/bin/nextpnr-ice40";
+          YOSYS = "${lib.getBin pkgs.yosys}/bin/yosys";
+          ICEPACK = "${lib.getBin pkgs.icestorm}/bin/icepack";
+          NEXTPNR_ICE40 = "${lib.getBin pkgs.nextpnr}/bin/nextpnr-ice40";
         };
 
         formatter = pkgs.nixfmt-rfc-style;

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
       {
         packages = rec {
           glasgow = pkgs.glasgow.overrideAttrs {
-            version = "";
+            version = "0+unstable-memory-24x-emu";
             src = ./.;
           };
           default = glasgow;

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,10 @@
+(import
+  (
+    let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
+    fetchTarball {
+      url = lock.nodes.flake-compat.locked.url or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).shellNix

--- a/software/glasgow/applet/memory/_24x_emu/README.md
+++ b/software/glasgow/applet/memory/_24x_emu/README.md
@@ -1,0 +1,55 @@
+# 24-series I²C EEPROM emulation applet
+
+Emulates the read and write operations of a generic 24-series I²C EEPROM. The memory size, address width, and initial contents can be chosen at build time.
+
+Operations besides read and write operations no further operations are implemented. Reads and writes are not paged and may be performed in arbitrarily sized batches (reads only or writes only). Paging reliant behavior like writes/reads wrapping around to the start of a page when the end of a page is reached in an operation is not supported. All reads and writes will always access the current address, wrapping around only once the end of the memory is reached.
+
+<!--
+    TODO: packet diagrams are not flexible enough
+          START/STOP are not really normal bits
+          can't have a discontinuous section
+-->
+
+## Random Address Read
+During a random address read the I²C initiator sends a start strobe initiating a write and writes as many bytes as the chosen address width. This is followed by a restart strobe initiating a read. This read will return the byte from the selected address.
+
+Deviating from I²C devices, the initiator may follow up with further reads. Each read will increment the address being read from. See [Sequential Read](#sequential-read)
+
+```mermaid
+---
+title: Random Address Read
+---
+packet-beta
+    0: "STA"
+    1-7: "I²C device address"
+    8: "R/W"
+    9: "ACK"
+    10-17: "memory address (= n)"
+    18: "ACK"
+    19: "STA"
+    20-26: "I²C device address"
+    27: "R/w"
+    28: "ACK"
+    29-36: "data (n)"
+    37: "NAK"
+    38: "STO"
+```
+
+## Sequential Read
+During a sequential read, the initiator sends a start strobe initiating a read. The read will return the byte in memory stored at the current address. This may be followed by as many further reads as desired. Each read increments the current address, i.e. consecutive reads will read bytes sequentially from memory.
+
+```mermaid
+---
+title: Sequential Read
+---
+packet-beta
+    0: "STA"
+    1-7: "I²C device address"
+    8: "R/w"
+    9: "ACK"
+    10-17: "data (n)"
+    18: "ACK"
+    19-26: "data (n + 1)"
+    27: "NAK"
+    28: "STO"
+```

--- a/software/glasgow/applet/memory/_24x_emu/__init__.py
+++ b/software/glasgow/applet/memory/_24x_emu/__init__.py
@@ -1,0 +1,410 @@
+import argparse
+import logging
+import enum
+from typing import Any, Optional
+from amaranth import *
+from amaranth.lib.memory import Memory
+
+from ....access import (
+    AccessArguments,
+    AccessDemultiplexerInterface,
+    AccessMultiplexer,
+)
+from ....applet import GlasgowApplet
+from ....device.hardware import GlasgowHardwareDevice
+from ....gateware.i2c import I2CTarget
+from ....gateware.ports import PortGroup
+from ....target.hardware import GlasgowHardwareTarget
+
+
+class Event(enum.IntEnum):
+    READ = 0x10
+    "Memory read performed. Followed by the current address and the data byte returned in the read"
+    WRITE = 0x20
+    "Memory write performed. Followed by the current address and the data byte written to our memory"
+
+
+class Memory24xEmuSubtarget(Elaboratable):
+    def __init__(
+        self,
+        ports: PortGroup,
+        in_fifo,
+        i2c_address: int,
+        address_width: int,
+        initial_data: bytearray,
+    ):
+        self.ports = ports
+        self.in_fifo = in_fifo
+        self.i2c_address = i2c_address
+
+        self.address_width = address_width
+        self.initial_data = initial_data
+
+    def elaborate(self, platform):
+        m = Module()
+
+        m.submodules.memory = memory = Memory(
+            shape=unsigned(8), depth=len(self.initial_data), init=self.initial_data
+        )
+        wr_port = memory.write_port()
+        rd_port = memory.read_port(domain="comb")
+        current_address = Signal(8 * self.address_width)
+        m.d.comb += [
+            wr_port.addr.eq(current_address),
+            rd_port.addr.eq(current_address),
+        ]
+
+        m.submodules.i2c_target = i2c_target = I2CTarget(self.ports)
+        m.d.comb += [
+            i2c_target.address.eq(self.i2c_address),
+            i2c_target.data_o.eq(rd_port.data),
+        ]
+
+        # TODO: handle invalid command ordering
+        with m.FSM():
+            incoming_write_data = Signal(8)
+            incoming_address_byte_index = Signal(range(self.address_width))
+            incoming_address = Signal(8 * self.address_width)
+
+            m.d.comb += i2c_target.busy.eq(1)
+
+            with m.State("IDLE"):
+                m.d.comb += i2c_target.busy.eq(0)
+
+                with m.If(i2c_target.start):
+                    m.next = "TRANSACTION-STARTED"
+
+            with m.State("TRANSACTION-STARTED"):
+                m.d.comb += i2c_target.busy.eq(0)
+
+                with m.If(i2c_target.write):
+                    m.d.sync += [
+                        incoming_address.eq(i2c_target.data_i),
+                        incoming_address_byte_index.eq(0),
+                    ]
+                    m.d.comb += i2c_target.ack_o.eq(1)
+                    m.next = "RECEIVING-ADDRESS"
+
+                with m.Elif(i2c_target.read):
+                    m.next = "BEING-READ-SEND-EVENT"
+
+                with m.Elif(i2c_target.stop):
+                    m.next = "IDLE"
+
+            with m.State("RECEIVING-ADDRESS"):
+                m.d.comb += i2c_target.busy.eq(0)
+
+                with m.If(
+                    incoming_address_byte_index < self.address_width - 1
+                    and i2c_target.write
+                ):
+                    m.d.sync += [
+                        incoming_address.eq(incoming_address << 8 | i2c_target.data_i),
+                        incoming_address_byte_index.eq(incoming_address_byte_index + 1),
+                    ]
+                    m.d.comb += i2c_target.ack_o.eq(1)
+                    m.next = "RECEIVING-ADDRESS"
+
+                with m.Elif(i2c_target.write):
+                    m.d.sync += [
+                        incoming_write_data.eq(i2c_target.data_i),
+                        current_address.eq(incoming_address % len(self.initial_data)),
+                    ]
+                    m.d.comb += i2c_target.ack_o.eq(1)
+                    m.next = "BEING-WRITTEN-SEND-EVENT"
+
+                with m.Elif(i2c_target.read):
+                    m.d.sync += current_address.eq(
+                        incoming_address % len(self.initial_data)
+                    )
+                    m.next = "BEING-READ-SEND-EVENT"
+
+                with m.Elif(i2c_target.stop):
+                    m.next = "IDLE"
+
+            # --- Reading ---
+
+            with m.State("BEING-READ-SEND-EVENT"):
+                m.d.comb += [
+                    self.in_fifo.w_data.eq(Event.READ),
+                    self.in_fifo.w_en.eq(1),
+                ]
+                m.next = "BEING-READ-SEND-ADDRESS"
+
+            with m.State("BEING-READ-SEND-ADDRESS"):
+                m.d.comb += [
+                    self.in_fifo.w_data.eq(current_address),
+                    self.in_fifo.w_en.eq(1),
+                ]
+                m.next = "BEING-READ-SEND-DATA"
+
+            with m.State("BEING-READ-SEND-DATA"):
+                m.d.comb += [
+                    self.in_fifo.w_data.eq(rd_port.data),
+                    self.in_fifo.w_en.eq(1),
+                ]
+                m.d.sync += current_address.eq(
+                    (current_address + 1) % len(self.initial_data)
+                )
+                m.next = "BEING-READ"
+
+            with m.State("BEING-READ"):
+                m.d.comb += i2c_target.busy.eq(0)
+
+                with m.If(i2c_target.read):
+                    m.next = "BEING-READ-SEND-EVENT"
+
+                with m.If(i2c_target.stop):
+                    m.next = "IDLE"
+
+            # --- Writing ---
+
+            with m.State("BEING-WRITTEN-SEND-EVENT"):
+                m.d.comb += [
+                    self.in_fifo.w_data.eq(Event.WRITE),
+                    self.in_fifo.w_en.eq(1),
+                    wr_port.en.eq(1),
+                ]
+
+                m.d.sync += wr_port.data.eq(incoming_write_data)
+
+                m.next = "BEING-WRITTEN-SEND-ADDRESS"
+
+            with m.State("BEING-WRITTEN-SEND-ADDRESS"):
+                m.d.comb += [
+                    self.in_fifo.w_data.eq(current_address),
+                    self.in_fifo.w_en.eq(1),
+                ]
+                m.next = "BEING-WRITTEN-SEND-DATA"
+
+            with m.State("BEING-WRITTEN-SEND-DATA"):
+                m.d.comb += [
+                    self.in_fifo.w_data.eq(incoming_write_data),
+                    self.in_fifo.w_en.eq(1),
+                ]
+                m.d.sync += current_address.eq(
+                    (current_address + 1) % len(self.initial_data)
+                )
+                m.next = "BEING-WRITTEN"
+
+            with m.State("BEING-WRITTEN"):
+                m.d.comb += i2c_target.busy.eq(0)
+
+                with m.If(i2c_target.write):
+                    m.d.sync += incoming_write_data.eq(i2c_target.data_i)
+                    m.d.comb += i2c_target.ack_o.eq(1)
+                    m.next = "BEING-WRITTEN-SEND-EVENT"
+
+                with m.Elif(i2c_target.stop):
+                    m.next = "IDLE"
+
+        return m
+
+
+class Memory24xEmuInterface:
+
+    def __init__(self, interface: AccessDemultiplexerInterface, logger: logging.Logger):
+        self.lower = interface
+        self._logger = logger
+        self._level: int = (
+            logging.DEBUG if self._logger.name == __name__ else logging.TRACE
+        )
+
+    def _log(self, message: str):
+        self._logger.log(self._level, "I²C: %s", message)
+
+    async def read_event(self):
+        event: int = (await self.lower.read(1))[0]
+        if event == Event.WRITE:
+            address, data_byte = await self.lower.read(2)
+
+            self._log(
+                f"Written to at <0x{address:02x}>: 0x{data_byte:02x} ({bytes([data_byte])!r})"
+            )
+
+        elif event == Event.READ:
+            address, data_byte = await self.lower.read(2)
+
+            self._log(
+                f"Read at <0x{address:02x}>: 0x{data_byte:02x} ({bytes([data_byte])!r})"
+            )
+
+
+class Memory24xEmuApplet(GlasgowApplet):
+    logger = logging.getLogger(__name__)
+    help = "emulate a 24-series I²C EEPROM"
+    description = """
+    FIXME: description
+    """
+    required_revision = "C0"
+
+    mux_interface: AccessMultiplexer
+
+    @classmethod
+    def add_build_arguments(
+        cls, parser: argparse.ArgumentParser, access: AccessArguments
+    ):
+        super().add_build_arguments(parser, access)
+
+        access.add_pin_argument(parser, "scl", default=True)
+        access.add_pin_argument(parser, "sda", default=True)
+
+        def i2c_address(arg: str) -> int:
+            return int(arg, base=0)
+
+        def data_str(arg: str) -> bytes:
+            # `unicode_escape` decodes as latin-1, resolving python backslash-escapes
+            #
+            # The round-trip through latin-1 de-/encoding with resolution of
+            # backslash escape sequences preserves byte values of utf-8 encoded chars.
+            # The intermediary python unicode string is however not sensible,
+            # only the end result.
+            return arg.encode("utf_8").decode("unicode_escape").encode("latin_1")
+
+        def filler_byte(arg: str):
+            val = int(arg, base=0)
+            assert val >= -128 and val <= 255, "filler value must fit into a byte"
+            return val
+
+        parser.add_argument(
+            "-A",
+            "--i2c-address",
+            metavar="I2C-ADDR",
+            help="I²C address of the target",
+            type=i2c_address,
+            required=True,
+        )
+        parser.add_argument(
+            "-w",
+            "--address-width",
+            metavar="ADDR-WIDTH",
+            help="Width of the memory addresses in bytes",
+            type=int,
+            default=1,
+        )
+
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument(
+            "-d",
+            "--init-data",
+            metavar="INIT-DATA",
+            help="Data the memory is initialized with",
+            type=data_str,
+        )
+        group.add_argument(
+            "-f",
+            "--init-data-file",
+            metavar="INIT-DATA-FILE",
+            help="File to read data bytes from with which the memory is initialized",
+            type=argparse.FileType("rb"),
+        )
+
+        parser.add_argument(
+            "-s",
+            "--memory-size",
+            metavar="MEM-SIZE",
+            help="Size of the memory in bytes (len(init_data) + init_data_offset by default)",
+            type=int,
+        )
+        parser.add_argument(
+            "--init-data-offset",
+            metavar="INIT-DATA-OFFSET",
+            help="Offset the initial data within the memory by this amount of bytes",
+            type=int,
+        )
+        parser.add_argument(
+            "--filler-byte",
+            metavar="FILLER-BYTE",
+            help="Byte with which to fill the remaining memory not covered by the provided initial data",
+            type=filler_byte,
+            default=0,
+        )
+
+    def build(self, target: GlasgowHardwareTarget, args: argparse.Namespace):
+        self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
+
+        init_data_offset = (
+            args.init_data_offset if args.init_data_offset is not None else 0
+        )
+
+        init_data = bytes([])
+        init_data_not_provided = False
+        if args.init_data is not None:
+            init_data = args.init_data
+        elif args.init_data_file is not None:
+            init_data = args.init_data_file.read()
+            args.init_data_file.close()
+        else:
+            init_data_not_provided = True
+
+        if init_data_not_provided and args.init_data_offset is not None:
+            raise argparse.ArgumentError(
+                None,
+                "--init-data-offset requires one of -d/--init-data or -f/--init-data-file to be specified",
+            )
+
+        memory_size = (
+            args.memory_size
+            if args.memory_size is not None
+            else len(init_data) + init_data_offset
+        )
+
+        if args.memory_size is None and init_data_not_provided:
+            memory_size = 4000
+
+        # Pad start according to offset
+        init_data = bytes([args.filler_byte]) * init_data_offset + init_data
+        # Pad end according to size
+        init_data += bytes([args.filler_byte]) * max(0, memory_size - len(init_data))
+
+        if args.memory_size is not None and len(init_data) > args.memory_size:
+            self.logger.log(
+                "Initial data exceeds specified memory size after applying the offset. Extending size to make it fit"
+            )
+
+        iface.add_subtarget(
+            Memory24xEmuSubtarget(
+                ports=iface.get_port_group(scl=args.pin_scl, sda=args.pin_sda),
+                in_fifo=iface.get_in_fifo(),
+                i2c_address=args.i2c_address,
+                address_width=args.address_width,
+                initial_data=init_data,
+            )
+        )
+
+    @classmethod
+    def add_run_arguments(
+        cls, parser: argparse._ArgumentGroup, access: AccessArguments
+    ):
+        super().add_run_arguments(parser, access)
+
+        parser.add_argument(
+            "--pulls",
+            default=False,
+            action="store_true",
+            help="enable integrated pull-ups",
+        )
+
+    async def run(self, device: GlasgowHardwareDevice, args: argparse.Namespace):
+        pulls = set()
+        if args.pulls:
+            pulls = {args.pin_scl, args.pin_sda}
+        iface = await device.demultiplexer.claim_interface(
+            self, self.mux_interface, args, pull_high=pulls
+        )
+        return Memory24xEmuInterface(iface, self.logger)
+
+    async def interact(
+        self,
+        device: GlasgowHardwareDevice,
+        args: argparse.Namespace,
+        iface: Memory24xEmuInterface,
+    ):
+        while True:
+            await iface.read_event()
+
+    @classmethod
+    def tests(cls):
+        from . import test
+
+        return test.Memory24xEmuAppletTestCase

--- a/software/glasgow/applet/memory/_24x_emu/__init__.py
+++ b/software/glasgow/applet/memory/_24x_emu/__init__.py
@@ -95,8 +95,8 @@ class Memory24xEmuSubtarget(Elaboratable):
                 m.d.comb += i2c_target.busy.eq(0)
 
                 with m.If(
-                    incoming_address_byte_index < self.address_width - 1
-                    and i2c_target.write
+                    (incoming_address_byte_index < self.address_width - 1)
+                    & i2c_target.write
                 ):
                     m.d.sync += [
                         incoming_address.eq(incoming_address << 8 | i2c_target.data_i),

--- a/software/glasgow/applet/memory/_24x_emu/test.py
+++ b/software/glasgow/applet/memory/_24x_emu/test.py
@@ -1,0 +1,8 @@
+from ... import *
+from . import Memory24xEmuApplet
+
+
+class Memory24xEmuAppletTestCase(GlasgowAppletTestCase, applet=Memory24xEmuApplet):
+    @synthesis_test
+    def test_build(self):
+        self.assertBuilds(args=["-A", "0b1010000"])

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -95,6 +95,7 @@ sbw-probe = "glasgow.applet.interface.sbw_probe:SpyBiWireProbeApplet"
 swd-openocd = "glasgow.applet.interface.swd_openocd:SWDOpenOCDApplet"
 
 memory-24x = "glasgow.applet.memory._24x:Memory24xApplet"
+memory-24x-emu = "glasgow.applet.memory._24x_emu:Memory24xEmuApplet"
 memory-25x = "glasgow.applet.memory._25x:Memory25xApplet"
 memory-onfi = "glasgow.applet.memory.onfi:MemoryONFIApplet"
 memory-prom = "glasgow.applet.memory.prom:MemoryPROMApplet"


### PR DESCRIPTION
I've started writing a 24-series I2C EEPROM emulator applet for the glasgow. Currently this still has some issues with addressing and the way addresses for reads/writes are sent to the host is not yet ready for multi-byte addresses and the most significant bits of the address contained in the least significant I2C address bits.

Since I've asked around on the IRC in relation to this applet a bunch of times now I thought it was time to at least open a draft PR.
This is not yet ready for review and I will be working on improving it some more (perhaps figuring out how to test it against the 24x applet too).

This also adds GlasgowAnaylzer / --trace events for I2CBus, I2CTarget, and I2CInitiator. I'll probably extract this into another branch and PR once I'm done with this emulator.