### PR TITLE
applet.program.ice40_flash: read done reg if it exists (not if reset exists)

### DIFF
--- a/software/glasgow/applet/program/ice40_flash/__init__.py
+++ b/software/glasgow/applet/program/ice40_flash/__init__.py
@@ -45,7 +45,7 @@ class ProgramICE40FlashInterface:
             await self._device.write_register(self._addr_dut_reset, int(reset))
 
     async def get_done(self):
-        if self._addr_dut_reset is not None:
+        if self._addr_dut_done is not None:
             return await self._device.read_register(self._addr_dut_done)
 
 


### PR DESCRIPTION
This is an apparent copy-paste error; it checked for the address for the reset pin control register (same as previous fn), then read the done pin reg.

I'm sorry but I don't have the resources (physical hardware nor mental effort) to do actual testing to this, but I couldn't leave it either, so this is almost as-is (i did test that glasgow runs and i can build the applet..).