### PR TITLE
applet.interface.spi_flashrom: modify to use port groups

### DIFF
--- a/software/glasgow/applet/interface/spi_flashrom/__init__.py
+++ b/software/glasgow/applet/interface/spi_flashrom/__init__.py
@@ -2,6 +2,7 @@ import logging
 import asyncio
 import enum
 from amaranth import *
+from amaranth.lib import io
 
 from ... import *
 from ....support.endpoint import *
@@ -181,10 +182,10 @@ class SPIFlashromApplet(SPIControllerApplet):
     def build_subtarget(self, target, args):
         subtarget = super().build_subtarget(target, args)
         if args.pin_hold is not None:
-            hold_t = self.mux_interface.get_deprecated_pad(args.pin_hold)
+            hold = self.mux_interface.get_port(args.pin_hold, name="hold")
         else:
-            hold_t = None
-        return Memory25xSubtarget(subtarget, hold_t)
+            hold = None
+        return Memory25xSubtarget(subtarget, hold)
 
     async def run(self, device, args):
         spi_iface = await self.run_lower(SPIFlashromApplet, device, args)

--- a/software/glasgow/applet/interface/spi_flashrom/test.py
+++ b/software/glasgow/applet/interface/spi_flashrom/test.py
@@ -1,0 +1,10 @@
+from amaranth import *
+
+from ... import *
+from . import SPIFlashromApplet
+
+
+class SPIFlashromAppletTestCase(GlasgowAppletTestCase, applet=SPIFlashromApplet):
+    @synthesis_test
+    def test_build(self):
+        self.assertBuilds()

--- a/software/glasgow/applet/memory/_25x/__init__.py
+++ b/software/glasgow/applet/memory/_25x/__init__.py
@@ -7,6 +7,7 @@ import struct
 import logging
 import argparse
 from amaranth import *
+from amaranth.lib import io
 
 from ....support.logging import dump_hex
 from ....database.jedec import *
@@ -28,21 +29,22 @@ BIT_ERR  = 0b10000000
 
 # This is also used in SPIFlashromApplet.
 class Memory25xSubtarget(Elaboratable):
-    def __init__(self, controller, hold_t):
+    def __init__(self, controller, hold):
         self.controller = controller
-        self.hold_t = hold_t
+        self.hold = hold
 
     def elaborate(self, platform):
         m = Module()
 
         m.submodules.controller = self.controller
+        m.submodules.hold_buffer = hold = io.Buffer("o", self.hold)
 
         m.d.comb += self.controller.bus.oe.eq(self.controller.bus.cs == 1)
 
-        if self.hold_t is not None:
+        if self.hold is not None:
             m.d.comb += [
-                self.hold_t.oe.eq(1),
-                self.hold_t.o.eq(1),
+                hold.oe.eq(1),
+                hold.o.eq(1),
             ]
 
         return m


### PR DESCRIPTION
Part of #599. `applet.memory._25x` also had to be refactored to use a buffer. 