### PR TITLE
Fix SPI/QSPI controllers to actually comply with Mode 3

### DIFF
--- a/software/glasgow/gateware/qspi.py
+++ b/software/glasgow/gateware/qspi.py
@@ -78,6 +78,9 @@ class Enframer(wiring.Component):
         with m.If(self.octets.p.chip):
             m.d.comb += self.frames.p.port.sck.o[0].eq(timer * 2 >  self.divisor)
             m.d.comb += self.frames.p.port.sck.o[1].eq(timer * 2 >= self.divisor)
+        with m.Else():
+            for n in range(2):
+                m.d.comb += self.frames.p.port.sck.o[n].eq(1)
         m.d.comb += self.frames.p.port.sck.oe.eq(1)
 
         with m.If(timer == (self.divisor + 1) >> 1):

--- a/software/glasgow/gateware/spi.py
+++ b/software/glasgow/gateware/spi.py
@@ -58,6 +58,9 @@ class Enframer(wiring.Component):
         with m.If(self.octets.p.chip):
             m.d.comb += self.frames.p.port.sck.o[0].eq(timer * 2 >  self.divisor)
             m.d.comb += self.frames.p.port.sck.o[1].eq(timer * 2 >= self.divisor)
+        with m.Else():
+            for n in range(2):
+                m.d.comb += self.frames.p.port.sck.o[n].eq(1)
         m.d.comb += self.frames.p.port.sck.oe.eq(1)
 
         with m.If(timer == (self.divisor + 1) >> 1):

--- a/software/tests/gateware/test_qspi.py
+++ b/software/tests/gateware/test_qspi.py
@@ -149,10 +149,14 @@ class QSPIFramingTestCase(unittest.TestCase):
         async def testbench_out(ctx):
             async def bits_get(*, cs, ox, oe, mode):
                 for cycle, o in enumerate(ox):
+                    if cs:
+                        sck_o = [0,1]
+                    else:
+                        sck_o = [1,1]
                     expected = {
                         "port": {
                             "cs":  {"o": [      cs,       cs], "oe":         1},
-                            "sck": {"o": [       0,       cs], "oe":         1},
+                            "sck": {"o":                sck_o, "oe":         1},
                             "io0": {"o": [(o>>0)&1, (o>>0)&1], "oe": (oe>>0)&1},
                             "io1": {"o": [(o>>1)&1, (o>>1)&1], "oe": (oe>>1)&1},
                             "io2": {"o": [(o>>2)&1, (o>>2)&1], "oe": (oe>>2)&1},

--- a/software/tests/gateware/test_spi.py
+++ b/software/tests/gateware/test_spi.py
@@ -105,10 +105,14 @@ class SPIFramingTestCase(unittest.TestCase):
         async def testbench_out(ctx):
             async def bits_get(*, cs, ox, oe, mode):
                 for cycle, o in enumerate(ox):
+                    if cs:
+                        sck_o = [0,1]
+                    else:
+                        sck_o = [1,1]
                     expected = {
                         "port": {
                             "cs":   {"o": [cs,cs], "oe":  1},
-                            "sck":  {"o": [ 0,cs], "oe":  1},
+                            "sck":  {"o": sck_o,   "oe":  1},
                             "copi": {"o": [ o, o], "oe": oe},
                             "cipo": {"o": [ 0, 0], "oe":  0},
                         },


### PR DESCRIPTION
Before this PR, the clock would idle low after the first transaction was completed.