### PR TITLE
Ensure a chip is selected when transferring bytes via SPI/QSPI interface

### DIFF
--- a/software/glasgow/applet/interface/spi_controller/test.py
+++ b/software/glasgow/applet/interface/spi_controller/test.py
@@ -31,6 +31,12 @@ class SPIControllerAppletTestCase(GlasgowAppletTestCase, applet=SPIControllerApp
 
         ports = mux_iface._subtargets[0].ports
         self.assertEqual((yield ports.cs.o), 1)
+        select_cm = spi_iface.select()
+        yield from select_cm.__aenter__() # no `async with` in applet simulation tests :(
+        yield; yield;
+        self.assertEqual((yield ports.cs.o), 0)
         result = yield from spi_iface.exchange([0xAA, 0x55, 0x12, 0x34])
         self.assertEqual(result, bytearray([0xAA, 0x55, 0x12, 0x34]))
+        yield from select_cm.__aexit__(None, None, None)
+        yield; yield;
         self.assertEqual((yield ports.cs.o), 1)


### PR DESCRIPTION
Forgetting to `async with iface.select():` is a common novice usage error that is frustrating to debug.