### PR TITLE
gateware.uart: fix parity computation

### DIFF
--- a/software/glasgow/applet/interface/uart/test.py
+++ b/software/glasgow/applet/interface/uart/test.py
@@ -17,6 +17,11 @@ class UARTAppletTestCase(GlasgowAppletV2TestCase, applet=UARTApplet):
         await applet.uart_iface.write(bytes([0xAA, 0x55]))
         self.assertEqual(await applet.uart_iface.read(2), bytes([0xAA, 0x55]))
 
+    @applet_v2_simulation_test(prepare=prepare_loopback, args="--baud 9600 --parity odd")
+    async def test_parity_loopback(self, applet, ctx):
+        await applet.uart_iface.write(bytes([0x55, 0xAA]))
+        self.assertEqual(await applet.uart_iface.read(2), bytes([0x55, 0xAA]))
+
     # This test is here mainly to test the test machinery.
     @applet_v2_hardware_test(args="-V 3.3 --baud 9600", mock="uart_iface")
     async def test_loopback_hw(self, applet):

--- a/software/glasgow/gateware/uart.py
+++ b/software/glasgow/gateware/uart.py
@@ -126,12 +126,13 @@ class UART(Elaboratable):
             elif kind == "one":
                 return C(1, 1)
             else:
-                bits, _ = sig.shape()
-                even_parity = sum([sig[b] for b in range(bits)]) & 1
+                # odd or even parity includes the parity bit; since `xor()`
+                # calculates odd parity, invert that to get its expected value
+                parity_bit = ~sig.xor()
                 if kind == "odd":
-                    return ~even_parity
+                    return parity_bit
                 elif kind == "even":
-                    return even_parity
+                    return ~parity_bit
                 else:
                     assert False
 


### PR DESCRIPTION
Iteration over a `Shape` has not been a thing since Amaranth 0.4, causing a `TypeError` when setting up non-constant parity. Use the reduction XOR operator instead of hand-rolling the parity computation.

Tested that both odd and even parity work, and that mismatched settings generate receive errors, when listening to an FT232R on macOS running CoolTerm. Tested also that a loopback connection works.

Also adds an applet test for this functionality.