### PR TITLE
Reset FPGA side FIFOs automatically

### DIFF
--- a/firmware/fifo.c
+++ b/firmware/fifo.c
@@ -69,18 +69,18 @@ void fifo_configure(bool two_ep) {
   EP8CFG = ep48valid|_DIR|_TYPE1; // IN BULK 512B
 
   // Reset and configure endpoints.
-  fifo_reset(two_ep, two_ep ? 0x1 : 0x3);
+  fifo_reset(two_ep, two_ep ? 0b0101 : 0b1111);
 
   // Enable FIFOs.
   SYNCDELAY;
   FIFORESET = 0;
 }
 
-void fifo_reset(bool two_ep, uint8_t interfaces) {
+void fifo_reset(bool two_ep, uint8_t ep_mask) {
   // For the following code, note that for FIFORESET and OUTPKTEND to do anything,
   // the endpoints *must* be in manual mode (_AUTOIN/_AUTOOUT bits cleared).
 
-  if(interfaces & (1 << 0)) {
+  if(ep_mask & 0b0001) {
     // Reset EP2OUT.
     SYNCDELAY;
     EP2FIFOCFG = 0;
@@ -98,17 +98,9 @@ void fifo_reset(bool two_ep, uint8_t interfaces) {
     }
     SYNCDELAY;
     EP2FIFOCFG = _AUTOOUT;
-
-    // Reset EP6IN.
-    SYNCDELAY;
-    EP6FIFOCFG = 0;
-    SYNCDELAY;
-    FIFORESET |= 6;
-    SYNCDELAY;
-    EP6FIFOCFG = _ZEROLENIN;
   }
 
-  if(interfaces & (1 << 1)) {
+  if(ep_mask & 0b0010) {
     // Reset EP4OUT.
     SYNCDELAY;
     EP4FIFOCFG = 0;
@@ -120,7 +112,19 @@ void fifo_reset(bool two_ep, uint8_t interfaces) {
     OUTPKTEND = _SKIP|4;
     SYNCDELAY;
     EP4FIFOCFG = _AUTOOUT;
+  }
 
+  if(ep_mask & 0b0100) {
+    // Reset EP6IN.
+    SYNCDELAY;
+    EP6FIFOCFG = 0;
+    SYNCDELAY;
+    FIFORESET |= 6;
+    SYNCDELAY;
+    EP6FIFOCFG = _ZEROLENIN;
+  }
+
+  if(ep_mask & 0b1000) {
     // Reset EP8IN.
     SYNCDELAY;
     EP8FIFOCFG = 0;

--- a/firmware/glasgow.h
+++ b/firmware/glasgow.h
@@ -28,7 +28,7 @@ enum {
 
 enum {
   // API compatibility level
-  CUR_API_LEVEL  = 0x03,
+  CUR_API_LEVEL  = 0x04,
 };
 
 // PORTA pins
@@ -101,6 +101,12 @@ enum {
 #define MIN_VOLTAGE 1650 // mV
 #define MAX_VOLTAGE 5500 // mV
 
+// FPGA registers
+enum {
+  FPGA_REG_HEALTH   = 0x00,
+  FPGA_REG_PIPE_RST = 0x01,
+};
+
 // Config API
 enum {
   /// Size of the bitstream ID field.
@@ -138,6 +144,12 @@ bool fpga_is_ready();
 bool fpga_reg_select(uint8_t addr);
 bool fpga_reg_read(__xdata uint8_t *value, uint8_t length);
 bool fpga_reg_write(__xdata const uint8_t *value, uint8_t length);
+bool fpga_pipe_rst(uint8_t set, uint8_t clr);
+
+// FIFO API
+void fifo_init();
+void fifo_configure(bool two_ep);
+void fifo_reset(bool two_ep, uint8_t ep_mask);
 
 // DAC/LDO API
 void iobuf_init_dac_ldo();
@@ -176,15 +188,8 @@ void iobuf_read_alert_cache_ina233(__xdata uint8_t *mask, bool clear);
 bool iobuf_set_pull(uint8_t selector, uint8_t enable, uint8_t level);
 bool iobuf_get_pull(uint8_t selector, __xdata uint8_t *enable, __xdata uint8_t *level);
 
-// FIFO API
-void fifo_init();
-void fifo_configure(bool two_ep);
-void fifo_reset(bool two_ep, uint8_t interfaces);
-
 // Util functions
-bool i2c_reg8_read(uint8_t addr, uint8_t reg,
-                         __pdata uint8_t *value, uint8_t length);
-bool i2c_reg8_write(uint8_t addr, uint8_t reg,
-                          __pdata const uint8_t *value, uint8_t length);
+bool i2c_reg8_read(uint8_t addr, uint8_t reg, __pdata uint8_t *value, uint8_t length);
+bool i2c_reg8_write(uint8_t addr, uint8_t reg, __pdata const uint8_t *value, uint8_t length);
 
 #endif

--- a/firmware/main.c
+++ b/firmware/main.c
@@ -44,7 +44,7 @@ usb_desc_device_qualifier_c usb_device_qualifier = {
   .bNumConfigurations   = 0,
 };
 
-#define USB_INTERFACE(bInterfaceNumber_, bAlternateSetting_, bNumEndpoints_, iInterface_) \
+#define USB_INTERFACE(bInterfaceNumber_, bAlternateSetting_, bNumEndpoints_)              \
   {                                                                                       \
     .bLength              = sizeof(struct usb_desc_interface),                            \
     .bDescriptorType      = USB_DESC_INTERFACE,                                           \
@@ -54,24 +54,25 @@ usb_desc_device_qualifier_c usb_device_qualifier = {
     .bInterfaceClass      = USB_IFACE_CLASS_VENDOR,                                       \
     .bInterfaceSubClass   = USB_IFACE_SUBCLASS_VENDOR,                                    \
     .bInterfaceProtocol   = USB_IFACE_PROTOCOL_VENDOR,                                    \
-    .iInterface           = iInterface_,                                                  \
+    .iInterface           = 0,                                                            \
   }
 
 usb_desc_interface_c usb_interface_0_disabled =
-  USB_INTERFACE(/*bInterfaceNumber=*/0, /*bAlternateSetting=*/0, /*bNumEndpoints=*/0,
-                /*iInterface=*/6);
-usb_desc_interface_c usb_interface_0_double =
-  USB_INTERFACE(/*bInterfaceNumber=*/0, /*bAlternateSetting=*/1, /*bNumEndpoints=*/2,
-                /*iInterface=*/7);
-usb_desc_interface_c usb_interface_0_quad =
-  USB_INTERFACE(/*bInterfaceNumber=*/0, /*bAlternateSetting=*/1, /*bNumEndpoints=*/2,
-                /*iInterface=*/8);
+  USB_INTERFACE(/*bInterfaceNumber=*/0, /*bAlternateSetting=*/0, /*bNumEndpoints=*/0);
+usb_desc_interface_c usb_interface_0_enabled =
+  USB_INTERFACE(/*bInterfaceNumber=*/0, /*bAlternateSetting=*/1, /*bNumEndpoints=*/1);
 usb_desc_interface_c usb_interface_1_disabled =
-  USB_INTERFACE(/*bInterfaceNumber=*/1, /*bAlternateSetting=*/0, /*bNumEndpoints=*/0,
-                /*iInterface=*/6);
-usb_desc_interface_c usb_interface_1_double =
-  USB_INTERFACE(/*bInterfaceNumber=*/1, /*bAlternateSetting=*/1, /*bNumEndpoints=*/2,
-                /*iInterface=*/7);
+  USB_INTERFACE(/*bInterfaceNumber=*/1, /*bAlternateSetting=*/0, /*bNumEndpoints=*/0);
+usb_desc_interface_c usb_interface_1_enabled =
+  USB_INTERFACE(/*bInterfaceNumber=*/1, /*bAlternateSetting=*/1, /*bNumEndpoints=*/1);
+usb_desc_interface_c usb_interface_2_disabled =
+  USB_INTERFACE(/*bInterfaceNumber=*/2, /*bAlternateSetting=*/0, /*bNumEndpoints=*/0);
+usb_desc_interface_c usb_interface_2_enabled =
+  USB_INTERFACE(/*bInterfaceNumber=*/2, /*bAlternateSetting=*/1, /*bNumEndpoints=*/1);
+usb_desc_interface_c usb_interface_3_disabled =
+  USB_INTERFACE(/*bInterfaceNumber=*/3, /*bAlternateSetting=*/0, /*bNumEndpoints=*/0);
+usb_desc_interface_c usb_interface_3_enabled =
+  USB_INTERFACE(/*bInterfaceNumber=*/3, /*bAlternateSetting=*/1, /*bNumEndpoints=*/1);
 
 #define USB_BULK_ENDPOINT(bEndpointAddress_)                                              \
   {                                                                                       \
@@ -96,20 +97,24 @@ usb_configuration_c usb_config_2_pipes = {
   {
     .bLength              = sizeof(struct usb_desc_configuration),
     .bDescriptorType      = USB_DESC_CONFIGURATION,
-    .bNumInterfaces       = 2,
+    .bNumInterfaces       = 4,
     .bConfigurationValue  = 1,
-    .iConfiguration       = 4,
+    .iConfiguration       = 0,
     .bmAttributes         = USB_ATTR_RESERVED_1,
     .bMaxPower            = 250,
   },
   {
     { .interface  = &usb_interface_0_disabled },
-    { .interface  = &usb_interface_0_double   },
+    { .interface  = &usb_interface_0_enabled  },
     { .endpoint   = &usb_endpoint_2_out       },
-    { .endpoint   = &usb_endpoint_6_in        },
     { .interface  = &usb_interface_1_disabled },
-    { .interface  = &usb_interface_1_double   },
+    { .interface  = &usb_interface_1_enabled  },
     { .endpoint   = &usb_endpoint_4_out       },
+    { .interface  = &usb_interface_2_disabled },
+    { .interface  = &usb_interface_2_enabled  },
+    { .endpoint   = &usb_endpoint_6_in        },
+    { .interface  = &usb_interface_3_disabled },
+    { .interface  = &usb_interface_3_enabled  },
     { .endpoint   = &usb_endpoint_8_in        },
     { 0 }
   }
@@ -119,16 +124,18 @@ usb_configuration_c usb_config_1_pipe = {
   {
     .bLength              = sizeof(struct usb_desc_configuration),
     .bDescriptorType      = USB_DESC_CONFIGURATION,
-    .bNumInterfaces       = 1,
+    .bNumInterfaces       = 2,
     .bConfigurationValue  = 2,
-    .iConfiguration       = 5,
+    .iConfiguration       = 0,
     .bmAttributes         = USB_ATTR_RESERVED_1,
     .bMaxPower            = 250,
   },
   {
     { .interface  = &usb_interface_0_disabled },
-    { .interface  = &usb_interface_0_quad     },
+    { .interface  = &usb_interface_0_enabled  },
     { .endpoint   = &usb_endpoint_2_out       },
+    { .interface  = &usb_interface_1_disabled },
+    { .interface  = &usb_interface_1_enabled  },
     { .endpoint   = &usb_endpoint_6_in        },
     { 0 }
   }
@@ -152,13 +159,6 @@ usb_ascii_string_c usb_strings[] = {
   [0] = "whitequark research\0\0\0", // CONFIG_SIZE_MANUFACTURER characters long
   [1] = "Glasgow Interface Explorer (git " GIT_REVISION ")",
   [2] = "XX-XXXXXXXXXXXXXXXX",
-  // Configurations
-  [3] = "Pipe P at {2x512B EP2OUT/EP6IN}, Q at {2x512B EP4OUT/EP8IN}",
-  [4] = "Pipe P at {4x512B EP2OUT/EP6IN}",
-  // Interfaces
-  [5] = "Disabled",
-  [6] = "Double-buffered 512B",
-  [7] = "Quad-buffered 512B",
 };
 
 usb_descriptor_set_c usb_descriptor_set = {
@@ -379,16 +379,22 @@ bool handle_usb_set_configuration(uint8_t config_value) {
 
 bool handle_usb_set_interface(uint8_t interface, uint8_t alt_setting) {
   bool two_ep;
+  uint8_t ep_mask;
 
   switch(usb_config_value) {
-    case 1: two_ep = false; break;
-    case 2: two_ep = true;  break;
+    case 1: two_ep = false; ep_mask = 1 <<      interface;  break;
+    case 2: two_ep = true;  ep_mask = 1 << (2 * interface); break;
     default: return false;
   }
 
+  if (!fpga_pipe_rst(/*set=*/ep_mask, /*clr=*/0))
+    return false;
+
+  fifo_reset(two_ep, ep_mask);
+
   if(alt_setting == 1) {
-    // The interface is being (re)activated, so reset the FIFOs.
-    fifo_reset(two_ep, (1 << interface));
+    if (!fpga_pipe_rst(/*set=*/0, /*clr=*/ep_mask))
+      return false;
   }
 
   usb_alt_setting[interface] = alt_setting;

--- a/software/glasgow/abstract.py
+++ b/software/glasgow/abstract.py
@@ -159,6 +159,10 @@ class AbstractInPipe(metaclass=ABCMeta):
     async def recv(self, length) -> memoryview:
         pass
 
+    @abstractmethod
+    async def reset(self):
+        pass
+
 
 class AbstractOutPipe(metaclass=ABCMeta):
     @property
@@ -172,6 +176,10 @@ class AbstractOutPipe(metaclass=ABCMeta):
 
     @abstractmethod
     async def flush(self):
+        pass
+
+    @abstractmethod
+    async def reset(self):
         pass
 
 

--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -707,14 +707,17 @@ async def main():
                 except asyncio.CancelledError:
                     return 130 # 128 + SIGINT
 
-            with gc_freeze():
-                async with asyncio.TaskGroup() as group:
-                    applet_task = group.create_task(run_applet())
+            try:
+                with gc_freeze():
+                    async with asyncio.TaskGroup() as group:
+                        applet_task = group.create_task(run_applet())
 
-                    if args.action != "repl":
-                        sigint_task = group.create_task(wait_for_sigint())
-                        await asyncio.wait([applet_task])
-                        sigint_task.cancel()
+                        if args.action != "repl":
+                            sigint_task = group.create_task(wait_for_sigint())
+                            await asyncio.wait([applet_task])
+                            sigint_task.cancel()
+            except* SIGINTCaught:
+                pass
 
             await assembly.stop()
             if args.show_statistics:

--- a/software/glasgow/hardware/device.py
+++ b/software/glasgow/hardware/device.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 VID_QIHW         = 0x20b7
 PID_GLASGOW      = 0x9db1
 
-CUR_API_LEVEL    = 0x03
+CUR_API_LEVEL    = 0x04
 
 REQ_EEPROM       = 0x10
 REQ_FPGA_CFG     = 0x11

--- a/software/glasgow/legacy.py
+++ b/software/glasgow/legacy.py
@@ -253,9 +253,14 @@ class DeprecatedDemultiplexerInterface:
             self._mux_interface._out_pipe._out_buffer_size = write_buffer_size
 
     async def reset(self):
-        # Note that this will reset the ~entire FPGA. This is OK, since the legacy interface
-        # isn't intended to be used by more than one applet anyway.
-        await self.device.assembly.reset()
+        if self._mux_interface._in_pipe is not None:
+            await self._mux_interface._in_pipe._stop()
+        if self._mux_interface._out_pipe is not None:
+            await self._mux_interface._out_pipe._stop()
+        if self._mux_interface._in_pipe is not None:
+            await self._mux_interface._in_pipe._start()
+        if self._mux_interface._out_pipe is not None:
+            await self._mux_interface._out_pipe._start()
 
     async def read(self, length=None, *, flush=True):
         if flush:

--- a/software/glasgow/simulation/assembly.py
+++ b/software/glasgow/simulation/assembly.py
@@ -47,6 +47,10 @@ class SimulationPipe(AbstractInOutPipe):
             clk_hit, rst_hit = await self._parent._context.tick()
             assert not rst_hit
 
+    async def reset(self):
+        self._i_buffer.clear()
+        self._o_buffer.clear()
+
 
 class SimulationRORegister(AbstractRORegister):
     def __init__(self, parent, signal):


### PR DESCRIPTION
This commit ties together several changes that align the way FIFOs work with the new API with the way the firmware treats FIFOs. With new API, applets can request up to 4 independent pipes: two OUT and two IN. There is no inherent ties between any of the pipes, in particular they are not paired as IN+OUT.

Until this commit, the gateware would pair pipes into interfaces: one IN+OUT pair per interface. After this commit, each endpoint gets its own interface, independent from all others. Moreover, the firmware is now aware of a pipe reset register in the FPGA, and will reset a pipe in response to the standard Set Interface command. This command would already clear buffers in the FX2, and for correctness it is necessary to reset the complementary buffers in the FPGA too; until now this was the responsibility of the host software, which made using the Glasgow hardware with non-Glasgow software rather annoying. (Even while it is not supported, we don't want to make it painful.)

Until this commit, the hardware assembly would create a global reset register, and apply `ResetInserter` to every added submodule. This was not robust: due to Amaranth issues, it is less reliable than adding a clock domain per applet (`ResetValue()` only looks at the domain reset, not any added reset), and it made it impossible to a single applet individually in a multiple applet configuration. After this commit, an applet is reset whenever *any* of the pipes connected to it are reset. (Also, pipes gain a `reset()` method.) While a bit limited, this approach avoids needing to introduce applet resets explicitly, at least for most applets which are controlled via a pipe.

The approach of offering two configurations (one with four EPs and one with two EPs) is unchanged, with all of its upsides and downsides.