### PR TITLE
Modernize the UART applet

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,6 @@ jobs:
         - '3.10.x'
         - '3.11.x'
         - '3.12.x'
-        - 'pypy-3.9'
         - 'pypy-3.10'
         dep-versions:
         - minimal


### PR DESCRIPTION
This applet is often used as an example and until now would return the DemultiplexerInterface object which isn't intended for direct applet end user manipulation, only for applet developers. Instead, it should be wrapped by an applet-specific *Interface object.

Also, the contract for `read()` (with `length = None`) was confusing.