### PR TITLE
SPI controller: migrate to V2 API

### DIFF
--- a/docs/manual/src/applets/interface/index.rst
+++ b/docs/manual/src/applets/interface/index.rst
@@ -10,6 +10,7 @@ I/O interfaces
 
     uart
     uart_analyzer
+    spi_controller
     spi_analyzer
     qspi_controller
     qspi_analyzer

--- a/docs/manual/src/applets/interface/spi_controller.rst
+++ b/docs/manual/src/applets/interface/spi_controller.rst
@@ -1,0 +1,7 @@
+``spi-controller``
+==================
+
+.. _applet.interface.spi_controller:
+
+.. autoprogram:: glasgow.applet.interface.spi_controller:SPIControllerApplet._get_argparser_for_sphinx("spi-controller")
+    :prog: glasgow run spi-controller

--- a/software/glasgow/applet/display/pdi/__init__.py
+++ b/software/glasgow/applet/display/pdi/__init__.py
@@ -65,7 +65,7 @@ from glasgow.support.bits import bitarray
 from amaranth import *
 from amaranth.lib import io
 
-from ...interface.spi_controller import SPIControllerSubtarget, SPIControllerInterface
+from ...interface.spi_controller_deprecated import SPIControllerSubtarget, SPIControllerInterface
 from ... import *
 
 

--- a/software/glasgow/applet/interface/qspi_controller/__init__.py
+++ b/software/glasgow/applet/interface/qspi_controller/__init__.py
@@ -201,7 +201,7 @@ class QSPIControllerInterface:
                 (QSPICommand.Transfer.value << 4) | mode.value, len(chunk)))
             await self._pipe.send(chunk)
 
-    async def read(self, count, *, x: Literal[1, 2, 4] = 1):
+    async def read(self, count: int, *, x: Literal[1, 2, 4] = 1) -> memoryview:
         assert self._active is not None, "no chip selected"
         mode = {1: qspi.Mode.GetX1, 2: qspi.Mode.GetX2, 4: qspi.Mode.GetX4}[x]
         for chunk in self._chunked(range(count)):
@@ -267,10 +267,10 @@ class QSPIControllerApplet(GlasgowAppletV2):
     @classmethod
     def add_build_arguments(cls, parser, access):
         access.add_voltage_argument(parser)
-        access.add_pins_argument(parser, "sck", default=True)
-        access.add_pins_argument(parser, "io",  default=True, width=4,
+        access.add_pins_argument(parser, "sck", default=True, required=True)
+        access.add_pins_argument(parser, "io",  default=True, required=True, width=4,
             help="bind the applet I/O lines 'copi', 'cipo', 'io2', 'io3' to PINS")
-        access.add_pins_argument(parser, "cs",  default=True)
+        access.add_pins_argument(parser, "cs",  default=True, required=True)
 
     def build(self, args):
         with self.assembly.add_applet(self):

--- a/software/glasgow/applet/interface/spi_controller/test.py
+++ b/software/glasgow/applet/interface/spi_controller/test.py
@@ -1,34 +1,26 @@
-import types
 from amaranth import *
-from amaranth.lib import io
 
-from ... import *
+from glasgow.applet import GlasgowAppletV2TestCase, synthesis_test, applet_v2_simulation_test
 from . import SPIControllerApplet
 
 
-class SPIControllerAppletTestCase(GlasgowAppletTestCase, applet=SPIControllerApplet):
+class SPIControllerAppletTestCase(GlasgowAppletV2TestCase, applet=SPIControllerApplet):
     @synthesis_test
     def test_build(self):
-        self.assertBuilds(args=["--sck",  "A0", "--cs",   "A1",
-                                "--copi", "A2", "--cipo", "A3"])
+        self.assertBuilds()
 
-    def setup_loopback(self, target, parsed_args):
-        self.applet.build(target, parsed_args)
-        target.assembly.connect_pins("A2", "A3")
+    def setup_loopback(self, assembly):
+        assembly.connect_pins("A2", "A3")
 
-    @applet_simulation_test("setup_loopback",
-                            ["--sck",  "A0", "--cs",   "A1",
-                             "--copi", "A2", "--cipo", "A3",
-                             "--frequency", "10"])
-    async def test_loopback(self, device, parsed_args, ctx):
-        spi_iface = await self.applet.run(device, parsed_args)
-
-        cs = device.assembly.get_pin("A1")
+    @applet_v2_simulation_test(prepare=setup_loopback,
+                               args=["--sck",  "A0", "--cs",   "A1",
+                                     "--copi", "A2", "--cipo", "A3"])
+    async def test_loopback(self, applet, ctx):
+        cs = applet.assembly.get_pin("A1")
         self.assertEqual(ctx.get(cs.o), 1)
-        async with spi_iface.select():
-            await ctx.tick().repeat(2)
+        async with applet.spi_iface.select():
+            result = await applet.spi_iface.exchange([0xAA, 0x55, 0x12, 0x34])
             self.assertEqual(ctx.get(cs.o), 0)
-            result = await spi_iface.exchange([0xAA, 0x55, 0x12, 0x34])
             self.assertEqual(result, bytearray([0xAA, 0x55, 0x12, 0x34]))
         await ctx.tick()
         self.assertEqual(ctx.get(cs.o), 1)

--- a/software/glasgow/applet/interface/spi_controller_deprecated/__init__.py
+++ b/software/glasgow/applet/interface/spi_controller_deprecated/__init__.py
@@ -1,0 +1,393 @@
+import math
+import struct
+import logging
+import contextlib
+from amaranth import *
+from amaranth.lib import io
+from amaranth.lib.cdc import FFSynchronizer
+
+from ....support.logging import *
+from ....gateware.clockgen import *
+from ... import *
+
+
+class SPIControllerBus(Elaboratable):
+    def __init__(self, ports, sck_idle, sck_edge):
+        self.ports = ports
+        self.sck_idle = sck_idle
+        self.sck_edge = sck_edge
+
+        self.oe   = Signal(init=1)
+
+        self.sck  = Signal(init=sck_idle)
+        self.cs   = Signal()
+        self.copi = Signal()
+        self.cipo = Signal()
+
+        self.setup = Signal()
+        self.latch = Signal()
+
+    def elaborate(self, platform):
+        m = Module()
+
+        m.submodules.sck_buffer = sck_buffer = io.Buffer("o", self.ports.sck)
+
+        m.d.comb += [
+            sck_buffer.oe.eq(self.oe),
+            sck_buffer.o.eq(self.sck),
+        ]
+
+        if hasattr(self.ports, "cs"):
+            if self.ports.cs is not None:
+                m.submodules.cs_buffer = cs_buffer = io.Buffer("o", self.ports.cs)
+                m.d.comb += cs_buffer.o.eq(~self.cs),
+
+        if hasattr(self.ports, "copi"):
+            if self.ports.copi is not None:
+                m.submodules.copi_buffer = copi_buffer = io.Buffer("o", self.ports.copi)
+                m.d.comb += [
+                    copi_buffer.oe.eq(self.oe),
+                    copi_buffer.o.eq(self.copi)
+                ]
+
+        if hasattr(self.ports, "cipo"):
+            if self.ports.cipo is not None:
+                m.submodules.cipo_buffer = cipo_buffer = io.Buffer("i", self.ports.cipo)
+                m.submodules += FFSynchronizer(cipo_buffer.i, self.cipo)
+
+        sck_r = Signal()
+        m.d.sync += sck_r.eq(self.sck)
+
+        if self.sck_edge in ("r", "rising"):
+            m.d.comb += [
+                self.setup.eq( sck_r & ~self.sck),
+                self.latch.eq(~sck_r &  self.sck),
+            ]
+        elif self.sck_edge in ("f", "falling"):
+            m.d.comb += [
+                self.setup.eq(~sck_r &  self.sck),
+                self.latch.eq( sck_r & ~self.sck),
+            ]
+        else:
+            assert False
+
+        return m
+
+
+CMD_MASK     = 0b11110000
+CMD_SELECT   = 0b00000000
+CMD_SHIFT    = 0b00010000
+CMD_DELAY    = 0b00100000
+CMD_SYNC     = 0b00110000
+# CMD_SHIFT
+BIT_DATA_OUT =     0b0001
+BIT_DATA_IN  =     0b0010
+
+
+class SPIControllerSubtarget(Elaboratable):
+    def __init__(self, ports, out_fifo, in_fifo, period_cyc, delay_cyc,
+                 sck_idle, sck_edge):
+        self.ports = ports
+        self.out_fifo = out_fifo
+        self.in_fifo = in_fifo
+        self.period_cyc = period_cyc
+        self.delay_cyc = delay_cyc
+
+        self.bus = SPIControllerBus(ports, sck_idle, sck_edge)
+
+    def elaborate(self, platform):
+        m = Module()
+
+        m.submodules.bus = self.bus
+
+        ###
+
+        clkgen_reset = Signal()
+        m.submodules.clkgen = clkgen = ResetInserter(clkgen_reset)(ClockGen(self.period_cyc))
+
+        timer    = Signal(range(self.delay_cyc))
+        timer_en = Signal()
+
+        with m.If(timer != 0):
+            m.d.sync += timer.eq(timer - 1)
+        with m.Elif(timer_en):
+            m.d.sync += timer.eq(self.delay_cyc - 1)
+
+        shreg_o = Signal(8)
+        shreg_i = Signal(8)
+        m.d.comb += [
+            self.bus.sck.eq(clkgen.clk),
+            self.bus.copi.eq(shreg_o[-1]),
+        ]
+
+        with m.If(self.bus.setup):
+            m.d.sync += shreg_o.eq(Cat(C(0, 1), shreg_o))
+        with m.Elif(self.bus.latch):
+            m.d.sync += shreg_i.eq(Cat(self.bus.cipo, shreg_i))
+
+        cmd   = Signal(8)
+        count = Signal(16)
+        bitno = Signal(range(8 + 1))
+
+        with m.FSM() as fsm:
+            with m.State("RECV-COMMAND"):
+                m.d.comb += self.in_fifo.flush.eq(1)
+                with m.If(self.out_fifo.r_rdy):
+                    m.d.comb += self.out_fifo.r_en.eq(1)
+                    m.d.sync += cmd.eq(self.out_fifo.r_data)
+                    with m.If((self.out_fifo.r_data & CMD_MASK) == CMD_SELECT):
+                        m.d.sync += self.bus.cs.eq(self.out_fifo.r_data[0])
+                    with m.Elif((self.out_fifo.r_data & CMD_MASK) == CMD_SYNC):
+                        m.next = "SYNC"
+                    with m.Else():
+                        m.next = "RECV-COUNT-1"
+
+            with m.State("SYNC"):
+                with m.If(self.in_fifo.w_rdy):
+                    m.d.comb += [
+                        self.in_fifo.w_en.eq(1),
+                        self.in_fifo.w_data.eq(0),
+                    ]
+                    m.next = "RECV-COMMAND"
+
+            with m.State("RECV-COUNT-1"):
+                with m.If(self.out_fifo.r_rdy):
+                    m.d.comb += self.out_fifo.r_en.eq(1)
+                    m.d.sync += count[0:8].eq(self.out_fifo.r_data)
+                    m.next = "RECV-COUNT-2"
+
+            with m.State("RECV-COUNT-2"):
+                with m.If(self.out_fifo.r_rdy):
+                    m.d.comb += self.out_fifo.r_en.eq(1)
+                    m.d.sync += count[8:16].eq(self.out_fifo.r_data)
+                    with m.If((cmd & CMD_MASK) == CMD_DELAY):
+                        m.next = "DELAY"
+                    with m.Else():
+                        m.next = "COUNT-CHECK"
+
+            with m.State("DELAY"):
+                with m.If(timer == 0):
+                    with m.If(count == 0):
+                        m.next = "RECV-COMMAND"
+                    with m.Else():
+                        m.d.sync += count.eq(count - 1)
+                        m.d.comb += timer_en.eq(1)
+
+            with m.State("COUNT-CHECK"):
+                with m.If(count == 0):
+                    m.next = "RECV-COMMAND"
+                with m.Else():
+                    m.next = "RECV-DATA"
+
+            with m.State("RECV-DATA"):
+                with m.If((cmd & BIT_DATA_OUT) != 0):
+                    m.d.comb += self.out_fifo.r_en.eq(1)
+                    m.d.sync += shreg_o.eq(self.out_fifo.r_data)
+                with m.Else():
+                    m.d.sync += shreg_o.eq(0)
+
+                with m.If(((cmd & BIT_DATA_IN) != 0) | self.out_fifo.r_rdy):
+                    m.d.sync += [
+                        count.eq(count - 1),
+                        bitno.eq(8),
+                    ]
+                    m.next = "TRANSFER"
+
+            m.d.comb += clkgen_reset.eq(~fsm.ongoing("TRANSFER"))
+            with m.State("TRANSFER"):
+                with m.If(clkgen.stb_r):
+                    m.d.sync += bitno.eq(bitno - 1)
+                with m.Elif(clkgen.stb_f):
+                    with m.If(bitno == 0):
+                        m.next = "SEND-DATA"
+
+            with m.State("SEND-DATA"):
+                with m.If((cmd & BIT_DATA_IN) != 0):
+                    m.d.comb += [
+                        self.in_fifo.w_data.eq(shreg_i),
+                        self.in_fifo.w_en.eq(1),
+                    ]
+
+                with m.If(((cmd & BIT_DATA_OUT) != 0) | self.in_fifo.w_rdy):
+                    with m.If(count == 0):
+                        m.next = "RECV-COMMAND"
+                    with m.Else():
+                        m.next = "RECV-DATA"
+
+        return m
+
+
+class SPIControllerInterface:
+    def __init__(self, interface, logger):
+        self.lower   = interface
+        self._logger = logger
+        self._level  = logging.DEBUG if self._logger.name == __name__ else logging.TRACE
+        self._active = None
+
+    def _log(self, message, *args):
+        self._logger.log(self._level, "SPI: " + message, *args)
+
+    async def reset(self):
+        self._log("reset")
+        await self.lower.reset()
+
+    @staticmethod
+    def _chunked(items, *, count=0xffff):
+        while items:
+            yield items[:count]
+            items = items[count:]
+
+    @contextlib.asynccontextmanager
+    async def select(self, index=0):
+        assert self._active is None, "chip already selected"
+        assert index == 0, "only one chip is supported"
+        try:
+            self._log("select chip=%d", index)
+            await self.lower.write(struct.pack("<B",
+                CMD_SELECT|(1 + index)))
+            self._active = index
+            yield
+        finally:
+            self._log("deselect")
+            await self.lower.write(struct.pack("<B",
+                CMD_SELECT|0))
+            await self.lower.flush()
+            self._active = None
+
+    async def exchange(self, octets):
+        assert self._active is not None, "no chip selected"
+        self._log("xchg-o=<%s>", dump_hex(octets))
+        for chunk in self._chunked(octets):
+            await self.lower.write(struct.pack("<BH",
+                CMD_SHIFT|BIT_DATA_IN|BIT_DATA_OUT, len(chunk)))
+            await self.lower.write(chunk)
+        octets = await self.lower.read(len(octets))
+        self._log("xchg-i=<%s>", dump_hex(octets))
+        return octets
+
+    async def write(self, octets, *, x=1):
+        assert self._active is not None, "no chip selected"
+        assert x == 1, "only x1 mode is supported"
+        self._log("write=<%s>", dump_hex(octets))
+        for chunk in self._chunked(octets):
+            await self.lower.write(struct.pack("<BH",
+                CMD_SHIFT|BIT_DATA_OUT, len(chunk)))
+            await self.lower.write(chunk)
+
+    async def read(self, count, *, x=1):
+        assert self._active is not None, "no chip selected"
+        assert x == 1, "only x1 mode is supported"
+        for chunk in self._chunked(range(count)):
+            await self.lower.write(struct.pack("<BH",
+                CMD_SHIFT|BIT_DATA_IN, len(chunk)))
+        octets = await self.lower.read(count)
+        self._log("read=<%s>", dump_hex(octets))
+        return octets
+
+    async def dummy(self, count):
+        # We intentionally allow sending dummy cycles with no chip selected.
+        self._log("dummy=%d", count)
+        for chunk in self._chunked(range(count)):
+            assert count % 8 == 0, "only multiples of 8 dummy cycles are supported"
+            await self.lower.write(struct.pack("<BH",
+                CMD_SHIFT, len(chunk) // 8))
+
+    async def delay_us(self, duration):
+        self._log("delay us=%d", duration)
+        for chunk in self._chunked(range(duration)):
+            await self.lower.write(struct.pack("<BH",
+                CMD_DELAY, len(chunk)))
+
+    async def delay_ms(self, duration):
+        self._log("delay ms=%d", duration)
+        for chunk in self._chunked(range(duration * 1000)):
+            await self.lower.write(struct.pack("<BH",
+                CMD_DELAY, len(chunk)))
+
+    async def synchronize(self):
+        self._log("sync-o")
+        await self.lower.write([CMD_SYNC])
+        await self.lower.read(1)
+        self._log("sync-i")
+
+
+class SPIControllerApplet(GlasgowApplet):
+    logger = logging.getLogger(__name__)
+    help = "initiate SPI transactions"
+    description = """
+    Initiate transactions on the SPI bus.
+    """
+
+    @classmethod
+    def add_build_arguments(cls, parser, access, omit_pins=False):
+        super().add_build_arguments(parser, access)
+
+        if not omit_pins:
+            access.add_pins_argument(parser, "sck", required=True)
+            access.add_pins_argument(parser, "cs")
+            access.add_pins_argument(parser, "copi")
+            access.add_pins_argument(parser, "cipo")
+
+        parser.add_argument(
+            "-f", "--frequency", metavar="FREQ", type=int, default=100,
+            help="set SPI clock frequency to FREQ kHz (default: %(default)s)")
+        parser.add_argument(
+            "--sck-idle", metavar="LEVEL", type=int, choices=[0, 1], default=0,
+            help="set idle clock level to LEVEL (default: %(default)s)")
+        parser.add_argument(
+            "--sck-edge", metavar="EDGE", type=str, choices=["r", "rising", "f", "falling"],
+            default="rising",
+            help="latch data at clock edge EDGE (default: %(default)s)")
+
+    def build_subtarget(self, target, args):
+        iface = self.mux_interface
+        return SPIControllerSubtarget(
+            ports=iface.get_port_group(
+                sck  = args.sck,
+                cs   = args.cs if hasattr(args, "cs") else None,
+                copi = args.copi if hasattr(args, "copi") else None,
+                cipo = args.cipo if hasattr(args, "cipo") else None
+            ),
+            out_fifo=iface.get_out_fifo(),
+            in_fifo=iface.get_in_fifo(auto_flush=False),
+            period_cyc=self.derive_clock(input_hz=target.sys_clk_freq,
+                                         output_hz=args.frequency * 1000,
+                                         clock_name="sck",
+                                         # 2 cyc MultiReg delay from SCK to CIPO requires a 4 cyc
+                                         # period with current implementation of SERDES
+                                         min_cyc=4),
+            delay_cyc=self.derive_clock(input_hz=target.sys_clk_freq,
+                                        output_hz=1e6,
+                                        clock_name="delay"),
+            sck_idle=args.sck_idle,
+            sck_edge=args.sck_edge,
+        )
+
+    def build(self, target, args):
+        self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
+        controller = self.build_subtarget(target, args)
+        return iface.add_subtarget(controller)
+
+    async def run(self, device, args):
+        iface = await device.demultiplexer.claim_interface(self, self.mux_interface, args)
+        spi_iface = SPIControllerInterface(iface, self.logger)
+        return spi_iface
+
+    @classmethod
+    def add_interact_arguments(cls, parser):
+        def hex(arg): return bytes.fromhex(arg)
+
+        parser.add_argument(
+            "data", metavar="DATA", type=hex, nargs="+",
+            help="hex bytes to exchange with the device")
+
+    async def interact(self, device, args, spi_iface):
+        for octets in args.data:
+            async with spi_iface.select():
+                octets = await spi_iface.exchange(octets)
+            print(octets.hex())
+
+    @classmethod
+    def tests(cls):
+        from . import test
+        return test.SPIControllerAppletTestCase

--- a/software/glasgow/applet/interface/spi_controller_deprecated/test.py
+++ b/software/glasgow/applet/interface/spi_controller_deprecated/test.py
@@ -1,0 +1,34 @@
+import types
+from amaranth import *
+from amaranth.lib import io
+
+from ... import *
+from . import SPIControllerApplet
+
+
+class SPIControllerAppletTestCase(GlasgowAppletTestCase, applet=SPIControllerApplet):
+    @synthesis_test
+    def test_build(self):
+        self.assertBuilds(args=["--sck",  "A0", "--cs",   "A1",
+                                "--copi", "A2", "--cipo", "A3"])
+
+    def setup_loopback(self, target, parsed_args):
+        self.applet.build(target, parsed_args)
+        target.assembly.connect_pins("A2", "A3")
+
+    @applet_simulation_test("setup_loopback",
+                            ["--sck",  "A0", "--cs",   "A1",
+                             "--copi", "A2", "--cipo", "A3",
+                             "--frequency", "10"])
+    async def test_loopback(self, device, parsed_args, ctx):
+        spi_iface = await self.applet.run(device, parsed_args)
+
+        cs = device.assembly.get_pin("A1")
+        self.assertEqual(ctx.get(cs.o), 1)
+        async with spi_iface.select():
+            await ctx.tick().repeat(2)
+            self.assertEqual(ctx.get(cs.o), 0)
+            result = await spi_iface.exchange([0xAA, 0x55, 0x12, 0x34])
+            self.assertEqual(result, bytearray([0xAA, 0x55, 0x12, 0x34]))
+        await ctx.tick()
+        self.assertEqual(ctx.get(cs.o), 1)

--- a/software/glasgow/applet/interface/spi_flashrom/__init__.py
+++ b/software/glasgow/applet/interface/spi_flashrom/__init__.py
@@ -6,7 +6,7 @@ from amaranth.lib import io
 
 from ... import *
 from ....support.endpoint import *
-from ...interface.spi_controller import SPIControllerApplet
+from ...interface.spi_controller_deprecated import SPIControllerApplet
 
 
 class SPISerprogInterface:

--- a/software/glasgow/applet/program/avr/spi/__init__.py
+++ b/software/glasgow/applet/program/avr/spi/__init__.py
@@ -6,7 +6,7 @@ import logging
 from amaranth import *
 from amaranth.lib import io
 
-from ....interface.spi_controller import SPIControllerSubtarget, SPIControllerInterface
+from ....interface.spi_controller_deprecated import SPIControllerSubtarget, SPIControllerInterface
 from .... import *
 from .. import *
 

--- a/software/glasgow/applet/program/ice40_sram/__init__.py
+++ b/software/glasgow/applet/program/ice40_sram/__init__.py
@@ -8,7 +8,7 @@ import logging
 from amaranth import *
 from amaranth.lib import io
 
-from ...interface.spi_controller import SPIControllerApplet
+from ...interface.spi_controller_deprecated import SPIControllerApplet
 from ... import *
 
 

--- a/software/glasgow/applet/program/nrf24lx1/__init__.py
+++ b/software/glasgow/applet/program/nrf24lx1/__init__.py
@@ -13,7 +13,7 @@ from amaranth.lib import io
 from fx2.format import input_data, output_data
 
 from ....support.logging import dump_hex
-from ...interface.spi_controller import SPIControllerSubtarget, SPIControllerInterface
+from ...interface.spi_controller_deprecated import SPIControllerSubtarget, SPIControllerInterface
 from ... import *
 
 

--- a/software/glasgow/applet/radio/nrf24l01/__init__.py
+++ b/software/glasgow/applet/radio/nrf24l01/__init__.py
@@ -12,7 +12,7 @@ from ....support.logging import *
 from ....support.bits import *
 from ....arch.nrf24l import *
 from ....arch.nrf24l.rf import *
-from ...interface.spi_controller import SPIControllerSubtarget, SPIControllerInterface
+from ...interface.spi_controller_deprecated import SPIControllerSubtarget, SPIControllerInterface
 from ... import *
 
 

--- a/software/glasgow/gateware/spi.py
+++ b/software/glasgow/gateware/spi.py
@@ -1,0 +1,165 @@
+from amaranth import *
+from amaranth.lib import enum, data, wiring, stream, io
+from amaranth.lib.wiring import In, Out, connect, flipped
+
+from .ports import PortGroup
+from .iostream import IOStreamer
+
+
+__all__ = ["Mode", "Enframer", "Deframer", "Controller"]
+
+
+class Mode(enum.Enum, shape=2):
+    Dummy = 0
+    Put   = 1
+    Get   = 2
+    Swap  = 3
+
+
+class Sample(data.Struct):
+    mode: Mode
+    half: 1
+
+
+class Enframer(wiring.Component):
+    def __init__(self, ports, *, chip_count=None):
+        super().__init__({
+            "octets":  In(stream.Signature(data.StructLayout({
+                "chip": range(1 + (chip_count or len(ports.cs))),
+                "mode": Mode,
+                "data": 8,
+            }))),
+            "frames":  Out(IOStreamer.i_signature(ports, ratio=2, meta_layout=Sample)),
+            "divisor": In(16)
+        })
+
+    def elaborate(self, platform):
+        m = Module()
+
+        timer = Signal.like(self.divisor)
+        cycle = Signal(range(8))
+
+        for n in range(2):
+            m.d.comb += self.frames.p.port.cs.o[n].eq((1 << self.octets.p.chip)[1:])
+        m.d.comb += self.frames.p.port.cs.oe.eq(1)
+
+        rev_data = self.octets.p.data[::-1] # MSB first
+        with m.Switch(self.octets.p.mode):
+            with m.Case(Mode.Put, Mode.Swap):
+                for n in range(2):
+                    m.d.comb += self.frames.p.port.copi.o[n].eq(rev_data.word_select(cycle, 1))
+                m.d.comb += self.frames.p.port.copi.oe.eq(0b1)
+            with m.Case(Mode.Get):
+                m.d.comb += self.frames.p.port.copi.oe.eq(0b1)
+
+        # When no chip is selected, keep clock in the idle state. The only supported `mode`
+        # in this case is `SPIMode.Dummy`, which should be used to deassert CS# at the end of
+        # a transfer.
+        with m.If(self.octets.p.chip):
+            m.d.comb += self.frames.p.port.sck.o[0].eq(timer * 2 >  self.divisor)
+            m.d.comb += self.frames.p.port.sck.o[1].eq(timer * 2 >= self.divisor)
+        m.d.comb += self.frames.p.port.sck.oe.eq(1)
+
+        with m.If(timer == (self.divisor + 1) >> 1):
+            with m.Switch(self.octets.p.mode):
+                with m.Case(Mode.Get, Mode.Swap):
+                    m.d.comb += self.frames.p.meta.mode.eq(self.octets.p.mode)
+                    m.d.comb += self.frames.p.meta.half.eq(~self.divisor[0])
+
+        m.d.comb += self.frames.valid.eq(self.octets.valid)
+        with m.If(self.frames.valid & self.frames.ready):
+            with m.If(timer == self.divisor):
+                with m.Switch(self.octets.p.mode):
+                    with m.Case(Mode.Put, Mode.Get, Mode.Swap):
+                        m.d.comb += self.octets.ready.eq(cycle == 7)
+                    with m.Case(Mode.Dummy):
+                        m.d.comb += self.octets.ready.eq(cycle == 0)
+                m.d.sync += cycle.eq(Mux(self.octets.ready, 0, cycle + 1))
+                m.d.sync += timer.eq(0)
+            with m.Else():
+                m.d.sync += timer.eq(timer + 1)
+
+        return m
+
+
+class Deframer(wiring.Component):
+    def __init__(self, ports):
+        super().__init__({
+            "frames": In(IOStreamer.o_signature(ports, ratio=2, meta_layout=Sample)),
+            "octets": Out(stream.Signature(data.StructLayout({
+                "data": 8,
+            }))),
+        })
+
+    def elaborate(self, platform):
+        m = Module()
+
+        shreg = Signal(8)
+        with m.Switch(self.frames.p.meta.mode):
+            half = self.frames.p.meta.half
+            with m.Case(Mode.Get, Mode.Swap):
+                m.d.comb += self.octets.p.data.eq(Cat(self.frames.p.port.cipo.i[half], shreg))
+
+        cycle = Signal(range(8))
+        m.d.comb += self.frames.ready.eq(1)
+        with m.If(self.frames.valid & (self.frames.p.meta.mode != Mode.Dummy)):
+            with m.Switch(self.frames.p.meta.mode):
+                with m.Case(Mode.Get, Mode.Swap):
+                    m.d.comb += self.octets.valid.eq(cycle == 7)
+            m.d.comb += self.frames.ready.eq(~self.octets.valid | self.octets.ready)
+            with m.If(self.frames.ready):
+                m.d.sync += shreg.eq(self.octets.p.data)
+                m.d.sync += cycle.eq(Mux(self.octets.valid, 0, cycle + 1))
+
+        return m
+
+
+class Controller(wiring.Component):
+    def __init__(self, ports, *, offset=0, chip_count=None):
+        assert chip_count is None or len(ports.cs) <= chip_count
+        assert len(ports.cs)   >= 1
+        assert len(ports.sck)  == 1
+        assert len(ports.copi) == 1
+        assert len(ports.cipo) == 1
+
+        self._ports = PortGroup(
+            cs   = ~ports.cs  .with_direction("o"),
+            sck  =  ports.sck .with_direction("o"),
+            copi =  ports.copi.with_direction("o"),
+            cipo =  ports.cipo.with_direction("i"),
+        )
+        self._offset = offset
+        self._chip_count = chip_count or len(ports.cs)
+
+        super().__init__({
+            "i_stream": In(stream.Signature(data.StructLayout({
+                "chip": range(1 + self._chip_count),
+                "mode": Mode,
+                "data": 8
+            }))),
+            "o_stream": Out(stream.Signature(data.StructLayout({
+                "data": 8
+            }))),
+            "divisor": In(16),
+        })
+
+    def elaborate(self, platform):
+        m = Module()
+
+        m.submodules.enframer = enframer = Enframer(ports=self._ports, chip_count=self._chip_count)
+        connect(m, enframer=enframer.octets, controller=flipped(self.i_stream))
+        m.d.comb += enframer.divisor.eq(self.divisor)
+
+        m.submodules.io_streamer = io_streamer = \
+            IOStreamer(self._ports, ratio=2, offset=self._offset, meta_layout=Sample, init={
+                "cs":  {"o": 0, "oe": 1}, # deselected
+                "sck": {"o": 1, "oe": 1}, # Motorola "Mode 3" with clock idling high
+            })
+        connect(m, io_streamer=io_streamer.i, enframer=enframer.frames)
+
+        m.submodules.deframer = deframer = Deframer(ports=self._ports)
+        connect(m, deframer=deframer.frames, io_streamer=io_streamer.o)
+
+        connect(m, controller=flipped(self.o_stream), deframer=deframer.octets)
+
+        return m

--- a/software/tests/gateware/test_spi.py
+++ b/software/tests/gateware/test_spi.py
@@ -1,0 +1,257 @@
+import unittest
+from amaranth import *
+from amaranth.sim import Simulator, BrokenTrigger
+from amaranth.lib import io
+
+from glasgow.gateware.ports import PortGroup
+from glasgow.gateware.stream import stream_get, stream_put
+from glasgow.gateware.spi import *
+
+
+def simulate_flash(ports, memory=b"nya nya nya nya nyaaaaan"):
+    class CSDeasserted(Exception):
+        pass
+
+    async def watch_cs(cs_o, triggers):
+        try:
+            *values, posedge_cs_o = await triggers.posedge(cs_o)
+        except BrokenTrigger: # Workaround for amaranth-lang/amaranth#1508
+            # Both our original trigger and posedge of cs happened at the same time.
+            # Prioritize CS being deasserted.
+            raise CSDeasserted
+        if posedge_cs_o == 1:
+            raise CSDeasserted
+        return values
+
+    async def dev_get(ctx, ports):
+        sck, copi, cipo, cs = ports.sck, ports.copi, ports.cipo, ports.cs
+        word = 0
+        for _ in range(0, 8):
+            if ctx.get(sck.o):
+                await watch_cs(cs.o, ctx.negedge(sck.o))
+            _, copi_oe, copi_o = await watch_cs(cs.o, ctx.posedge(sck.o).sample(copi.oe, copi.o))
+            assert copi_oe == 1
+            word = (word << 1) | (copi_o << 0)
+        return word
+
+    async def dev_nop(ctx, ports, *, cycles):
+        sck, copi, cipo, cs = ports.sck, ports.copi, ports.cipo, ports.cs
+        for _ in range(cycles):
+            if ctx.get(sck.o):
+                await watch_cs(cs.o, ctx.negedge(sck.o))
+            _, copi_oe = await watch_cs(cs.o, ctx.posedge(sck.o).sample(copi.oe))
+
+    async def dev_put(ctx, ports, word):
+        sck, copi, cipo, cs = ports.sck, ports.copi, ports.cipo, ports.cs
+        for _ in range(0, 8):
+            if ctx.get(sck.o):
+                await watch_cs(cs.o, ctx.negedge(sck.o))
+            ctx.set(Cat(cipo.i), (word >> 7))
+            word = (word << 1) & 0xff
+            _, copi_oe = await watch_cs(cs.o, ctx.posedge(sck.o).sample(copi.oe))
+            assert copi_oe == 1
+
+    async def testbench(ctx):
+        await ctx.negedge(ports.cs.o)
+        while True:
+            try:
+                cmd = await dev_get(ctx, ports)
+                if cmd == 0x0B:
+                    addr2 = await dev_get(ctx, ports)
+                    addr1 = await dev_get(ctx, ports)
+                    addr0 = await dev_get(ctx, ports)
+                    await dev_nop(ctx, ports, cycles=8)
+                    addr = (addr2 << 16) | (addr1 << 8) | (addr0 << 0)
+                    while True:
+                        if addr >= len(memory):
+                            addr = 0
+                        await dev_put(ctx, ports, memory[addr])
+                        addr += 1
+            except CSDeasserted:
+                await ctx.negedge(ports.cs.o)
+                continue
+
+    return testbench
+
+
+class SPIFramingTestCase(unittest.TestCase):
+    def setUp(self):
+        self.ports = PortGroup()
+        self.ports.cs   = io.SimulationPort("o",  1)
+        self.ports.sck  = io.SimulationPort("o",  1)
+        self.ports.copi = io.SimulationPort("io", 1)
+        self.ports.cipo = io.SimulationPort("io", 1)
+
+    def test_spi_enframer(self):
+        dut = Enframer(self.ports)
+
+        async def testbench_in(ctx):
+            async def data_put(*, chip, data, mode):
+                await stream_put(ctx, dut.octets, {"chip": chip, "data": data, "mode": mode})
+
+            await data_put(chip=1, data=0xBA, mode=Mode.Swap)
+
+            await data_put(chip=1, data=0xAA, mode=Mode.Put)
+            await data_put(chip=1, data=0x55, mode=Mode.Put)
+            await data_put(chip=1, data=0xC1, mode=Mode.Put)
+
+            for _ in range(6):
+                await data_put(chip=1, data=0, mode=Mode.Dummy)
+
+            await data_put(chip=1, data=0, mode=Mode.Get)
+
+            await data_put(chip=0, data=0, mode=Mode.Dummy)
+
+        async def testbench_out(ctx):
+            async def bits_get(*, cs, ox, oe, mode):
+                for cycle, o in enumerate(ox):
+                    expected = {
+                        "port": {
+                            "cs":   {"o": [cs,cs], "oe":  1},
+                            "sck":  {"o": [ 0,cs], "oe":  1},
+                            "copi": {"o": [ o, o], "oe": oe},
+                            "cipo": {"o": [ 0, 0], "oe":  0},
+                        },
+                        "meta": {
+                            "mode": mode,
+                            "half": 0 if mode == Mode.Dummy else 1
+                        }
+                    }
+                    assert (actual := await stream_get(ctx, dut.frames)) == expected, \
+                        f"(cycle {cycle}) {actual} != {expected}"
+
+            await bits_get(cs=1, ox=[1,0,1,1,1,0,1,0], oe=1, mode=Mode.Swap)
+
+            await bits_get(cs=1, ox=[1,0,1,0,1,0,1,0], oe=1, mode=Mode.Dummy)
+            await bits_get(cs=1, ox=[0,1,0,1,0,1,0,1], oe=1, mode=Mode.Dummy)
+            await bits_get(cs=1, ox=[1,1,0,0,0,0,0,1], oe=1, mode=Mode.Dummy)
+
+            await bits_get(cs=1, ox=[0,0,0,0,0,0],     oe=0, mode=Mode.Dummy)
+
+            await bits_get(cs=1, ox=[0,0,0,0,0,0,0,0], oe=1, mode=Mode.Get)
+
+            await bits_get(cs=0, ox=[0],               oe=0, mode=Mode.Dummy)
+
+        sim = Simulator(dut)
+        sim.add_clock(1e-6)
+        sim.add_testbench(testbench_in)
+        sim.add_testbench(testbench_out)
+        with sim.write_vcd("test.vcd"):
+            sim.run()
+
+    def test_spi_deframer(self):
+        dut = Deframer(self.ports)
+
+        async def testbench_in(ctx):
+            async def bits_put(*, ix, mode):
+                for cycle, i in enumerate(ix):
+                    await stream_put(ctx, dut.frames, {
+                        "port": {
+                            "cipo": {"i": [0, i]},
+                        },
+                        "meta": {
+                            "mode": mode,
+                            "half": 1
+                        }
+                    })
+
+            await bits_put(ix=[1,0,1,1,1,0,1,0], mode=Mode.Swap)
+
+            await bits_put(ix=[1,0,1,0,1,0,1,0], mode=Mode.Get)
+            await bits_put(ix=[0,1,0,1,0,1,0,1], mode=Mode.Get)
+            await bits_put(ix=[1,1,0,0,0,0,0,1], mode=Mode.Get)
+
+        async def testbench_out(ctx):
+            async def data_get(*, data):
+                expected = {"data": data}
+                assert (actual := await stream_get(ctx, dut.octets)) == expected, \
+                    f"{actual} != {expected}; data: {actual.data:08b} != {data:08b}"
+
+            await data_get(data=0xBA)
+
+            await data_get(data=0xAA)
+            await data_get(data=0x55)
+            await data_get(data=0xC1)
+
+        sim = Simulator(dut)
+        sim.add_clock(1e-6)
+        sim.add_testbench(testbench_in)
+        sim.add_testbench(testbench_out)
+        with sim.write_vcd("test.vcd"):
+            sim.run()
+
+
+class SPIIntegrationTestCase(unittest.TestCase):
+    def subtest_spi_controller(self, *, divisor: int):
+        ports = PortGroup()
+        ports.cs   = io.SimulationPort("o", 1)
+        ports.sck  = io.SimulationPort("o", 1)
+        ports.copi = io.SimulationPort("o", 1)
+        ports.cipo = io.SimulationPort("i", 1)
+
+        dut = Controller(ports)
+
+        async def testbench_controller(ctx):
+            async def ctrl_idle():
+                await stream_put(ctx, dut.i_stream, {"chip": 0, "data": 0, "mode": Mode.Dummy})
+
+            async def ctrl_put(*, mode, data=0):
+                await stream_put(ctx, dut.i_stream, {"chip": 1, "data": data, "mode": mode})
+
+            async def ctrl_get(*, mode, count=1):
+                ctx.set(dut.i_stream.p.chip, 1)
+                ctx.set(dut.i_stream.p.mode, mode)
+                ctx.set(dut.i_stream.valid, 1)
+                ctx.set(dut.o_stream.ready, 1)
+                words = bytearray()
+                o_count = i_count = 0
+                while True:
+                    _, _, o_stream_ready, i_stream_valid, i_stream_p_data = \
+                        await ctx.tick().sample(
+                            dut.i_stream.ready, dut.o_stream.valid, dut.o_stream.p.data)
+                    if o_stream_ready:
+                        o_count += 1
+                        if o_count == count:
+                            ctx.set(dut.i_stream.valid, 0)
+                    if i_stream_valid:
+                        words.append(i_stream_p_data)
+                        if len(words) == count:
+                            ctx.set(dut.o_stream.ready, 0)
+                            assert not ctx.get(dut.i_stream.valid)
+                            break
+                return words
+            if divisor is not None:
+                ctx.set(dut.divisor, divisor)
+
+            await ctrl_idle()
+
+            await ctrl_put(mode=Mode.Put, data=0x0B)
+            await ctrl_put(mode=Mode.Put, data=0x00)
+            await ctrl_put(mode=Mode.Put, data=0x00)
+            await ctrl_put(mode=Mode.Put, data=0x08)
+            for _ in range(8):
+                await ctrl_put(mode=Mode.Dummy)
+            assert (data := await ctrl_get(mode=Mode.Get, count=4)) == b"awa!", data
+
+            await ctrl_idle()
+
+        testbench_flash = simulate_flash(ports, memory=b"nya nya awa!nya nyaaaaan")
+
+        sim = Simulator(dut)
+        sim.add_clock(1e-6)
+        sim.add_testbench(testbench_controller)
+        sim.add_testbench(testbench_flash, background=True)
+        with sim.write_vcd("test.vcd"):
+            sim.run()
+
+    def test_spi_controller_div0(self):
+        self.subtest_spi_controller(divisor=0)
+
+    def test_spi_controller_div1(self):
+        self.subtest_spi_controller(divisor=1)
+
+    def test_spi_controller_div2(self):
+        self.subtest_spi_controller(divisor=2)
+
+    def test_spi_controller_div3(self):
+        self.subtest_spi_controller(divisor=2)


### PR DESCRIPTION
This also unfortunately removes functionality (only Mode 3 is supported in the new controller, whereas the old one supported all modes), but most devices use either Mode 0 or Mode 3 and don't care which one it is.