### PR TITLE
Fix non-virtualenv installations with YoWASP on Windows

### DIFF
--- a/software/glasgow/hardware/build_plan.py
+++ b/software/glasgow/hardware/build_plan.py
@@ -69,7 +69,8 @@ class GlasgowBuildPlan:
                 # Windows has some environment variables that are required by the OS runtime:
                 # - SYSTEMROOT: required for child Python processes to initialize properly
                 # - PROCESSOR_ARCHITECTURE: required for YoWASP (used by wasmtime)
-                for var in ("PROCESSOR_ARCHITECTURE", "SYSTEMROOT"):
+                # - APPDATA: required for YoWASP (used by pip executable stub)
+                for var in ("PROCESSOR_ARCHITECTURE", "SYSTEMROOT", "APPDATA"):
                     environ[var] = os.environ[var]
 
             # collect stdout (so that it can be reproduced if a log for a cached bitstream is

--- a/software/glasgow/hardware/toolchain.py
+++ b/software/glasgow/hardware/toolchain.py
@@ -105,7 +105,17 @@ class WasmTool(Tool):
             # will not be true when Glasgow is running from a pipx virtual environment (which isn't
             # activated when the `glasgow` script is run). Also, our build environment does not
             # even *have* PATH.
-            return os.path.join(sysconfig.get_path('scripts'), basename)
+            match os.name:
+                case "nt":
+                    schemes = ["nt_venv", "nt_user", "nt"]
+                case "posix":
+                    schemes = ["posix_venv", "posix_user", "posix_home", "posix_prefix"]
+            for scheme in schemes:
+                script_path  = os.path.join(sysconfig.get_path("scripts", scheme), basename)
+                script_path += sysconfig.get_config_var('EXE')
+                if os.path.exists(script_path):
+                    return script_path
+            raise FileNotFoundError(f"script {basename!r} not found; this is an issue with your installation")
 
     @property
     def version(self):


### PR DESCRIPTION
Before this commit, the toolchain module would attempt to run a stub script (`yowasp-yosys.exe`) from the directory where Python is installed (`C:\Program Files\something` usually), but that's not user-writable, and the script is usually in `%APPDATA%`.

After this commit, we check several paths (from most to least specific). We do not check `PATH` at all since our sandbox does not include `PATH`. It would be ideal to use the path from which the `glasgow[.exe]` stub script was run, but since you can use `python -m glasgow` this isn't feasible. ~~It would also work to execute `python -m yowasp_yosys` but this requires a greater restructuring of the toolchain functionality and I'm not sure it's worth it.~~ It would make it impossible to use with `amaranth.build.BuildPlan.execute_local` since it expects a single path (which it quotes) and not a command chunk.