### PR TITLE
Add stub mode parameter to SPI controller interface

### DIFF
--- a/software/glasgow/applet/bridge/flashrom/__init__.py
+++ b/software/glasgow/applet/bridge/flashrom/__init__.py
@@ -131,7 +131,8 @@ class FlashromApplet(GlasgowAppletV2):
         with self.assembly.add_applet(self):
             self.assembly.use_voltage(args.voltage)
             self.spi_iface = SPIControllerInterface(self.logger, self.assembly,
-                cs=args.cs, sck=args.sck, copi=args.copi, cipo=args.cipo)
+                cs=args.cs, sck=args.sck, copi=args.copi, cipo=args.cipo,
+                mode=3)
             if args.wp:
                 self.assembly.use_pulls({~args.wp:   "low"})
             if args.hold:

--- a/software/glasgow/applet/interface/spi_controller/__init__.py
+++ b/software/glasgow/applet/interface/spi_controller/__init__.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Literal
 import contextlib
 import logging
 import struct
@@ -139,7 +139,9 @@ class SPIControllerComponent(wiring.Component):
 class SPIControllerInterface:
     def __init__(self, logger: logging.Logger, assembly: AbstractAssembly, *,
                  cs: GlasgowPin, sck: GlasgowPin, copi: Optional[GlasgowPin] = None,
-                 cipo: Optional[GlasgowPin] = None):
+                 cipo: Optional[GlasgowPin] = None, mode: Literal[0, 1, 2, 3]):
+        assert mode == 3, "Only Mode 3 is supported at the moment"
+
         self._logger = logger
         self._level  = logging.DEBUG if self._logger.name == __name__ else logging.TRACE
 
@@ -259,11 +261,16 @@ class SPIControllerApplet(GlasgowAppletV2):
         access.add_pins_argument(parser, "copi", default=True)
         access.add_pins_argument(parser, "cipo", default=True)
 
+        parser.add_argument(
+            "-m", "--mode", metavar="MODE", choices=(0, 1, 2, 3), default=3,
+            help="configure clock phase and idle state according to MODE (default: %(default)s)")
+
     def build(self, args):
         with self.assembly.add_applet(self):
             self.assembly.use_voltage(args.voltage)
             self.spi_iface = SPIControllerInterface(self.logger, self.assembly,
-                cs=args.cs, sck=args.sck, copi=args.copi, cipo=args.cipo)
+                cs=args.cs, sck=args.sck, copi=args.copi, cipo=args.cipo,
+                mode=args.mode)
 
     @classmethod
     def add_setup_arguments(cls, parser):

--- a/software/glasgow/applet/program/ice40_sram/__init__.py
+++ b/software/glasgow/applet/program/ice40_sram/__init__.py
@@ -24,7 +24,7 @@ class ProgramICE40SRAMInterface:
         self._level  = logging.DEBUG if self._logger.name == __name__ else logging.TRACE
 
         self._spi_iface = SPIControllerInterface(logger, assembly,
-            cs=cs, sck=sck, copi=copi)
+            cs=cs, sck=sck, copi=copi, mode=3)
         self._reset_iface = GPIOInterface(logger, assembly, pins=(~reset,))
         if done is not None:
             self._done_iface = GPIOInterface(logger, assembly, pins=(done,))


### PR DESCRIPTION
This parameter is currently just there to make any downstream user stop and consider whether their device actually uses Mode 3 or not. Once SPI modes are implemented properly, it will configure the SPI controller.