### PR TITLE
support.arepl,cli: intercept `SystemExit`.

### DIFF
--- a/docs/manual/src/conf.py
+++ b/docs/manual/src/conf.py
@@ -84,6 +84,8 @@ linkcheck_ignore = [
     r"^https://chaos\.social/",
     # As above.
     r"^https://en\.uesp\.net/",
+    # As above.
+    r"^https://www\.gnu\.org/",
 ]
 
 linkcheck_anchors_ignore_for_url = [

--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -670,6 +670,8 @@ async def main():
                         if future is not None:
                             await future
 
+                except SystemExit as e:
+                    return e.code
                 except GlasgowAppletError as e:
                     applet.logger.error(str(e))
                     return 1


### PR DESCRIPTION
Asyncio returns from the event loop if a future raises `SystemExit`, and the async console wraps the code it runs in a future.

Also, it looks like Python 3.13 [broke](https://github.com/python/cpython/issues/129900) `exit()` in an interactive console:

![image](https://github.com/user-attachments/assets/1fdf9e47-0cd8-498b-9a7c-6f5be2e53d2d)

We handle that case properly.