### PR TITLE
Gateware I2C regsiter improvements

### DIFF
--- a/software/glasgow/hardware/assembly.py
+++ b/software/glasgow/hardware/assembly.py
@@ -431,7 +431,7 @@ class HardwareAssembly(AbstractAssembly):
             self._revision  = self._device.revision
 
         self._platform      = self._create_platform(self._revision)
-        self._registers     = [] # (register, signal)
+        self._registers     = [] # (register, signal, domain)
         self._domains       = [] # domain
         self._modules       = [] # (domain, elaboratable, name)
         self._in_streams    = [] # (domain, in_stream, in_flush, fifo_depth)
@@ -496,14 +496,14 @@ class HardwareAssembly(AbstractAssembly):
         assert self._artifact is None, "cannot add a register to a sealed assembly"
         register = HardwareRORegister(self._logger, self,
             address=2 + len(self._registers), shape=signal.shape(), name=signal.name)
-        self._registers.append((register, signal))
+        self._registers.append((register, signal, self._domain))
         return register
 
     def add_rw_register(self, signal) -> AbstractRWRegister:
         assert self._artifact is None, "cannot add a register to a sealed assembly"
         register = HardwareRWRegister(self._logger, self,
             address=2 + len(self._registers), shape=signal.shape(), name=signal.name)
-        self._registers.append((register, signal))
+        self._registers.append((register, signal, self._domain))
         return register
 
     def add_in_pipe(self, in_stream, *, in_flush=C(1),
@@ -598,9 +598,9 @@ class HardwareAssembly(AbstractAssembly):
             else:
                 m.submodules[name] = DomainRenamer(domain.name)(elaboratable)
 
-        for register, signal in self._registers:
+        for register, signal, domain in self._registers:
             if isinstance(register, HardwareRWRegister):
-                register_addr = i2c_registers.add_existing_rw(Value.cast(signal))
+                register_addr = i2c_registers.add_existing_rw(Value.cast(signal), domain=domain)
             elif isinstance(register, HardwareRORegister):
                 register_addr = i2c_registers.add_existing_ro(Value.cast(signal))
             assert register_addr == register._address

--- a/software/tests/gateware/test_registers.py
+++ b/software/tests/gateware/test_registers.py
@@ -58,9 +58,10 @@ class I2CRegistersTestCase(unittest.TestCase):
         self.assertEqual((yield from tb.i2c.read_bit()), 0)
         yield from tb.i2c.write_octet(0b10100101)
         self.assertEqual((yield from tb.i2c.read_bit()), 0)
+        self.assertEqual((yield tb.dut.regs_r[self.tb.addr_rw_8]), 0)
+        yield from tb.i2c.stop()
         self.assertEqual((yield tb.dut.regs_r[self.tb.addr_rw_8]), 0b10100101)
         self.assertEqual((yield tb.dut.regs_r[self.tb.addr_dummy]), 0b00000000)
-        yield from tb.i2c.stop()
 
     @simulation_test
     def test_data_read_8(self, tb):
@@ -86,10 +87,12 @@ class I2CRegistersTestCase(unittest.TestCase):
         self.assertEqual((yield from tb.i2c.read_bit()), 0)
         yield from tb.i2c.write_octet(0b11110000)
         self.assertEqual((yield from tb.i2c.read_bit()), 0)
+        self.assertEqual((yield tb.dut.regs_r[self.tb.addr_rw_16]), 0)
         yield from tb.i2c.write_octet(0b10100101)
         self.assertEqual((yield from tb.i2c.read_bit()), 0)
-        self.assertEqual((yield tb.dut.regs_r[self.tb.addr_rw_16]), 0b1111000010100101)
+        self.assertEqual((yield tb.dut.regs_r[self.tb.addr_rw_16]), 0)
         yield from tb.i2c.stop()
+        self.assertEqual((yield tb.dut.regs_r[self.tb.addr_rw_16]), 0b1111000010100101)
 
     @simulation_test
     def test_data_read_16(self, tb):
@@ -117,10 +120,12 @@ class I2CRegistersTestCase(unittest.TestCase):
         self.assertEqual((yield from tb.i2c.read_bit()), 0)
         yield from tb.i2c.write_octet(0b00001110)
         self.assertEqual((yield from tb.i2c.read_bit()), 0)
+        self.assertEqual((yield tb.dut.regs_r[self.tb.addr_rw_12]), 0)
         yield from tb.i2c.write_octet(0b10100101)
         self.assertEqual((yield from tb.i2c.read_bit()), 0)
-        self.assertEqual((yield tb.dut.regs_r[self.tb.addr_rw_12]), 0b111010100101)
+        self.assertEqual((yield tb.dut.regs_r[self.tb.addr_rw_12]), 0)
         yield from tb.i2c.stop()
+        self.assertEqual((yield tb.dut.regs_r[self.tb.addr_rw_12]), 0b111010100101)
 
     @simulation_test
     def test_data_read_12(self, tb):


### PR DESCRIPTION
- Make RW register writes atomic
- Make RW registers be reset by applet reset