### PR TITLE
Modernize use of GPIO in `program-ice40-flash`

### DIFF
--- a/software/glasgow/applet/program/ice40_flash/__init__.py
+++ b/software/glasgow/applet/program/ice40_flash/__init__.py
@@ -1,34 +1,8 @@
 import asyncio
 import logging
-from amaranth import *
-from amaranth.lib import wiring, io
-from amaranth.lib.wiring import In, Out
 
-from ...memory._25x import Memory25xApplet
-from ... import *
-
-
-class ProgramICE40FlashComponent(wiring.Component):
-    reset: In(1)
-    done:  Out(1)
-
-    def __init__(self, ports):
-        self._ports = ports
-
-        super().__init__()
-
-    def elaborate(self, platform):
-        m = Module()
-
-        if self._ports.reset is not None:
-            m.submodules.reset_buffer = reset = io.Buffer("o", self._ports.reset)
-            m.d.comb += reset.oe.eq(self.reset)
-
-        if self._ports.done is not None:
-            m.submodules.done_buffer = done = io.Buffer("i", self._ports.done)
-            m.d.comb += self.done.eq(done.i)
-
-        return m
+from glasgow.applet.memory._25x import Memory25xApplet
+from glasgow.applet.control.gpio import GPIOInterface
 
 
 class ProgramICE40FlashApplet(Memory25xApplet):
@@ -47,26 +21,27 @@ class ProgramICE40FlashApplet(Memory25xApplet):
     def add_build_arguments(cls, parser, access):
         super().add_build_arguments(parser, access)
 
-        access.add_pins_argument(parser, "reset")
-        access.add_pins_argument(parser, "done")
+        access.add_pins_argument(parser, "reset", default="A6", required=True)
+        access.add_pins_argument(parser, "done",  default="A7")
 
     def build(self, args):
         super().build(args)
 
-        ports = self.assembly.add_port_group(reset=args.reset, done=args.done)
-        component = self.assembly.add_submodule(ProgramICE40FlashComponent(ports))
-        self.__reset = self.assembly.add_rw_register(component.reset)
-        self.__done = self.assembly.add_ro_register(component.done)
+        self._reset_iface = GPIOInterface(self.logger, self.assembly, pins=(~args.reset,))
+        if args.done is not None:
+            self._done_iface = GPIOInterface(self.logger, self.assembly, pins=(args.done,))
+        else:
+            self._done_iface = None
 
     async def run(self, args):
-        await self.__reset.set(True)
+        await self._reset_iface.output(0, True)
         await super().run(args)
-        await self.__reset.set(False)
+        await self._reset_iface.output(0, False)
 
-        if args.done is not None:
-            for _ in range(200):    # Wait up to 2s
+        if self._done_iface is not None:
+            for _ in range(10):    # Wait up to 100 ms
                 await asyncio.sleep(0.010)  # Poll every 10 ms
-                if await self.__done:
+                if await self._done_iface.get(0):
                     self.logger.info("FPGA configured from flash")
                     break
             else:

--- a/software/glasgow/applet/program/ice40_flash/test.py
+++ b/software/glasgow/applet/program/ice40_flash/test.py
@@ -4,5 +4,9 @@ from . import ProgramICE40FlashApplet
 
 class ProgramICE40FlashAppletTestCase(GlasgowAppletV2TestCase, applet=ProgramICE40FlashApplet):
     @synthesis_test
-    def test_build(self):
-        self.assertBuilds("--reset B0 --done B1")
+    def test_build_with_done(self):
+        self.assertBuilds(args=["--done", "A7"])
+
+    @synthesis_test
+    def test_build_without_done(self):
+        self.assertBuilds(args=["--done", "-"])


### PR DESCRIPTION
The old implementation worked fine, but the new one demonstrates how to use composition (and avoids adding any custom gateware).

The high-level functionality is also synchronized with `program-ice40-sram`.