### PR TITLE
cli: invert voltage alert handling

### DIFF
--- a/software/glasgow/applet/sensor/scd30/__init__.py
+++ b/software/glasgow/applet/sensor/scd30/__init__.py
@@ -172,7 +172,7 @@ class SensorSCD30Applet(I2CInitiatorApplet):
     Measure CO₂ concentration, humidity, and temperature using Sensirion SCD30 sensors
     connected over the I²C interface.
 
-    NOTE: The SCD30 takes some time to start up. Run `glasgow voltage AB 3.3 --no-alert`
+    NOTE: The SCD30 takes some time to start up. Run `glasgow voltage AB 3.3`
     or similar before attempting to interact with it.
     """
 

--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -254,8 +254,8 @@ def get_argparser():
         "--tolerance", metavar="PCT", type=float, default=10.0,
         help="raise alert if measured voltage deviates by more than ±PCT%% (default: %(default)s)")
     p_voltage.add_argument(
-        "--no-alert", dest="set_alert", default=True, action="store_false",
-        help="do not raise an alert if Vsense is out of range of Vio")
+        "--alert", dest="set_alert", default=False, action="store_true",
+        help="raise an alert if Vsense is out of range of Vio")
 
     p_safe = subparsers.add_parser(
         "safe", formatter_class=TextHelpFormatter,


### PR DESCRIPTION
Alert handling was default enabled which led to unintuitiv usage of the
voltage cli interface, since --no-alert needs to be set if Vio should
just be enabled.

Invert the handling, alerting is now default disabled and --alert can be
used to turn it on.

Fixes https://github.com/GlasgowEmbedded/glasgow/issues/718

Possible improvement would be to issue a warning for the no longer
supported `--no-alert` option instead of the program exiting with
an error about the changed CLI option. Let me know if this is wanted.