### PR TITLE
Fix FX2 crossbar skid buffer implementation

### DIFF
--- a/software/glasgow/gateware/fx2_crossbar.py
+++ b/software/glasgow/gateware/fx2_crossbar.py
@@ -219,11 +219,10 @@ class _OUTFIFO(wiring.Component):
     def elaborate(self, platform):
         m = Module()
 
-        m.submodules.skid = skid = StreamFIFO(shape=8, depth=self._skid_depth, buffered=False)
+        m.submodules.skid = skid = StreamFIFO(shape=8, depth=self._skid_depth, buffered=True)
 
         m.d.comb += skid.w.payload.eq(self.w.payload)
         m.d.comb += skid.w.valid.eq(self.w.valid & ~self.r.ready)
-        m.d.comb += self.w.ready.eq(self.r.ready)
         with m.If(skid.r.valid):
             connect(m, flipped(self.r), skid.r)
         with m.Else():


### PR DESCRIPTION
Fixes #850.

The change to `buffered` is required. The change to `ready` doesn't seem to make a difference in testing, but seems correct.