### PR TITLE
Applet `control-gpio`: allow interacting with pins from CLI

### DIFF
--- a/software/glasgow/applet/control/gpio/__init__.py
+++ b/software/glasgow/applet/control/gpio/__init__.py
@@ -1,3 +1,5 @@
+import re
+import argparse
 import logging
 
 from amaranth import *
@@ -5,7 +7,7 @@ from amaranth.lib import wiring, io, cdc
 from amaranth.lib.wiring import In, Out
 
 from glasgow.abstract import AbstractAssembly, PullState
-from glasgow.applet import GlasgowAppletError, GlasgowAppletV2
+from glasgow.applet import GlasgowAppletError, GlasgowAppletV2, GlasgowPin
 
 
 __all__ = ["GPIOException", "GPIOComponent", "GPIOInterface"]
@@ -39,7 +41,8 @@ class GPIOComponent(wiring.Component):
 
 
 class GPIOInterface:
-    def __init__(self, logger: logging.Logger, assembly: AbstractAssembly, *, pins):
+    def __init__(self, logger: logging.Logger, assembly: AbstractAssembly, *,
+                 pins: tuple[GlasgowPin]):
         self._logger   = logger
         self._level    = logging.DEBUG if self._logger.name == __name__ else logging.TRACE
         self._assembly = assembly
@@ -114,7 +117,11 @@ class ControlGPIOApplet(GlasgowAppletV2):
     logger = logging.getLogger(__name__)
     help = "control individual I/O pins"
     description = """
-    Sample and drive individual I/O pins via the REPL or a script.
+    Sample and drive individual I/O pins via the CLI, the REPL, or a script.
+
+    CLI pin actions can be used to configure a pin to be driven strongly (``A0=0`` or ``A0=1``),
+    or to be driven weakly using a pull resistor (``A0=H`` or ``A0=L``). The actions are executed
+    in the order they are provided on the command line.
     """
 
     @classmethod
@@ -126,6 +133,41 @@ class ControlGPIOApplet(GlasgowAppletV2):
         with self.assembly.add_applet(self):
             self.assembly.use_voltage(args.voltage)
             self.gpio_iface = GPIOInterface(self.logger, self.assembly, pins=args.pins)
+
+    @classmethod
+    def add_run_arguments(cls, parser):
+        def pin_action(arg):
+            if m := re.match(r"^([A-Z][0-9]+)(?:=([01HL]))?$", arg):
+                (pin,), value = GlasgowPin.parse(m[1]), m[2]
+                return (pin, value)
+            raise argparse.ArgumentTypeError(f"{arg!r} is not a valid pin action")
+
+        parser.add_argument(
+            "pin_actions", metavar="PIN-ACTION", nargs="*", type=pin_action,
+            help="pins to drive or sample, e.g.: 'A0=1', 'A1=L', 'B5'")
+
+    async def run(self, args):
+        for pin, level in args.pin_actions:
+            try:
+                pin_index = args.pins.index(pin)
+            except ValueError:
+                raise GlasgowAppletError(f"pin {pin} is not included in the '--pins' argument")
+
+            match level:
+                case None:
+                    print(f"{pin}={await self.gpio_iface.get(pin_index):b}")
+                case '0':
+                    await self.gpio_iface.output(pin_index, False)
+                case '1':
+                    await self.gpio_iface.output(pin_index, True)
+                case 'H':
+                    await self.gpio_iface.pull(pin_index, PullState.High)
+                    await self.gpio_iface.input(pin_index)
+                case 'L':
+                    await self.gpio_iface.pull(pin_index, PullState.Low)
+                    await self.gpio_iface.input(pin_index)
+                case _:
+                    assert False
 
     @classmethod
     def tests(cls):


### PR DESCRIPTION
This is very useful to set strap pins, e.g. if you have a system reset connected to pin `B7` and it must be asserted for JTAG to work:

    glasgow multi jtag-probe <...> ++ gpio --pins B7 B7=0

It is also possible to set pins to drive weakly (e.g. use the `B7=H` or `B7=L` as an argument), and to sample pins (e.g. use `B6` as an argument).