### PR TITLE
Make SPI/QSPI analyzer pull settings less aggressive (pull high CS# only)

### DIFF
--- a/software/glasgow/abstract.py
+++ b/software/glasgow/abstract.py
@@ -204,7 +204,7 @@ class AbstractAssembly(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def add_platform_pin(self, pin_name: str, port_name: str) -> io.PortLike:
+    def add_platform_pin(self, pin: GlasgowPin, port_name: str) -> io.PortLike:
         pass
 
     def add_port(self, pins: GlasgowPin | tuple[GlasgowPin] | str | None, name: str) -> io.PortLike:
@@ -222,9 +222,8 @@ class AbstractAssembly(metaclass=ABCMeta):
                     else:
                         port += pin_port
                 return port
-            case GlasgowPin(port, number, invert):
-                port = self.add_platform_pin(f"{port}{number}", name)
-                return ~port if invert else port
+            case GlasgowPin() as pin:
+                return self.add_platform_pin(pin, name)
             case _:
                 raise TypeError(f"cannot add a port for object {pins!r}")
 

--- a/software/glasgow/applet/interface/qspi_analyzer/__init__.py
+++ b/software/glasgow/applet/interface/qspi_analyzer/__init__.py
@@ -260,7 +260,7 @@ class QSPIAnalyzerApplet(GlasgowAppletV2):
     def build(self, args):
         with self.assembly.add_applet(self):
             self.assembly.use_voltage(args.voltage)
-            self.assembly.use_pulls({args.cs: "high", args.sck: "low", args.io: "high"})
+            self.assembly.use_pulls({args.cs: "high"})
             self.qspi_analyzer_iface = QSPIAnalyzerInterface(self.logger, self.assembly,
                 cs=args.cs, sck=args.sck, io=args.io,
                 buffer_size=args.buffer_size)

--- a/software/glasgow/applet/interface/spi_analyzer/__init__.py
+++ b/software/glasgow/applet/interface/spi_analyzer/__init__.py
@@ -273,10 +273,7 @@ class SPIAnalyzerApplet(GlasgowAppletV2):
     def build(self, args):
         with self.assembly.add_applet(self):
             self.assembly.use_voltage(args.voltage)
-            self.assembly.use_pulls({
-                args.cs:   "high", args.sck:  "low",
-                args.copi: "high", args.cipo: "high"
-            })
+            self.assembly.use_pulls({args.cs: "high"})
             self.spi_analyzer_iface = SPIAnalyzerInterface(self.logger, self.assembly,
                 cs=args.cs, sck=args.sck, copi=args.copi, cipo=args.cipo,
                 buffer_size=args.buffer_size)

--- a/software/glasgow/hardware/assembly.py
+++ b/software/glasgow/hardware/assembly.py
@@ -448,12 +448,16 @@ class HardwareAssembly(AbstractAssembly):
             self._applet = None
             self._domain = None
 
-    def add_platform_pin(self, pin_name: str, port_name: str) -> io.PortLike:
+    def add_platform_pin(self, pin: GlasgowPin, port_name: str) -> io.PortLike:
         assert self._artifact is None, "cannot add a port to a sealed assembly"
         # TODO: make this a proper error and not an assertion
+        pin_name = f"{pin.port}{pin.number}"
         assert pin_name in self._platform.glasgow_pins, f"unknown or already used pin {pin_name}"
         self._logger.debug(f"assigning pin {port_name!r} to {pin_name}")
-        return self._platform.glasgow_pins.pop(pin_name)
+        if (pin.port, pin.number) not in self._pulls:
+            self._pulls[pin.port, pin.number] = PullState.Float
+        port = self._platform.glasgow_pins.pop(pin_name)
+        return ~port if pin.invert else port
 
     def add_submodule(self, elaboratable, *, name=None) -> Elaboratable:
         assert self._artifact is None, "cannot add a submodule to a sealed assembly"

--- a/software/glasgow/simulation/assembly.py
+++ b/software/glasgow/simulation/assembly.py
@@ -83,7 +83,8 @@ class SimulationAssembly(AbstractAssembly):
     def add_applet(self, applet: Any) -> Generator[None, None, None]:
         yield
 
-    def add_platform_pin(self, pin_name: str, port_name: str) -> io.PortLike:
+    def add_platform_pin(self, pin: GlasgowPin, port_name: str) -> io.PortLike:
+        pin_name = f"{pin.port}{pin.number}"
         port = io.SimulationPort("io", 1, name=pin_name)
         self._pins[pin_name] = port
         return port


### PR DESCRIPTION
This caused problems with unpowered targets and autosensing level shifters. Making pull on CS# configurable may also be something to do in the future.