### PR TITLE
FIFO ports should not be elaboratable

### DIFF
--- a/software/glasgow/access/direct/multiplexer.py
+++ b/software/glasgow/access/direct/multiplexer.py
@@ -6,7 +6,7 @@ from ...platform.generic import GlasgowPlatformPort
 from .. import AccessMultiplexer, AccessMultiplexerInterface
 
 
-class _FIFOReadPort(Elaboratable):
+class _FIFOReadPort:
     """
     FIFO read port wrapper that exists for historical reasons.
     """
@@ -25,7 +25,7 @@ class _FIFOReadPort(Elaboratable):
         self.stream.ready = self.r_en
 
 
-class _FIFOWritePort(Elaboratable):
+class _FIFOWritePort:
     """
     FIFO write port wrapper that exists for historical reasons.
     """


### PR DESCRIPTION
This was missed in commit 8dc3d8ff2 and caused UnusedElaboratable warnings for every created FIFO.