### PR TITLE
Drop `pin{s,}-` prefix from pin arguments

### DIFF
--- a/docs/manual/src/use/basic.rst
+++ b/docs/manual/src/use/basic.rst
@@ -92,7 +92,7 @@ Applets that have ``run`` nable programs often have `subcommands` to specify wha
     [...]
     $ glasgow run socket --help
     usage: glasgow run uart socket [-h] ENDPOINT
-    
+
     positional arguments:
       ENDPOINT    listen at ENDPOINT, either unix:PATH or tcp:HOST:PORT
     [...]
@@ -103,7 +103,7 @@ Putting it together, the following command will run the ``uart`` applet, with an
 
 .. code:: console
 
-    $ glasgow run uart -V 3.3 --pin-tx 0 --pin-rx 1 socket tcp:127.0.0.1:4321
+    $ glasgow run uart -V 3.3 --tx 0 --rx 1 socket tcp:127.0.0.1:4321
     I: g.device.hardware: generating bitstream ID [...]
     I: g.cli: running handler for applet 'uart'
     I: g.applet.interface.uart: port(s) A, B voltage set to 3.3 V
@@ -116,15 +116,15 @@ As the applet's output suggests, you can connect to TCP port 4321 using a tool o
 Specifying port numbers
 #######################
 
-The ``revC`` hardware has two ports (A and B), each of which have 8× I/O pins. When running the ``glasgow`` utility, you will see reference to a ``--port`` argument, along with ``--pin-*``, as defined by each applet (e.g: ``--pin-tx`` for UART).
+The ``revC`` hardware has two ports (A and B), each of which have 8× I/O pins. When running the ``glasgow`` utility, you will see A reference to a ``--port`` argument, along with pin arguments as defined by each applet (e.g.: ``--tx`` for UART).
 
-By default, the `port` will typically be set to ``AB``, which results in all 16× I/O pins being available for use, numbered 0 to 15... e.g: "`pin 0`" is ``A0``, "`pin 7`" is ``A7``, "`pin 8`" is ``B0``, and so on.
+By default, the `port` will be set to ``AB``, which results in all 16× I/O pins being available for use, numbered 0 to 15... e.g: "`pin 0`" is ``A0``, "`pin 7`" is ``A7``, "`pin 8`" is ``B0``, and so on.
 
 In some cases, you may want to use ``B3`` without using port A, which can be achieved using the following:
 
 .. code:: console
 
-    $ glasgow run uart -V 3.3 --port B --pin-tx 3 socket tcp:127.0.0.1:4321
+    $ glasgow run uart -V 3.3 --port B --tx 3 socket tcp:127.0.0.1:4321
 
 
 Inverting pins
@@ -132,9 +132,9 @@ Inverting pins
 
 Any pin can be inverted via the command-line interface using one of the following syntaxes:
 
-* single pin: ``--pin-x 0#``
-* pin range:  ``--pins-x 0:8#``      (inverts all of them)
-* pin list:   ``--pins-x 0,1#,2#,3`` (inverts only specified pins)
+* single pin: ``--x 0#``
+* pin range:  ``--x 0:8#``      (inverts all of them)
+* pin list:   ``--x 0,1#,2#,3`` (inverts only specified pins)
 
 Pull-ups configured for a pin with inversion get converted to pull-downs and vice versa.
 
@@ -156,7 +156,7 @@ Aside from the ``tty`` mode, others are available (``pty``, ``socket``), which a
 
 .. code:: console
 
-    $ glasgow run uart -V 3.3 --pin-tx 0 --pin-rx 1 -b 57600 tty
+    $ glasgow run uart -V 3.3 --tx 0 --rx 1 -b 57600 tty
 
 
 SPI controller
@@ -166,7 +166,7 @@ The ``spi-controller`` applet implements an SPI controller, allowing full-duplex
 
 .. code:: console
 
-    $ glasgow run spi-controller -V 3.3 --pin-sck 0 --pin-cs 1 --pin-copi 2 --pin-cipo 3 \
+    $ glasgow run spi-controller -V 3.3 --sck 0 --cs 1 --copi 2 --cipo 3 \
         '0301235ff5'
 
 

--- a/docs/manual/src/use/repl-script.rst
+++ b/docs/manual/src/use/repl-script.rst
@@ -137,7 +137,7 @@ I've got a `quarter of an Adafruit 60 LED ring <https://www.adafruit.com/product
 
 .. code:: console
 
-    $ glasgow repl video-ws2812-output -V 5 -c 15 -b 1 -f RGB-xBRG --pins-out 0
+    $ glasgow repl video-ws2812-output -V 5 -c 15 -b 1 -f RGB-xBRG --out 0
     I: g.device.hardware: device already has bitstream ID d8987a037e451abe4ffa1b6f76fd1116
     I: g.cli: running handler for applet 'video-ws2812-output'
     I: g.applet.video.ws2812_output: port(s) A, B voltage set to 5.0 V

--- a/software/glasgow/applet/audio/dac/__init__.py
+++ b/software/glasgow/applet/audio/dac/__init__.py
@@ -137,7 +137,7 @@ class AudioDACApplet(GlasgowApplet):
     For example, to play an ogg file:
 
         $ sox samples.ogg -c 2 -r 48000 samples.u16
-        $ glasgow run audio-dac --pins-o 0,1 -r 48000 -w 2 -u play samples.u16
+        $ glasgow run audio-dac --o 0,1 -r 48000 -w 2 -u play samples.u16
 
     To use the DAC as a PulseAudio sink, add the following line to default.pa:
 
@@ -146,7 +146,7 @@ class AudioDACApplet(GlasgowApplet):
 
     Then run:
 
-        $ glasgow run audio-dac --pins-o 0,1 -r 48000 -w 2 -s connect tcp::12345
+        $ glasgow run audio-dac --o 0,1 -r 48000 -w 2 -s connect tcp::12345
     """
 
     @classmethod

--- a/software/glasgow/applet/debug/arm/arm7/test.py
+++ b/software/glasgow/applet/debug/arm/arm7/test.py
@@ -16,7 +16,7 @@ from . import DebugARM7Applet, DebugARM7Sequencer
 
 class DebugARM7AppletTestCase(GlasgowAppletTestCase, applet=DebugARM7Applet):
     # DUT used for testing: Yamaha SWLL (from PSS-A50 keyboard)
-    hardware_args = "-e big -V 3.3 --pin-tck 8 --pin-tms 1 --pin-tdi 0 --pin-tdo 4 --pin-trst 15".split()
+    hardware_args = "-e big -V 3.3 --tck 8 --tms 1 --tdi 0 --tdo 4 --trst 15".split()
     ram_addr = 0x2ff00
 
     def test_sequencer(self):

--- a/software/glasgow/applet/interface/jtag_pinout/test.py
+++ b/software/glasgow/applet/interface/jtag_pinout/test.py
@@ -5,4 +5,4 @@ from . import JTAGPinoutApplet
 class JTAGPinoutAppletTestCase(GlasgowAppletTestCase, applet=JTAGPinoutApplet):
     @synthesis_test
     def test_build(self):
-        self.assertBuilds(args=["--pins-jtag", "0:3"])
+        self.assertBuilds(args=["--pins", "0:3"])

--- a/software/glasgow/applet/interface/spi_controller/test.py
+++ b/software/glasgow/applet/interface/spi_controller/test.py
@@ -9,8 +9,8 @@ from . import SPIControllerApplet
 class SPIControllerAppletTestCase(GlasgowAppletTestCase, applet=SPIControllerApplet):
     @synthesis_test
     def test_build(self):
-        self.assertBuilds(args=["--pin-sck",  "0", "--pin-cs",   "1",
-                                "--pin-copi", "2", "--pin-cipo", "3"])
+        self.assertBuilds(args=["--sck",  "0", "--cs",   "1",
+                                "--copi", "2", "--cipo", "3"])
 
     def setup_loopback(self, target, parsed_args):
         self.applet.build(target, parsed_args)
@@ -18,8 +18,8 @@ class SPIControllerAppletTestCase(GlasgowAppletTestCase, applet=SPIControllerApp
 
     @applet_simulation_test("setup_loopback",
                             ["--keep-voltage",
-                             "--pin-sck",  "0", "--pin-cs", "1",
-                             "--pin-copi", "2", "--pin-cipo",   "3",
+                             "--sck",  "0", "--cs", "1",
+                             "--copi", "2", "--cipo",   "3",
                              "--frequency", "10"])
     async def test_loopback(self, device, parsed_args, ctx):
         spi_iface = await self.applet.run(device, parsed_args)

--- a/software/glasgow/applet/memory/_25x/test.py
+++ b/software/glasgow/applet/memory/_25x/test.py
@@ -12,9 +12,9 @@ class Memory25xAppletTestCase(GlasgowAppletTestCase, applet=Memory25xApplet):
     # Flash used for testing: Winbond 25Q32FV
     hardware_args = [
         "--voltage", "3.3",
-        "--pin-sck", "0",
-        "--pins-io", "1:4",
-        "--pins-cs", "5",
+        "--sck", "0",
+        "--io", "1:4",
+        "--cs", "5",
     ]
     dut_ids = (0xef, 0x15, 0x4016)
     dut_page_size   = 0x100

--- a/software/glasgow/applet/memory/prom/__init__.py
+++ b/software/glasgow/applet/memory/prom/__init__.py
@@ -476,10 +476,10 @@ class MemoryPROMApplet(GlasgowApplet):
     To handle the large amount of address lines used by parallel memories, this applet supports
     two kinds of addressing: direct and indirect. The full address word (specified with
     the --a-bits option) is split into low and high parts. The low part is presented directly on
-    the IO pins (specified with the --pins-a option). The high part is presented through
-    a SIPO shift register (clock and data input specified with the --pin-a-clk and --pin-a-si
-    options respectively), such as a chain of 74HC164 ICs of the appropriate length.
-    Additionally, for shift registers with latches, specify --pin-a-lat to drive the latch pins.
+    the IO pins (specified with the --a option). The high part is presented through a SIPO shift
+    register (clock and data input specified with the --a-clk and --a-si options respectively),
+    such as a chain of 74HC164 ICs of the appropriate length. Additionally, for shift registers
+    with latches, specify --a-lat to drive the latch pins.
     """
 
     @classmethod
@@ -488,9 +488,9 @@ class MemoryPROMApplet(GlasgowApplet):
 
         access.add_pin_set_argument(parser, "dq", width=range(1, 16), default=8)
         access.add_pin_set_argument(parser, "a",  width=range(0, 24), default=0)
-        access.add_pin_argument(parser, "a-clk")
-        access.add_pin_argument(parser, "a-si")
-        access.add_pin_argument(parser, "a-lat")
+        access.add_pin_argument(parser, "a_clk")
+        access.add_pin_argument(parser, "a_si")
+        access.add_pin_argument(parser, "a_lat")
         access.add_pin_argument(parser, "oe")
         access.add_pin_argument(parser, "we")
         access.add_pin_argument(parser, "ce")

--- a/software/glasgow/applet/program/ice40_sram/test.py
+++ b/software/glasgow/applet/program/ice40_sram/test.py
@@ -5,6 +5,6 @@ from . import ProgramICE40SRAMApplet
 class ProgramICE40SRAMAppletTestCase(GlasgowAppletTestCase, applet=ProgramICE40SRAMApplet):
     @synthesis_test
     def test_build(self):
-        self.assertBuilds(args=["--pin-reset", "0", "--pin-done", "1",
-                                "--pin-sck",   "2", "--pin-cs",   "3",
-                                "--pin-copi",  "4"])
+        self.assertBuilds(args=["--reset", "0", "--done", "1",
+                                "--sck",   "2", "--cs",   "3",
+                                "--copi",  "4"])

--- a/software/glasgow/applet/video/rgb_input/test.py
+++ b/software/glasgow/applet/video/rgb_input/test.py
@@ -5,6 +5,6 @@ from . import VideoRGBInputApplet
 class VideoRGBInputAppletTestCase(GlasgowAppletTestCase, applet=VideoRGBInputApplet):
     @synthesis_test
     def test_build(self):
-        self.assertBuilds(args=["--pins-r", "0:4", "--pins-g", "5:9", "--pins-b", "10:14",
-                                "--pin-dck", "15", "--columns", "160", "--rows", "144",
+        self.assertBuilds(args=["--r", "0:4", "--g", "5:9", "--b", "10:14",
+                                "--dck", "15", "--columns", "160", "--rows", "144",
                                 "--vblank", "960e-6"])

--- a/software/glasgow/applet/video/ws2812_output/test.py
+++ b/software/glasgow/applet/video/ws2812_output/test.py
@@ -5,4 +5,4 @@ from . import VideoWS2812OutputApplet
 class VideoWS2812OutputAppletTestCase(GlasgowAppletTestCase, applet=VideoWS2812OutputApplet):
     @synthesis_test
     def test_build(self):
-        self.assertBuilds(args=["--pins-out", "0:3", "-c", "1024"])
+        self.assertBuilds(args=["--out", "0:3", "-c", "1024"])


### PR DESCRIPTION
I.e. instead of `glasgow run uart -V 3.3 --pin-rx 0 --pin-tx 1`, you would use `glasgow run uart -V 3.3 --rx 0 --tx 1`.

This is done because the prefix isn't really useful, because it is nice to group related arguments together, like `--sck 3 --sck-freq 1000`, and because it gets ugly when either one or multiple pins are accepted, like `--cs 0` vs `--cs 0,1`. The latter caused a breaking change reecntly when the QSPI controller applet added support for multiple CS pins; we should not allow that to happen again.