### PR TITLE
Resolve warnings of Logger library

### DIFF
--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -788,7 +788,7 @@ async def main():
                     logger.critical("configuration/firmware programming failed")
                     return 1
 
-                logger.warn("power cycle the device to apply changes")
+                logger.warning("power cycle the device to apply changes")
             else:
                 logger.info("configuration and firmware identical")
 

--- a/software/glasgow/protocol/nbd.py
+++ b/software/glasgow/protocol/nbd.py
@@ -160,7 +160,7 @@ class NBDServer:
                 await self._send_info(option)
                 await self._send_option(option, NBD_REP_ACK, struct.pack('>I', option))
             else:
-                self._logger.warn(f"client requested unknown option {option}")
+                self._logger.warning(f"client requested unknown option {option}")
                 await self._send_option(option, NBD_REP_ERR_UNSUP)
 
     async def _send_info(self, option):


### PR DESCRIPTION
# PR Summary
This PR resolves the deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```