### PR TITLE
abstract: add shape property to AbstractRORegister.

### DIFF
--- a/software/glasgow/abstract.py
+++ b/software/glasgow/abstract.py
@@ -142,6 +142,11 @@ class AbstractRORegister(metaclass=ABCMeta):
     def __await__(self):
         return self.get().__await__()
 
+    @property
+    @abstractmethod
+    def shape(self) -> Shape:
+        pass
+
 
 class AbstractRWRegister(AbstractRORegister):
     @abstractmethod

--- a/software/glasgow/hardware/assembly.py
+++ b/software/glasgow/hardware/assembly.py
@@ -99,6 +99,10 @@ class HardwareRORegister(AbstractRORegister):
             value = self._shape.from_bits(value)
         return value
 
+    @property
+    def shape(self):
+        return self._shape
+
 
 class HardwareRWRegister(HardwareRORegister, AbstractRWRegister):
     async def set(self, value):

--- a/software/glasgow/simulation/assembly.py
+++ b/software/glasgow/simulation/assembly.py
@@ -63,6 +63,10 @@ class SimulationRORegister(AbstractRORegister):
     async def get(self):
         return self._parent._context.get(self._signal)
 
+    @property
+    def shape(self):
+        return self._signal.shape()
+
 
 class SimulationRWRegister(SimulationRORegister, AbstractRWRegister):
     async def set(self, value):


### PR DESCRIPTION
In matrix, I talked about only adding shape to HardwareRORegister. I realized that adding it could create issues simulating an applet that references `register.shape` if SimulationRORegister didn't also have a shape property.

I can go back to only changing HardwareRORegister if you'd like.