### PR TITLE
Remove "analyzer throttle"

### DIFF
--- a/software/glasgow/applet/internal/benchmark/__init__.py
+++ b/software/glasgow/applet/internal/benchmark/__init__.py
@@ -106,7 +106,7 @@ class BenchmarkApplet(GlasgowApplet):
 
     def build(self, target, args):
         self.mux_interface = iface = \
-            target.multiplexer.claim_interface(self, args=None, throttle="none")
+            target.multiplexer.claim_interface(self, args=None)
         mode,  self.__addr_mode  = target.registers.add_rw(2)
         error, self.__addr_error = target.registers.add_ro(1)
         count, self.__addr_count = target.registers.add_ro(32)


### PR DESCRIPTION
This functionality has never worked correctly and is conceptually unsound and impossible to implement in a generic way.

In exchange the internals get simpler.