### PR TITLE
Add `AbstractAssembly.add_clock_divisor()` building block

### DIFF
--- a/software/glasgow/applet/__init__.py
+++ b/software/glasgow/applet/__init__.py
@@ -77,15 +77,6 @@ class GlasgowAppletV2(metaclass=ABCMeta):
     def add_build_arguments(cls, parser, access):
         access.add_voltage_argument(parser)
 
-    def derive_clock(self, *args, clock_name=None, **kwargs):
-        try:
-            return ClockGen.derive(*args, **kwargs, logger=self.logger, clock_name=clock_name)
-        except ValueError as e:
-            if clock_name is None:
-                raise GlasgowAppletError(e)
-            else:
-                raise GlasgowAppletError(f"clock {clock_name}: {e}")
-
     @abstractmethod
     def build(self, args):
         self.assembly.use_voltage(args.voltage)

--- a/software/glasgow/applet/interface/swd_probe/test.py
+++ b/software/glasgow/applet/interface/swd_probe/test.py
@@ -9,7 +9,7 @@ class SWDProbeAppletTestCase(GlasgowAppletV2TestCase, applet=SWDProbeApplet):
     def test_build(self):
         self.assertBuilds()
 
-    @applet_v2_simulation_test()
+    @applet_v2_simulation_test(args="--freq 100")
     async def test_read_dpidr_floating(self, applet, ctx):
         try:
             await applet.swd_iface.initialize()

--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -22,6 +22,7 @@ from . import __version__
 from .support.logging import *
 from .support.asignal import *
 from .support.plugin import PluginRequirementsUnmet, PluginLoadError
+from .abstract import ClockingError
 from .hardware.device import GlasgowDeviceError, GlasgowDevice, GlasgowDeviceConfig
 from .hardware.device import VID_QIHW, PID_GLASGOW
 from .hardware.toolchain import ToolchainNotFound
@@ -699,7 +700,7 @@ async def main():
 
                 except SystemExit as e:
                     return e.code
-                except GlasgowAppletError as e:
+                except (ClockingError, GlasgowAppletError) as e:
                     applet.logger.error(str(e))
                     return 1
                 except asyncio.CancelledError:
@@ -806,7 +807,7 @@ async def main():
             tool = GlasgowAppletToolMetadata.get(args.tool).load()()
             try:
                 return await tool.run(args)
-            except GlasgowAppletError as e:
+            except (ClockingError, GlasgowAppletError) as e:
                 tool.logger.error(e)
                 return 1
 

--- a/software/glasgow/simulation/assembly.py
+++ b/software/glasgow/simulation/assembly.py
@@ -14,6 +14,9 @@ from ..abstract import *
 __all__ = ["SimulationPipe", "SimulationRegister", "SimulationAssembly"]
 
 
+logger = logging.getLogger(__name__)
+
+
 class SimulationPipe(AbstractInOutPipe):
     def __init__(self, parent, *, i_buffer, o_buffer):
         self._parent   = parent
@@ -75,6 +78,7 @@ class SimulationRWRegister(SimulationRORegister, AbstractRWRegister):
 
 class SimulationAssembly(AbstractAssembly):
     def __init__(self):
+        self._logger   = logger
         self._pins     = {} # {name: io.PortLike}
         self._modules  = [] # (elaboratable, name)
         self._benches  = [] # (constructor, background)
@@ -88,7 +92,11 @@ class SimulationAssembly(AbstractAssembly):
 
     @contextmanager
     def add_applet(self, applet: Any) -> Generator[None, None, None]:
-        yield
+        self._logger = applet.logger
+        try:
+            yield
+        finally:
+            self._logger = logger
 
     def add_platform_pin(self, pin: GlasgowPin, port_name: str) -> io.PortLike:
         pin_name = f"{pin.port}{pin.number}"


### PR DESCRIPTION
This replaces `GlasgowApplet{,V2}.derive_clock` and `ClockGen.derive`. Eventually `ClockGen` should be removed.