### PR TITLE
applet.program.avr.spi: select SPI device before exchanging data

### DIFF
--- a/software/glasgow/applet/program/avr/spi/__init__.py
+++ b/software/glasgow/applet/program/avr/spi/__init__.py
@@ -46,7 +46,8 @@ class ProgramAVRSPIInterface(ProgramAVRInterface):
     async def _command(self, byte1, byte2, byte3, byte4):
         command = [byte1, byte2, byte3, byte4]
         self._log("command %s", "{:08b} {:08b} {:08b} {:08b}".format(*command))
-        result = await self.lower.exchange(command)
+        async with self.lower.select():
+            result = await self.lower.exchange(command)
         self._log("result  %s", "{:08b} {:08b} {:08b} {:08b}".format(*result))
         return result
 

--- a/software/glasgow/applet/program/avr/spi/fixtures/test_api_calibration.json
+++ b/software/glasgow/applet/program/avr/spi/fixtures/test_api_calibration.json
@@ -1,1 +1,3 @@
-{"method": "exchange", "async": true, "args": [[56, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00380063"}}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[56, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00380063"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}

--- a/software/glasgow/applet/program/avr/spi/fixtures/test_api_eeprom.json
+++ b/software/glasgow/applet/program/avr/spi/fixtures/test_api_eeprom.json
@@ -1,40 +1,120 @@
-{"method": "exchange", "async": true, "args": [[193, 0, 0, 255]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00c10000"}}
-{"method": "exchange", "async": true, "args": [[193, 0, 1, 255]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "ffc10001"}}
-{"method": "exchange", "async": true, "args": [[193, 0, 2, 255]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "ffc10002"}}
-{"method": "exchange", "async": true, "args": [[193, 0, 3, 255]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "ffc10003"}}
-{"method": "exchange", "async": true, "args": [[194, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "ffc20000"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
-{"method": "exchange", "async": true, "args": [[193, 0, 0, 255]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00c10000"}}
-{"method": "exchange", "async": true, "args": [[193, 0, 1, 255]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "ffc10001"}}
-{"method": "exchange", "async": true, "args": [[193, 0, 2, 255]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "ffc10002"}}
-{"method": "exchange", "async": true, "args": [[193, 0, 3, 255]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "ffc10003"}}
-{"method": "exchange", "async": true, "args": [[194, 0, 4, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "ffc20004"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
-{"method": "exchange", "async": true, "args": [[193, 0, 2, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00c10002"}}
-{"method": "exchange", "async": true, "args": [[193, 0, 3, 1]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00c10003"}}
-{"method": "exchange", "async": true, "args": [[194, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "01c20000"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
-{"method": "exchange", "async": true, "args": [[193, 0, 0, 2]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00c10000"}}
-{"method": "exchange", "async": true, "args": [[193, 0, 1, 3]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "02c10001"}}
-{"method": "exchange", "async": true, "args": [[194, 0, 4, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "03c20004"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
-{"method": "exchange", "async": true, "args": [[160, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00a000ff"}}
-{"method": "exchange", "async": true, "args": [[160, 0, 1, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00a000ff"}}
-{"method": "exchange", "async": true, "args": [[160, 0, 2, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00a00000"}}
-{"method": "exchange", "async": true, "args": [[160, 0, 3, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00a00001"}}
-{"method": "exchange", "async": true, "args": [[160, 0, 4, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00a00002"}}
-{"method": "exchange", "async": true, "args": [[160, 0, 5, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00a00003"}}
-{"method": "exchange", "async": true, "args": [[160, 0, 6, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00a000ff"}}
-{"method": "exchange", "async": true, "args": [[160, 0, 7, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00a000ff"}}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[193, 0, 0, 255]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00c10000"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[193, 0, 1, 255]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "ffc10001"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[193, 0, 2, 255]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "ffc10002"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[193, 0, 3, 255]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "ffc10003"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[194, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "ffc20000"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[193, 0, 0, 255]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00c10000"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[193, 0, 1, 255]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "ffc10001"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[193, 0, 2, 255]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "ffc10002"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[193, 0, 3, 255]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "ffc10003"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[194, 0, 4, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "ffc20004"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[193, 0, 2, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00c10002"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[193, 0, 3, 1]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00c10003"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[194, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "01c20000"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[193, 0, 0, 2]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00c10000"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[193, 0, 1, 3]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "02c10001"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[194, 0, 4, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "03c20004"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[160, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00a000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[160, 0, 1, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00a000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[160, 0, 2, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00a00000"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[160, 0, 3, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00a00001"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[160, 0, 4, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00a00002"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[160, 0, 5, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00a00003"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[160, 0, 6, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00a000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[160, 0, 7, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00a000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}

--- a/software/glasgow/applet/program/avr/spi/fixtures/test_api_fuses.json
+++ b/software/glasgow/applet/program/avr/spi/fixtures/test_api_fuses.json
@@ -1,37 +1,111 @@
-{"method": "exchange", "async": true, "args": [[172, 160, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00aca000"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
-{"method": "exchange", "async": true, "args": [[80, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00500000"}}
-{"method": "exchange", "async": true, "args": [[172, 160, 0, 255]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00aca000"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "fff000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
-{"method": "exchange", "async": true, "args": [[80, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "005000ff"}}
-{"method": "exchange", "async": true, "args": [[172, 168, 0, 199]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00aca800"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "c7f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
-{"method": "exchange", "async": true, "args": [[88, 8, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "005808c7"}}
-{"method": "exchange", "async": true, "args": [[172, 168, 0, 24]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00aca800"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "18f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
-{"method": "exchange", "async": true, "args": [[88, 8, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00580818"}}
-{"method": "exchange", "async": true, "args": [[172, 164, 0, 244]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00aca400"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "f4f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
-{"method": "exchange", "async": true, "args": [[80, 8, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "005008f4"}}
-{"method": "exchange", "async": true, "args": [[172, 164, 0, 203]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00aca400"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "cbf000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
-{"method": "exchange", "async": true, "args": [[80, 8, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "005008cb"}}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[172, 160, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00aca000"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[80, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00500000"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[172, 160, 0, 255]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00aca000"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "fff000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[80, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "005000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[172, 168, 0, 199]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00aca800"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "c7f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[88, 8, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "005808c7"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[172, 168, 0, 24]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00aca800"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "18f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[88, 8, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00580818"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[172, 164, 0, 244]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00aca400"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "f4f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[80, 8, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "005008f4"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[172, 164, 0, 203]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00aca400"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "cbf000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[80, 8, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "005008cb"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}

--- a/software/glasgow/applet/program/avr/spi/fixtures/test_api_lock_bits.json
+++ b/software/glasgow/applet/program/avr/spi/fixtures/test_api_lock_bits.json
@@ -1,15 +1,45 @@
-{"method": "exchange", "async": true, "args": [[172, 128, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00ac8000"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
-{"method": "exchange", "async": true, "args": [[88, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "005800ff"}}
-{"method": "exchange", "async": true, "args": [[172, 224, 0, 254]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00ace000"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "fef000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
-{"method": "exchange", "async": true, "args": [[88, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "005800fe"}}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[172, 128, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00ac8000"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[88, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "005800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[172, 224, 0, 254]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00ace000"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "fef000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[88, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "005800fe"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}

--- a/software/glasgow/applet/program/avr/spi/fixtures/test_api_program_memory.json
+++ b/software/glasgow/applet/program/avr/spi/fixtures/test_api_program_memory.json
@@ -1,404 +1,1212 @@
-{"method": "exchange", "async": true, "args": [[172, 128, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00ac8000"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 32, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00400020"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 32, 1]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00480020"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 33, 2]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "01400021"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 33, 3]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "02480021"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 34, 4]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "03400022"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 34, 5]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "04480022"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 35, 6]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "05400023"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 35, 7]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "06480023"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 36, 8]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "07400024"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 36, 9]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "08480024"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 37, 10]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "09400025"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 37, 11]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0a480025"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 38, 12]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0b400026"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 38, 13]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0c480026"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 39, 14]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0d400027"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 39, 15]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0e480027"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 40, 16]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0f400028"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 40, 17]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "10480028"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 41, 18]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "11400029"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 41, 19]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "12480029"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 42, 20]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "1340002a"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 42, 21]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "1448002a"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 43, 22]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "1540002b"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 43, 23]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "1648002b"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 44, 24]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "1740002c"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 44, 25]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "1848002c"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 45, 26]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "1940002d"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 45, 27]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "1a48002d"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 46, 28]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "1b40002e"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 46, 29]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "1c48002e"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 47, 30]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "1d40002f"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 47, 31]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "1e48002f"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 48, 32]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "1f400030"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 48, 33]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "20480030"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 49, 34]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "21400031"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 49, 35]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "22480031"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 50, 36]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "23400032"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 50, 37]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "24480032"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 51, 38]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "25400033"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 51, 39]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "26480033"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 52, 40]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "27400034"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 52, 41]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "28480034"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 53, 42]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "29400035"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 53, 43]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "2a480035"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 54, 44]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "2b400036"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 54, 45]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "2c480036"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 55, 46]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "2d400037"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 55, 47]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "2e480037"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 56, 48]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "2f400038"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 56, 49]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "30480038"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 57, 50]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "31400039"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 57, 51]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "32480039"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 58, 52]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "3340003a"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 58, 53]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "3448003a"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 59, 54]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "3540003b"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 59, 55]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "3648003b"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 60, 56]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "3740003c"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 60, 57]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "3848003c"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 61, 58]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "3940003d"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 61, 59]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "3a48003d"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 62, 60]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "3b40003e"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 62, 61]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "3c48003e"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 63, 62]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "3d40003f"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 63, 63]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "3e48003f"}}
-{"method": "exchange", "async": true, "args": [[77, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00000000"}}
-{"method": "exchange", "async": true, "args": [[76, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "3f4c0000"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 0, 64]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00400000"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 0, 65]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "40480000"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 1, 66]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "41400001"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 1, 67]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "42480001"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 2, 68]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "43400002"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 2, 69]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "44480002"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 3, 70]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "45400003"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 3, 71]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "46480003"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 4, 72]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "47400004"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 4, 73]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "48480004"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 5, 74]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "49400005"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 5, 75]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "4a480005"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 6, 76]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "4b400006"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 6, 77]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "4c480006"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 7, 78]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "4d400007"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 7, 79]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "4e480007"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 8, 80]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "4f400008"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 8, 81]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "50480008"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 9, 82]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "51400009"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 9, 83]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "52480009"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 10, 84]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "5340000a"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 10, 85]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "5448000a"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 11, 86]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "5540000b"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 11, 87]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "5648000b"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 12, 88]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "5740000c"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 12, 89]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "5848000c"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 13, 90]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "5940000d"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 13, 91]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "5a48000d"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 14, 92]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "5b40000e"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 14, 93]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "5c48000e"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 15, 94]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "5d40000f"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 15, 95]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "5e48000f"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 16, 96]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "5f400010"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 16, 97]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "60480010"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 17, 98]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "61400011"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 17, 99]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "62480011"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 18, 100]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "63400012"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 18, 101]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "64480012"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 19, 102]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "65400013"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 19, 103]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "66480013"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 20, 104]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "67400014"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 20, 105]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "68480014"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 21, 106]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "69400015"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 21, 107]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "6a480015"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 22, 108]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "6b400016"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 22, 109]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "6c480016"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 23, 110]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "6d400017"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 23, 111]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "6e480017"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 24, 112]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "6f400018"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 24, 113]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "70480018"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 25, 114]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "71400019"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 25, 115]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "72480019"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 26, 116]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "7340001a"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 26, 117]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "7448001a"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 27, 118]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "7540001b"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 27, 119]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "7648001b"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 28, 120]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "7740001c"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 28, 121]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "7848001c"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 29, 122]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "7940001d"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 29, 123]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "7a48001d"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 30, 124]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "7b40001e"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 30, 125]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "7c48001e"}}
-{"method": "exchange", "async": true, "args": [[64, 0, 31, 126]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "7d40001f"}}
-{"method": "exchange", "async": true, "args": [[72, 0, 31, 127]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "7e48001f"}}
-{"method": "exchange", "async": true, "args": [[76, 0, 64, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "7f4c0040"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
-{"method": "exchange", "async": true, "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 1, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 1, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 2, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 2, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 3, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 3, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 4, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 4, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 5, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 5, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 6, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 6, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 7, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 7, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 8, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 8, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 9, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 9, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 10, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 10, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 11, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 11, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 12, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 12, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 13, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 13, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 14, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 14, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 15, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 15, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 16, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 16, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 17, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 17, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 18, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 18, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 19, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 19, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 20, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 20, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 21, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 21, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 22, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 22, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 23, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 23, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 24, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 24, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 25, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 25, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 26, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 26, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 27, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 27, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 28, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 28, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 29, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 29, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 30, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 30, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 31, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 31, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 32, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200000"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 32, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280001"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 33, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200002"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 33, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280003"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 34, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200004"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 34, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280005"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 35, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200006"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 35, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280007"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 36, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200008"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 36, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280009"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 37, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020000a"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 37, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028000b"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 38, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020000c"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 38, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028000d"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 39, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020000e"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 39, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028000f"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 40, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200010"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 40, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280011"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 41, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200012"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 41, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280013"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 42, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200014"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 42, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280015"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 43, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200016"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 43, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280017"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 44, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200018"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 44, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280019"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 45, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020001a"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 45, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028001b"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 46, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020001c"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 46, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028001d"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 47, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020001e"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 47, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028001f"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 48, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200020"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 48, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280021"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 49, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200022"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 49, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280023"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 50, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200024"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 50, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280025"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 51, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200026"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 51, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280027"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 52, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200028"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 52, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280029"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 53, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020002a"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 53, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028002b"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 54, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020002c"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 54, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028002d"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 55, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020002e"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 55, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028002f"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 56, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200030"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 56, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280031"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 57, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200032"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 57, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280033"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 58, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200034"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 58, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280035"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 59, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200036"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 59, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280037"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 60, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200038"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 60, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280039"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 61, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020003a"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 61, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028003b"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 62, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020003c"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 62, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028003d"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 63, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020003e"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 63, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028003f"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 64, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200040"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 64, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280041"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 65, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200042"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 65, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280043"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 66, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200044"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 66, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280045"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 67, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200046"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 67, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280047"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 68, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200048"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 68, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280049"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 69, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020004a"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 69, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028004b"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 70, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020004c"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 70, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028004d"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 71, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020004e"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 71, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028004f"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 72, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200050"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 72, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280051"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 73, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200052"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 73, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280053"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 74, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200054"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 74, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280055"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 75, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200056"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 75, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280057"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 76, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200058"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 76, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280059"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 77, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020005a"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 77, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028005b"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 78, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020005c"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 78, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028005d"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 79, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020005e"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 79, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028005f"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 80, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200060"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 80, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280061"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 81, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200062"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 81, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280063"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 82, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200064"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 82, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280065"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 83, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200066"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 83, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280067"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 84, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200068"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 84, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280069"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 85, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020006a"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 85, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028006b"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 86, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020006c"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 86, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028006d"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 87, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020006e"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 87, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028006f"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 88, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200070"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 88, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280071"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 89, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200072"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 89, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280073"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 90, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200074"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 90, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280075"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 91, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200076"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 91, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280077"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 92, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200078"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 92, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280079"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 93, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020007a"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 93, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028007b"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 94, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020007c"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 94, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028007d"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 95, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020007e"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 95, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028007f"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 96, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 96, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 97, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 97, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 98, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 98, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 99, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 99, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 100, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 100, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 101, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 101, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 102, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 102, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 103, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 103, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 104, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 104, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 105, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 105, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 106, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 106, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 107, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 107, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 108, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 108, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 109, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 109, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 110, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 110, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 111, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 111, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 112, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 112, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 113, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 113, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 114, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 114, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 115, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 115, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 116, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 116, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 117, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 117, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 118, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 118, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 119, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 119, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 120, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 120, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 121, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 121, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 122, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 122, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 123, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 123, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 124, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 124, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 125, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 125, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 126, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 126, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
-{"method": "exchange", "async": true, "args": [[32, 0, 127, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
-{"method": "exchange", "async": true, "args": [[40, 0, 127, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[172, 128, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00ac8000"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 32, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00400020"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 32, 1]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00480020"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 33, 2]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "01400021"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 33, 3]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "02480021"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 34, 4]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "03400022"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 34, 5]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "04480022"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 35, 6]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "05400023"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 35, 7]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "06480023"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 36, 8]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "07400024"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 36, 9]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "08480024"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 37, 10]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "09400025"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 37, 11]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0a480025"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 38, 12]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0b400026"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 38, 13]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0c480026"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 39, 14]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0d400027"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 39, 15]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0e480027"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 40, 16]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0f400028"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 40, 17]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "10480028"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 41, 18]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "11400029"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 41, 19]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "12480029"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 42, 20]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "1340002a"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 42, 21]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "1448002a"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 43, 22]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "1540002b"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 43, 23]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "1648002b"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 44, 24]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "1740002c"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 44, 25]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "1848002c"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 45, 26]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "1940002d"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 45, 27]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "1a48002d"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 46, 28]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "1b40002e"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 46, 29]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "1c48002e"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 47, 30]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "1d40002f"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 47, 31]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "1e48002f"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 48, 32]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "1f400030"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 48, 33]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "20480030"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 49, 34]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "21400031"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 49, 35]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "22480031"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 50, 36]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "23400032"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 50, 37]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "24480032"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 51, 38]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "25400033"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 51, 39]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "26480033"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 52, 40]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "27400034"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 52, 41]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "28480034"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 53, 42]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "29400035"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 53, 43]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "2a480035"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 54, 44]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "2b400036"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 54, 45]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "2c480036"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 55, 46]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "2d400037"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 55, 47]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "2e480037"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 56, 48]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "2f400038"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 56, 49]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "30480038"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 57, 50]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "31400039"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 57, 51]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "32480039"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 58, 52]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "3340003a"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 58, 53]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "3448003a"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 59, 54]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "3540003b"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 59, 55]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "3648003b"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 60, 56]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "3740003c"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 60, 57]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "3848003c"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 61, 58]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "3940003d"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 61, 59]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "3a48003d"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 62, 60]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "3b40003e"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 62, 61]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "3c48003e"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 63, 62]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "3d40003f"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 63, 63]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "3e48003f"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[77, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00000000"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[76, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "3f4c0000"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 0, 64]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00400000"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 0, 65]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "40480000"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 1, 66]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "41400001"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 1, 67]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "42480001"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 2, 68]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "43400002"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 2, 69]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "44480002"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 3, 70]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "45400003"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 3, 71]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "46480003"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 4, 72]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "47400004"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 4, 73]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "48480004"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 5, 74]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "49400005"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 5, 75]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "4a480005"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 6, 76]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "4b400006"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 6, 77]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "4c480006"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 7, 78]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "4d400007"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 7, 79]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "4e480007"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 8, 80]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "4f400008"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 8, 81]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "50480008"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 9, 82]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "51400009"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 9, 83]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "52480009"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 10, 84]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "5340000a"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 10, 85]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "5448000a"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 11, 86]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "5540000b"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 11, 87]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "5648000b"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 12, 88]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "5740000c"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 12, 89]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "5848000c"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 13, 90]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "5940000d"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 13, 91]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "5a48000d"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 14, 92]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "5b40000e"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 14, 93]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "5c48000e"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 15, 94]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "5d40000f"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 15, 95]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "5e48000f"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 16, 96]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "5f400010"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 16, 97]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "60480010"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 17, 98]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "61400011"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 17, 99]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "62480011"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 18, 100]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "63400012"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 18, 101]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "64480012"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 19, 102]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "65400013"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 19, 103]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "66480013"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 20, 104]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "67400014"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 20, 105]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "68480014"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 21, 106]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "69400015"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 21, 107]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "6a480015"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 22, 108]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "6b400016"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 22, 109]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "6c480016"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 23, 110]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "6d400017"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 23, 111]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "6e480017"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 24, 112]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "6f400018"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 24, 113]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "70480018"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 25, 114]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "71400019"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 25, 115]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "72480019"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 26, 116]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "7340001a"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 26, 117]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "7448001a"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 27, 118]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "7540001b"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 27, 119]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "7648001b"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 28, 120]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "7740001c"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 28, 121]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "7848001c"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 29, 122]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "7940001d"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 29, 123]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "7a48001d"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 30, 124]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "7b40001e"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 30, 125]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "7c48001e"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[64, 0, 31, 126]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "7d40001f"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[72, 0, 31, 127]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "7e48001f"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[76, 0, 64, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "7f4c0040"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[240, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00f000fe"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 1, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 1, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 2, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 2, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 3, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 3, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 4, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 4, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 5, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 5, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 6, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 6, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 7, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 7, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 8, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 8, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 9, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 9, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 10, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 10, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 11, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 11, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 12, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 12, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 13, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 13, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 14, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 14, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 15, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 15, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 16, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 16, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 17, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 17, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 18, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 18, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 19, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 19, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 20, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 20, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 21, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 21, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 22, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 22, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 23, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 23, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 24, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 24, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 25, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 25, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 26, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 26, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 27, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 27, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 28, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 28, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 29, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 29, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 30, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 30, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 31, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 31, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 32, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200000"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 32, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280001"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 33, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200002"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 33, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280003"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 34, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200004"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 34, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280005"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 35, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200006"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 35, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280007"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 36, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200008"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 36, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280009"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 37, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020000a"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 37, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028000b"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 38, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020000c"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 38, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028000d"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 39, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020000e"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 39, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028000f"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 40, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200010"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 40, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280011"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 41, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200012"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 41, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280013"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 42, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200014"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 42, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280015"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 43, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200016"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 43, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280017"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 44, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200018"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 44, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280019"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 45, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020001a"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 45, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028001b"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 46, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020001c"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 46, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028001d"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 47, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020001e"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 47, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028001f"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 48, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200020"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 48, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280021"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 49, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200022"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 49, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280023"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 50, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200024"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 50, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280025"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 51, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200026"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 51, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280027"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 52, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200028"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 52, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280029"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 53, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020002a"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 53, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028002b"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 54, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020002c"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 54, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028002d"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 55, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020002e"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 55, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028002f"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 56, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200030"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 56, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280031"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 57, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200032"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 57, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280033"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 58, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200034"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 58, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280035"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 59, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200036"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 59, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280037"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 60, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200038"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 60, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280039"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 61, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020003a"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 61, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028003b"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 62, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020003c"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 62, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028003d"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 63, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020003e"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 63, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028003f"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 64, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200040"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 64, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280041"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 65, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200042"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 65, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280043"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 66, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200044"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 66, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280045"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 67, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200046"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 67, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280047"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 68, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200048"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 68, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280049"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 69, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020004a"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 69, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028004b"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 70, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020004c"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 70, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028004d"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 71, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020004e"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 71, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028004f"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 72, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200050"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 72, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280051"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 73, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200052"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 73, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280053"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 74, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200054"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 74, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280055"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 75, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200056"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 75, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280057"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 76, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200058"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 76, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280059"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 77, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020005a"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 77, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028005b"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 78, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020005c"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 78, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028005d"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 79, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020005e"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 79, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028005f"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 80, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200060"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 80, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280061"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 81, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200062"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 81, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280063"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 82, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200064"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 82, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280065"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 83, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200066"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 83, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280067"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 84, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200068"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 84, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280069"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 85, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020006a"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 85, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028006b"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 86, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020006c"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 86, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028006d"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 87, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020006e"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 87, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028006f"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 88, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200070"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 88, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280071"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 89, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200072"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 89, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280073"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 90, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200074"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 90, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280075"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 91, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200076"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 91, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280077"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 92, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00200078"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 92, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00280079"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 93, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020007a"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 93, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028007b"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 94, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020007c"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 94, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028007d"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 95, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0020007e"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 95, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0028007f"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 96, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 96, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 97, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 97, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 98, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 98, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 99, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 99, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 100, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 100, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 101, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 101, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 102, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 102, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 103, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 103, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 104, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 104, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 105, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 105, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 106, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 106, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 107, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 107, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 108, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 108, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 109, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 109, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 110, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 110, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 111, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 111, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 112, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 112, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 113, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 113, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 114, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 114, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 115, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 115, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 116, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 116, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 117, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 117, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 118, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 118, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 119, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 119, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 120, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 120, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 121, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 121, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 122, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 122, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 123, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 123, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 124, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 124, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 125, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 125, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 126, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 126, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[32, 0, 127, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002000ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[40, 0, 127, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "002800ff"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}

--- a/software/glasgow/applet/program/avr/spi/fixtures/test_api_signature.json
+++ b/software/glasgow/applet/program/avr/spi/fixtures/test_api_signature.json
@@ -1,3 +1,9 @@
-{"method": "exchange", "async": true, "args": [[48, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0030001e"}}
-{"method": "exchange", "async": true, "args": [[48, 0, 1, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00300095"}}
-{"method": "exchange", "async": true, "args": [[48, 0, 2, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00300087"}}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[48, 0, 0, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "0030001e"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[48, 0, 1, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00300095"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}
+{"call": "select", "kind": "asynccontext.enter", "args": [], "kwargs": {}, "result": null}
+{"call": "exchange", "kind": "asyncmethod", "args": [[48, 0, 2, 0]], "kwargs": {}, "result": {"__class__": "bytes", "hex": "00300087"}}
+{"call": "select", "kind": "asynccontext.exit", "args": [null], "kwargs": {}, "result": null}


### PR DESCRIPTION
Even though there is no CS line for AVR programming, SPI controller requires the device to be selected before exchanging data.