### PR TITLE
target.hardware: bugfix, pull up/down where not set for Port B when Port A and B was set

### DIFF
--- a/software/glasgow/applet/interface/analyzer/__init__.py
+++ b/software/glasgow/applet/interface/analyzer/__init__.py
@@ -76,10 +76,10 @@ class AnalyzerApplet(GlasgowApplet):
         g_pulls = parser.add_mutually_exclusive_group()
         g_pulls.add_argument(
             "--pull-ups", default=False, action="store_true",
-            help="enable pull-ups on all pins")
+            help="enable pull-ups on all pins which are set")
         g_pulls.add_argument(
             "--pull-downs", default=False, action="store_true",
-            help="enable pull-downs on all pins")
+            help="enable pull-downs on all pins which are set")
 
     async def run(self, device, args):
         pull_low  = set()

--- a/software/glasgow/applet/interface/analyzer/__init__.py
+++ b/software/glasgow/applet/interface/analyzer/__init__.py
@@ -76,10 +76,10 @@ class AnalyzerApplet(GlasgowApplet):
         g_pulls = parser.add_mutually_exclusive_group()
         g_pulls.add_argument(
             "--pull-ups", default=False, action="store_true",
-            help="enable pull-ups on all pins which are set")
+            help="enable pull-ups on all pins")
         g_pulls.add_argument(
             "--pull-downs", default=False, action="store_true",
-            help="enable pull-downs on all pins which are set")
+            help="enable pull-downs on all pins")
 
     async def run(self, device, args):
         pull_low  = set()

--- a/software/glasgow/device/hardware.py
+++ b/software/glasgow/device/hardware.py
@@ -648,9 +648,9 @@ class GlasgowHardwareDevice:
             port_enable = 0
             port_value  = 0
             for port_bit in range(0, 8):
-                if index * 8 + port_bit in low | high:
+                if port_bit in low | high:
                     port_enable |= 1 << port_bit
-                if index * 8 + port_bit in high:
+                if port_bit in high:
                     port_value  |= 1 << port_bit
             await self.control_write(usb1.REQUEST_TYPE_VENDOR, REQ_PULL,
                 0, self._iobuf_spec_to_mask(port, one=True),


### PR DESCRIPTION
when running for example:
glasgow -vvvv run analyzer --port AB --pull-ups -V 5 --pins-i 0,1,2,3,4,5,6,7 test.vcd
pull ups for Port B where not set cause of increasing value via index