### PR TITLE
Be explicit if pin is required or optional in the CLI pin help text

### DIFF
--- a/software/glasgow/applet/__init__.py
+++ b/software/glasgow/applet/__init__.py
@@ -167,8 +167,13 @@ class GlasgowAppletArguments:
             metavar = "PIN"
             if help is None:
                 help = f"bind the applet I/O line {name!r} to {metavar}"
+            help += f" ("
             if default:
-                help += f" (default: {default})"
+                help += f"default: '{default}', "
+            if required:
+                help += f"required)"
+            else:
+                help += f"optional)"
 
             def pin_arg(arg):
                 try:
@@ -208,10 +213,13 @@ class GlasgowAppletArguments:
             metavar = "PINS"
             if help is None:
                 help = f"bind the applet I/O lines {name!r} to {metavar}"
+            help += f" ("
             if default:
-                help += f" (default: {','.join(str(pin) for pin in default)})"
+                help += f"default: '{','.join(str(pin) for pin in default)}', "
+            if required:
+                help += f"required)"
             else:
-                help += " (default is empty)"
+                help += f"optional)"
 
             def pin_arg(arg):
                 try:


### PR DESCRIPTION
Many applets have optional pin arguments for some auxiliary function, but this is currently non-discoverable if they have a default value, since they look exactly the same as a required argument.