### PR TITLE
gateware.fx2_crossbar: fix skid buffer handling.

### DIFF
--- a/software/glasgow/gateware/fx2_crossbar.py
+++ b/software/glasgow/gateware/fx2_crossbar.py
@@ -222,8 +222,7 @@ class _OUTFIFO(wiring.Component):
         m.submodules.skid = skid = StreamFIFO(shape=8, depth=self._skid_depth, buffered=False)
 
         m.d.comb += skid.w.payload.eq(self.w.payload)
-        m.d.comb += skid.w.valid.eq(self.w.valid & ~self.r.ready)
-        m.d.comb += self.w.ready.eq(self.r.ready)
+        m.d.comb += skid.w.valid.eq(self.w.valid & (~self.r.ready | skid.r.valid))
         with m.If(skid.r.valid):
             connect(m, flipped(self.r), skid.r)
         with m.Else():


### PR DESCRIPTION
If the skid buffer starts being drained while the skid buffer is still skidding, we still need to direct incoming bytes to the skid buffer, even though the read stream is now ready.  This fixes problems with bytes being dropped on the OUT FIFO.

Fixes #850.