### PR TITLE
cli: print version info when using --verbose

### DIFF
--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -596,6 +596,8 @@ async def main():
     args = get_argparser().parse_args()
     configure_logger(args, term_handler)
 
+    logger.debug(version_info()) # print version info if verbose
+
     device = None
     try:
         if args.action not in ("build", "test", "tool", "factory", "list"):


### PR DESCRIPTION
Suggested in a recent conversation on matrix - should make debugging issues a bit easier.
Uses the same guts as `glasgow version`.