### PR TITLE
Flush IN FIFO once per microframe

### DIFF
--- a/software/glasgow/abstract.py
+++ b/software/glasgow/abstract.py
@@ -326,7 +326,7 @@ class AbstractAssembly(metaclass=ABCMeta):
                             name=name)
 
     @abstractmethod
-    def add_in_pipe(self, in_stream, *, in_flush=C(1),
+    def add_in_pipe(self, in_stream, *, in_flush=C(0),
                     fifo_depth=None, buffer_size=None) -> AbstractInPipe:
         pass
 
@@ -336,7 +336,7 @@ class AbstractAssembly(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def add_inout_pipe(self, in_stream, out_stream, *, in_flush=C(1),
+    def add_inout_pipe(self, in_stream, out_stream, *, in_flush=C(0),
                        in_fifo_depth=None, in_buffer_size=None,
                        out_fifo_depth=None, out_buffer_size=None) -> AbstractInOutPipe:
         pass

--- a/software/glasgow/applet/bridge/jtag_xvc/__init__.py
+++ b/software/glasgow/applet/bridge/jtag_xvc/__init__.py
@@ -100,7 +100,7 @@ class JTAGXVCProbe(wiring.Component):
 class JTAGXVCComponent(wiring.Component):
     i_stream: In(stream.Signature(8))
     o_stream: Out(stream.Signature(8))
-    o_flush:  Out(1)
+
     divisor:  In(16)
 
     def __init__(self, ports):
@@ -120,7 +120,6 @@ class JTAGXVCComponent(wiring.Component):
         count = Signal(16)
         with m.FSM():
             with m.State("Receive Count 8:16"):
-                m.d.comb += self.o_flush.eq(1)
                 m.d.comb += self.i_stream.ready.eq(1)
                 with m.If(self.i_stream.valid):
                     m.d.sync += count[8:16].eq(self.i_stream.payload)
@@ -170,8 +169,7 @@ class JTAGXVCInterface:
 
         ports = assembly.add_port_group(tck=tck, tms=tms, tdi=tdi, tdo=tdo)
         component = assembly.add_submodule(JTAGXVCComponent(ports))
-        self._pipe = assembly.add_inout_pipe(
-            component.o_stream, component.i_stream, in_flush=component.o_flush)
+        self._pipe = assembly.add_inout_pipe(component.o_stream, component.i_stream)
         self._clock = assembly.add_clock_divisor(component.divisor,
             # Tolerance is 10% because the XVC protocol transfers frequencies as an integral period
             # in nanoseconds. For frequencies >1 MHz this often results in a significant error.

--- a/software/glasgow/applet/debug/arm/arm7/__init__.py
+++ b/software/glasgow/applet/debug/arm/arm7/__init__.py
@@ -100,7 +100,6 @@ class DebugARM7Opcode(enum.Enum, shape=3):
 class DebugARM7Sequencer(wiring.Component):
     i_stream: In(stream.Signature(8))
     o_stream: Out(stream.Signature(8))
-    o_flush:  Out(1)
 
     divisor:  In(8)
 
@@ -163,8 +162,6 @@ class DebugARM7Sequencer(wiring.Component):
                             m.next = "Fetch data"
                         with m.Default():
                             m.next = "Run command"
-                with m.Else():
-                    m.d.comb += self.o_flush.eq(1)
 
             with m.State("Fetch data"):
                 i_offset = Signal(2)
@@ -762,8 +759,7 @@ class DebugARM7Interface(GDBRemote):
 
         ports = assembly.add_port_group(tck=tck, tms=tms, tdo=tdo, tdi=tdi, trst=trst)
         component = assembly.add_submodule(DebugARM7Sequencer(ports))
-        self._pipe = assembly.add_inout_pipe(component.o_stream, component.i_stream,
-            in_flush=component.o_flush)
+        self._pipe = assembly.add_inout_pipe(component.o_stream, component.i_stream)
         self._clock = assembly.add_clock_divisor(component.divisor,
             ref_period=assembly.sys_clk_period * 2, name="tck")
 

--- a/software/glasgow/applet/interface/spi_analyzer/__init__.py
+++ b/software/glasgow/applet/interface/spi_analyzer/__init__.py
@@ -119,7 +119,6 @@ class SPIAnalyzerFrontend(wiring.Component):
 
 class SPIAnalyzerComponent(wiring.Component):
     o_stream: Out(stream.Signature(8))
-    o_flush:  Out(1)
 
     overflow: Out(1)
 
@@ -137,8 +136,7 @@ class SPIAnalyzerComponent(wiring.Component):
 
         m.submodules.frontend = frontend = SPIAnalyzerFrontend(self._ports)
 
-        idle  = Signal(init=1)
-        timer = Signal(20)
+        idle = Signal(init=1)
         with m.FSM():
             with m.State("Idle"):
                 with m.If(frontend.stream.valid):
@@ -146,12 +144,6 @@ class SPIAnalyzerComponent(wiring.Component):
                     m.d.comb += encoder.i.valid.eq(1)
                     with m.If(encoder.i.ready):
                         m.next = "COPI"
-                # FIXME: this timeout should be a part of the common FX2 logic
-                with m.Else():
-                    with m.If(timer == 0):
-                        m.d.comb += self.o_flush.eq(1)
-                    with m.Else():
-                        m.d.sync += timer.eq(timer - 1)
 
             with m.State("COPI"):
                 with m.If(frontend.stream.valid):
@@ -178,9 +170,6 @@ class SPIAnalyzerComponent(wiring.Component):
                 m.d.comb += encoder.i.valid.eq(1)
                 with m.If(encoder.i.ready):
                     m.d.sync += idle.eq(1)
-                    # FIXME: not the most elegant approach to make the timeout shorter
-                    # during simulation
-                    m.d.sync += timer.eq(1000 if platform is None else ~0)
                     m.next = "Idle"
 
         m.d.comb += self.overflow.eq(frontend.overflow)
@@ -198,8 +187,7 @@ class SPIAnalyzerInterface:
         ports = assembly.add_port_group(cs=cs, sck=sck, copi=copi, cipo=cipo)
         component = assembly.add_submodule(SPIAnalyzerComponent(ports, buffer_size))
         # Don't use an interface FIFO; the input buffering is done in the COBS encoder.
-        self._pipe = assembly.add_in_pipe(
-            component.o_stream, in_flush=component.o_flush, fifo_depth=0)
+        self._pipe = assembly.add_in_pipe(component.o_stream, fifo_depth=0)
         self._overflow = assembly.add_ro_register(component.overflow)
 
     def _log(self, message, *args):

--- a/software/glasgow/applet/interface/swd_probe/__init__.py
+++ b/software/glasgow/applet/interface/swd_probe/__init__.py
@@ -65,7 +65,6 @@ class SWDResponse(data.Struct):
 class SWDProbeComponent(wiring.Component):
     i_stream: In(stream.Signature(8))
     o_stream: Out(stream.Signature(8))
-    o_flush:  Out(1)
 
     divisor: In(16)
     timeout: In(16, init=~0)
@@ -147,8 +146,6 @@ class SWDProbeComponent(wiring.Component):
                         m.d.comb += ctrl.o_stream.ready.eq(1)
                         m.next = "Response"
 
-        m.d.comb += self.o_flush.eq(~self.i_stream.valid)
-
         return m
 
 
@@ -159,8 +156,7 @@ class SWDProbeInterface:
 
         ports = assembly.add_port_group(swclk=swclk, swdio=swdio)
         component = assembly.add_submodule(SWDProbeComponent(ports))
-        self._pipe = assembly.add_inout_pipe(component.o_stream, component.i_stream,
-            in_flush=component.o_flush)
+        self._pipe = assembly.add_inout_pipe(component.o_stream, component.i_stream)
         self._clock = assembly.add_clock_divisor(component.divisor,
             ref_period=assembly.sys_clk_period, name="swclk")
         self._timeout = assembly.add_rw_register(component.timeout)

--- a/software/glasgow/applet/interface/uart/__init__.py
+++ b/software/glasgow/applet/interface/uart/__init__.py
@@ -194,7 +194,7 @@ class UARTInterface:
         await self._use_auto.set(1)
 
     async def read(self, length: int, *, flush=True) -> memoryview:
-        """Reads one or more bytes from the UART. If ``flush`` is true, transmits any buffered
+        """Reads one or more bytes from the UART. If :py:`flush` is true, transmits any buffered
         writes before starting to receive."""
         self._log("rx len=%d", length)
         if flush:
@@ -204,7 +204,7 @@ class UARTInterface:
         return data
 
     async def read_all(self, *, flush=True) -> memoryview:
-        """Reads all buffered bytes from the UART, but no less than one byte. If ``flush`` is
+        """Reads all buffered bytes from the UART, but no less than one byte. If :py:`flush` is
         true, transmits any buffered writes before starting to read."""
         self._log("rx all")
         if flush:
@@ -217,7 +217,7 @@ class UARTInterface:
         return data
 
     async def read_until(self, trailer: bytes | Tuple[bytes, ...]) -> memoryview:
-        """Reads bytes from the UART until ``trailer``, which can be a single byte sequence
+        """Reads bytes from the UART until :py:`trailer`, which can be a single byte sequence
         or a choice of multiple byte sequences, is encountered. The return value includes
         the trailer."""
         buffer = bytearray()

--- a/software/glasgow/applet/internal/benchmark/__init__.py
+++ b/software/glasgow/applet/internal/benchmark/__init__.py
@@ -23,7 +23,7 @@ class Mode(enum.Enum):
 class BenchmarkComponent(wiring.Component):
     i_stream: In(stream.Signature(8))
     o_stream: Out(stream.Signature(8))
-    o_flush:  Out(1)
+
     mode:     In(Mode)
     error:    Out(1)
     count:    Out(32)
@@ -81,10 +81,6 @@ class BenchmarkComponent(wiring.Component):
                 ]
                 with m.If(self.o_stream.ready & self.o_stream.valid):
                     m.d.sync += self.count.eq(self.count + 1)
-                with m.Else():
-                    m.d.comb += [
-                        self.o_flush.eq(1),
-                    ]
 
         return m
 
@@ -118,8 +114,7 @@ class BenchmarkApplet(GlasgowAppletV2):
     def build(self, args):
         with self.assembly.add_applet(self):
             component = self.assembly.add_submodule(BenchmarkComponent())
-            self._pipe = self.assembly.add_inout_pipe(
-                component.o_stream, component.i_stream, in_flush=component.o_flush)
+            self._pipe = self.assembly.add_inout_pipe(component.o_stream, component.i_stream)
             self._mode = self.assembly.add_rw_register(component.mode)
             self._error = self.assembly.add_ro_register(component.error)
             self._count = self.assembly.add_ro_register(component.count)

--- a/software/glasgow/hardware/assembly.py
+++ b/software/glasgow/hardware/assembly.py
@@ -552,7 +552,7 @@ class HardwareAssembly(AbstractAssembly):
         self._registers.append((register, signal, self._domain))
         return register
 
-    def add_in_pipe(self, in_stream, *, in_flush=C(1),
+    def add_in_pipe(self, in_stream, *, in_flush=C(0),
                     fifo_depth=None, buffer_size=None) -> AbstractInPipe:
         assert self._artifact is None, "cannot add a pipe to a sealed assembly"
         in_pipe = HardwareInPipe(self._logger, self, buffer_size=buffer_size)
@@ -568,7 +568,7 @@ class HardwareAssembly(AbstractAssembly):
         self._pipes.append(out_pipe)
         return out_pipe
 
-    def add_inout_pipe(self, in_stream, out_stream, *, in_flush=C(1),
+    def add_inout_pipe(self, in_stream, out_stream, *, in_flush=C(0),
                        in_fifo_depth=None, in_buffer_size=None,
                        out_fifo_depth=None, out_buffer_size=None) -> AbstractInOutPipe:
         assert self._artifact is None, "cannot add a pipe to a sealed assembly"


### PR DESCRIPTION
This eliminates a common pitfall for applet authors, where by default the IN FIFO is flushed too often, and very small packets clog the FX2 buffers, causing buffer overflows and data loss. With this change, so long as the host polls the device once per microframe (with XHCI hosts, this can happen even more than once), there will never be a case where an FX2 buffer isn't available, unless the bus is very heavily loaded with other traffic.

There are two cases where more control over flushing is desired.

First, in request/response style protocols, it is useful to flush the IN FIFO once the OUT FIFO is empty, since this reduces time spent waiting for responses. This can significantly improve `probe-rs` throughput, and is still used in that applet.

Second, an applet that produces a stream of data quickly enough that it would be sent as a sequence of maximum-length packets may still need this data to arrive at the host promptly. This can be an issue with `uart` applet at high baud rates and duty cycles. It is not fixed in this commit.

The throughput and latency when configured to flush implicitly, as measured by the `benchmark` applet, are essentially unchanged; the latency should be worse by ~125 µs (worst case), but this change is comparable to noise.

All of the V2 applets that used to use explicit flush have been updated to use autoflush where applicable; only `probe-rs` continues to use explicit flush.

The following applets have been modified as a result and need to be tested, both for function and for performance:
- [x] benchmark
- [x] uart-analyzer
- [x] uart
- [x] spi-analyzer
- [x] spi-controller
- [x] qspi-analyzer
- [x] qspi-controller
- [x] jtag-xvc
- [x] swd-probe
- [x] probe-rs
- [x] debug-arm7

Fixes #263.
Fixes #794.