### PR TITLE
Fix `ServerEndpoint` to not use asyncio cancellation in an unsound way

### DIFF
--- a/software/glasgow/applet/debug/mips/__init__.py
+++ b/software/glasgow/applet/debug/mips/__init__.py
@@ -868,7 +868,8 @@ class DebugMIPSApplet(JTAGProbeApplet):
                 print(f"{name:<3} = {value:08x}")
 
         if args.operation == "gdb":
-            endpoint = await ServerEndpoint("GDB socket", self.logger, args.gdb_endpoint)
+            endpoint = await ServerEndpoint("GDB socket", self.logger, args.gdb_endpoint,
+                deprecated_cancel_on_eof=True)
             while not args.once:
                 await ejtag_iface.gdb_run(endpoint)
 

--- a/software/glasgow/applet/interface/jtag_openocd/__init__.py
+++ b/software/glasgow/applet/interface/jtag_openocd/__init__.py
@@ -151,7 +151,8 @@ class JTAGOpenOCDApplet(GlasgowApplet):
         ServerEndpoint.add_argument(parser, "endpoint")
 
     async def interact(self, device, args, iface):
-        endpoint = await ServerEndpoint("socket", self.logger, args.endpoint)
+        endpoint = await ServerEndpoint("socket", self.logger, args.endpoint,
+            deprecated_cancel_on_eof=True)
         async def forward_out():
             while True:
                 try:

--- a/software/glasgow/applet/interface/jtag_openocd/__init__.py
+++ b/software/glasgow/applet/interface/jtag_openocd/__init__.py
@@ -151,27 +151,22 @@ class JTAGOpenOCDApplet(GlasgowApplet):
         ServerEndpoint.add_argument(parser, "endpoint")
 
     async def interact(self, device, args, iface):
-        endpoint = await ServerEndpoint("socket", self.logger, args.endpoint,
-            deprecated_cancel_on_eof=True)
+        endpoint = await ServerEndpoint("socket", self.logger, args.endpoint)
         async def forward_out():
             while True:
                 try:
                     data = await endpoint.recv()
-                    await iface.write(data)
-                    await iface.flush()
-                except asyncio.CancelledError:
-                    pass
+                except EOFError:
+                    continue
+                await iface.write(data)
+                await iface.flush()
         async def forward_in():
             while True:
-                try:
-                    data = await iface.read()
-                    await endpoint.send(data)
-                except asyncio.CancelledError:
-                    pass
-        forward_out_fut = asyncio.ensure_future(forward_out())
-        forward_in_fut  = asyncio.ensure_future(forward_in())
-        await asyncio.wait([forward_out_fut, forward_in_fut],
-                           return_when=asyncio.FIRST_EXCEPTION)
+                data = await iface.read()
+                await endpoint.send(data)
+        async with asyncio.TaskGroup() as group:
+            group.create_task(forward_out())
+            group.create_task(forward_in())
 
     @classmethod
     def tests(cls):

--- a/software/glasgow/applet/interface/spi_flashrom/__init__.py
+++ b/software/glasgow/applet/interface/spi_flashrom/__init__.py
@@ -196,7 +196,8 @@ class SPIFlashromApplet(SPIControllerApplet):
         ServerEndpoint.add_argument(parser, "endpoint")
 
     async def interact(self, device, args, iface):
-        endpoint = await ServerEndpoint("socket", self.logger, args.endpoint)
+        endpoint = await ServerEndpoint("socket", self.logger, args.endpoint,
+            deprecated_cancel_on_eof=True)
         async def handle():
             while True:
                 try:

--- a/software/glasgow/applet/interface/swd_openocd/__init__.py
+++ b/software/glasgow/applet/interface/swd_openocd/__init__.py
@@ -168,7 +168,8 @@ class SWDOpenOCDApplet(GlasgowApplet):
         ServerEndpoint.add_argument(parser, "endpoint")
 
     async def interact(self, device, args, iface):
-        endpoint = await ServerEndpoint("socket", self.logger, args.endpoint)
+        endpoint = await ServerEndpoint("socket", self.logger, args.endpoint,
+            deprecated_cancel_on_eof=True)
         async def forward_out():
             while True:
                 try:

--- a/software/glasgow/applet/interface/uart/__init__.py
+++ b/software/glasgow/applet/interface/uart/__init__.py
@@ -404,16 +404,18 @@ class UARTApplet(GlasgowApplet):
             group.create_task(forward_in())
 
     async def interact(self, device, args, uart):
-        asyncio.create_task(self._monitor_errors(device))
-
-        if args.operation is None:
-            await self._interact_tty(uart, stream=False)
-        if args.operation == "tty":
-            await self._interact_tty(uart, args.stream)
-        if args.operation == "pty":
-            await self._interact_pty(uart)
-        if args.operation == "socket":
-            await self._interact_socket(uart, args.endpoint)
+        monitor_task = asyncio.create_task(self._monitor_errors(device))
+        try:
+            if args.operation is None:
+                await self._interact_tty(uart, stream=False)
+            if args.operation == "tty":
+                await self._interact_tty(uart, args.stream)
+            if args.operation == "pty":
+                await self._interact_pty(uart)
+            if args.operation == "socket":
+                await self._interact_socket(uart, args.endpoint)
+        finally:
+            monitor_task.cancel()
 
     @classmethod
     def tests(cls):

--- a/software/glasgow/applet/interface/uart/__init__.py
+++ b/software/glasgow/applet/interface/uart/__init__.py
@@ -386,7 +386,8 @@ class UARTApplet(GlasgowApplet):
         await self._forward(master, master, uart)
 
     async def _interact_socket(self, uart, endpoint):
-        endpoint = await ServerEndpoint("socket", self.logger, endpoint)
+        endpoint = await ServerEndpoint("socket", self.logger, endpoint,
+            deprecated_cancel_on_eof=True)
         async def forward_out():
             while True:
                 try:

--- a/software/glasgow/applet/video/ws2812_output/__init__.py
+++ b/software/glasgow/applet/video/ws2812_output/__init__.py
@@ -194,7 +194,8 @@ class VideoWS2812OutputApplet(GlasgowApplet):
     async def interact(self, device, args, leds):
         frame_size = len(args.pin_set_out) * args.count * self.pix_in_size
         buffer_size = frame_size * args.buffer
-        endpoint = await ServerEndpoint("socket", self.logger, args.endpoint, queue_size=buffer_size)
+        endpoint = await ServerEndpoint("socket", self.logger, args.endpoint, queue_size=buffer_size,
+            deprecated_cancel_on_eof=True)
         while True:
             try:
                 data = await asyncio.shield(endpoint.recv(buffer_size))

--- a/software/glasgow/protocol/nbd.py
+++ b/software/glasgow/protocol/nbd.py
@@ -255,7 +255,8 @@ async def main():
         async def device_write(self, offset, data):
             disk[offset:offset+len(data)] = data
 
-    endpoint = await ServerEndpoint("socket", logger, args.endpoint)
+    endpoint = await ServerEndpoint("socket", logger, args.endpoint,
+        deprecated_cancel_on_eof=True)
     conn = Ramdisk(endpoint, logger, writable=True)
     await conn.handle()
 


### PR DESCRIPTION
This would previously cause many applets to not be properly responsive to ^C.