### PR TITLE
Abstract out USB communication to enable a future WebUSB backend

### DIFF
--- a/examples/applets_without_cli.py
+++ b/examples/applets_without_cli.py
@@ -31,7 +31,7 @@ logger = logging.getLogger()
 
 
 async def main():
-    assembly = HardwareAssembly()
+    assembly = await HardwareAssembly.find_device()
     assembly.use_voltage({"A": 3.3, "B": 3.3})
     spi_rom_iface = Memory25xInterface(logger, assembly,
         cs="A0", sck="A1", io="A2:5")

--- a/software/glasgow/applet/__init__.py
+++ b/software/glasgow/applet/__init__.py
@@ -367,8 +367,7 @@ def applet_v2_hardware_test(*, prepare=None, args=None, mocks: list[str]):
                 case.__name__ + ".json")
             if not os.path.exists(fixture_path):
                 # Record mode
-                device = GlasgowDevice()
-                assembly = HardwareAssembly(device=device)
+                assembly = HardwareAssembly.find_device()
                 applet: GlasgowAppletV2 = self.applet_cls(assembly)
                 applet.build(parsed_args)
                 async with assembly:
@@ -387,7 +386,6 @@ def applet_v2_hardware_test(*, prepare=None, args=None, mocks: list[str]):
                                     MockRecorder(self, fixture, mock, getattr(mock_obj, mock_attr)))
                         await case(self, applet)
                     os.rename(f"{fixture_path}.new", fixture_path)
-                device.close()
             else:
                 # Replay mode
                 assembly = HardwareAssembly(revision=self.applet_cls.required_revision)

--- a/software/glasgow/applet/debug/arm/arm7/test.py
+++ b/software/glasgow/applet/debug/arm/arm7/test.py
@@ -221,7 +221,7 @@ class DebugARM7AppletTestCase(GlasgowAppletV2TestCase, applet=DebugARM7Applet):
     @async_test
     async def run_on_hardware(self, test_case, **test_kwargs):
         parsed_args = self._parse_args(self.hardware_args)
-        assembly = HardwareAssembly()
+        assembly = await HardwareAssembly.find_device()
         applet = self.applet_cls(assembly)
         applet.build(parsed_args)
         async with assembly:

--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -45,7 +45,7 @@ class TextHelpFormatter(argparse.HelpFormatter):
         else:
             try:
                 columns, _ = os.get_terminal_size(sys.stderr.fileno())
-            except OSError:
+            except (OSError, AttributeError):
                 columns = 80
         super().__init__(prog, width=columns, max_help_position=28)
 

--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -601,7 +601,7 @@ async def main():
     device = None
     try:
         if args.action not in ("build", "test", "tool", "factory", "list"):
-            device = GlasgowDevice(args.serial)
+            device = await GlasgowDevice.find(args.serial)
             assembly = HardwareAssembly(device=device)
 
         if args.action == "voltage":
@@ -1006,7 +1006,7 @@ async def main():
             logger.warning("power cycle the device to finish the operation")
 
         if args.action == "list":
-            for serial in sorted(GlasgowDevice.enumerate_serials()):
+            for serial in sorted(await GlasgowDevice.enumerate()):
                 print(serial)
             return 0
 
@@ -1037,7 +1037,7 @@ async def main():
 
     finally:
         if device is not None:
-            device.close()
+            await device.close()
 
     return 0
 

--- a/software/glasgow/hardware/device.py
+++ b/software/glasgow/hardware/device.py
@@ -1,5 +1,6 @@
 from typing import Optional
 import re
+import sys
 import time
 import struct
 import logging
@@ -12,7 +13,10 @@ from fx2 import REQ_RAM, REG_CPUCS
 from fx2.format import input_data
 
 from ..support.logging import dump_hex
-from ..support.usb import libusb1 as usb
+if sys.platform == "emscripten":
+    from ..support.usb import webusb as usb
+else:
+    from ..support.usb import libusb1 as usb
 from . import quirks
 
 

--- a/software/glasgow/hardware/platform/__init__.py
+++ b/software/glasgow/hardware/platform/__init__.py
@@ -84,9 +84,9 @@ class GlasgowPlatform:
         bitstream = products.get(f"{name}.bin")
         async def do_program():
             from ..device import GlasgowDevice
-            device = GlasgowDevice()
+            device = await GlasgowDevice.find()
             await device.download_bitstream(bitstream)
-            device.close()
+            await device.close()
         asyncio.get_event_loop().run_until_complete(do_program())
 
     def get_io_buffer(self, buffer):

--- a/software/glasgow/support/usb/__init__.py
+++ b/software/glasgow/support/usb/__init__.py
@@ -1,0 +1,273 @@
+"""Abstract USB backend interface."""
+
+from typing import Optional, Callable
+from abc import ABCMeta, abstractmethod
+import enum
+
+
+__all__ = [
+    "RequestType",
+    "Recipient",
+    "Direction",
+    "EndpointType",
+    "Error",
+    "ErrorNotSupported",
+    "ErrorNotFound",
+    "ErrorNotOpen",
+    "ErrorAccess",
+    "ErrorBusy",
+    "ErrorOutOfMemory",
+    "ErrorDisconnected",
+    "ErrorStall",
+    "ErrorBabble",
+    "ErrorAborted",
+    "AbstractContext",
+    "AbstractDevice",
+    "AbstractConfiguration",
+    "AbstractInterface",
+    "AbstractAlternateInterface",
+    "AbstractEndpoint",
+]
+
+
+class RequestType(enum.Enum):
+    Standard = "standard"
+    Class = "class"
+    Vendor = "vendor"
+
+
+class Recipient(enum.Enum):
+    Device = "device"
+    Interface = "interface"
+    Endpoint = "endpoint"
+    Other = "other"
+
+
+class Direction(enum.Enum):
+    In = "in"
+    Out = "out"
+
+
+class EndpointType(enum.Enum):
+    Bulk = "bulk"
+    Interrupt = "interrupt"
+    Isochronous = "isochronous"
+
+
+class Error(Exception):
+    pass
+
+
+class ErrorNotSupported(Error):
+    pass
+
+
+class ErrorNotFound(Error):
+    pass
+
+
+class ErrorNotOpen(Error):
+    pass
+
+
+class ErrorAccess(Error):
+    pass
+
+
+class ErrorBusy(Error):
+    pass
+
+
+class ErrorOutOfMemory(Error):
+    pass
+
+
+class ErrorDisconnected(Error):
+    pass
+
+
+class ErrorStall(Error):
+    pass
+
+
+class ErrorBabble(Error):
+    pass
+
+
+class ErrorAborted(Error):
+    pass
+
+
+class AbstractContext(metaclass=ABCMeta):
+    @abstractmethod
+    async def request_device(self, vendor_id: int, product_id: int):
+        pass
+
+    @abstractmethod
+    async def get_devices(self) -> list['AbstractDevice']:
+        pass
+
+    @property
+    @abstractmethod
+    def has_hotplug_support(self) -> bool:
+        pass
+
+    @abstractmethod
+    def add_connect_callback(self, callback: Callable[['Device'], None]):
+        pass
+
+    @abstractmethod
+    def add_disconnect_callback(self, callback: Callable[['Device'], None]):
+        pass
+
+
+class AbstractDevice(metaclass=ABCMeta):
+    @property
+    @abstractmethod
+    def vendor_id(self) -> int:
+        pass
+
+    @property
+    @abstractmethod
+    def product_id(self) -> int:
+        pass
+
+    @property
+    @abstractmethod
+    def manufacturer_name(self) -> Optional[str]:
+        pass
+
+    @property
+    @abstractmethod
+    def product_name(self) -> Optional[str]:
+        pass
+
+    @property
+    @abstractmethod
+    def serial_number(self) -> Optional[str]:
+        pass
+
+    @property
+    @abstractmethod
+    def version(self) -> int:
+        pass
+
+    @property
+    @abstractmethod
+    def location(self) -> str:
+        pass
+
+    @property
+    @abstractmethod
+    def configuration(self) -> 'AbstractConfiguration':
+        pass
+
+    @property
+    @abstractmethod
+    def configurations(self) -> list['AbstractConfiguration']:
+        pass
+
+    @abstractmethod
+    async def open(self):
+        pass
+
+    @abstractmethod
+    async def close(self):
+        pass
+
+    @abstractmethod
+    async def select_configuration(self, configuration: int):
+        pass
+
+    @abstractmethod
+    async def select_alternate_interface(self, interface: int, setting: int):
+        pass
+
+    @abstractmethod
+    async def claim_interface(self, interface: int):
+        pass
+
+    @abstractmethod
+    async def release_interface(self, interface: int):
+        pass
+
+    @abstractmethod
+    async def control_transfer_in(self, request_type: RequestType, recipient: Recipient,
+                                  request: int, value: int, index: int, length: int) -> memoryview:
+        pass
+
+    @abstractmethod
+    async def control_transfer_out(self, request_type: RequestType, recipient: Recipient,
+                                   request: int, value: int, index: int, data: bytes | bytearray):
+        pass
+
+    @abstractmethod
+    async def bulk_transfer_in(self, endpoint: int, length: int) -> memoryview:
+        pass
+
+    @abstractmethod
+    async def bulk_transfer_out(self, endpoint: int, data: bytes | bytearray):
+        pass
+
+
+class AbstractConfiguration(metaclass=ABCMeta):
+    @property
+    @abstractmethod
+    def value(self) -> int:
+        pass
+
+    @property
+    @abstractmethod
+    def interfaces(self) -> list['AbstractInterface']:
+        pass
+
+
+class AbstractInterface(metaclass=ABCMeta):
+    @property
+    @abstractmethod
+    def number(self) -> int:
+        pass
+
+    # @property
+    # @abstractmethod
+    # def alternate(self) -> 'AbstractAlternateInterface':
+    #     pass
+
+    @property
+    @abstractmethod
+    def alternates(self) -> list['AbstractAlternateInterface']:
+        pass
+
+
+class AbstractAlternateInterface(metaclass=ABCMeta):
+    @property
+    @abstractmethod
+    def setting(self) -> int:
+        pass
+
+    @property
+    @abstractmethod
+    def endpoints(self) -> list['AbstractEndpoint']:
+        pass
+
+
+class AbstractEndpoint(metaclass=ABCMeta):
+    @property
+    @abstractmethod
+    def number(self) -> int:
+        pass
+
+    @property
+    @abstractmethod
+    def direction(self) -> Direction:
+        pass
+
+    @property
+    @abstractmethod
+    def type(self) -> EndpointType:
+        pass
+
+    @property
+    @abstractmethod
+    def packet_size(self) -> int:
+        pass

--- a/software/glasgow/support/usb/libusb1.py
+++ b/software/glasgow/support/usb/libusb1.py
@@ -1,0 +1,419 @@
+from typing import Optional, Callable
+import functools
+import threading
+import inspect
+import asyncio
+
+import usb1
+
+from . import *
+from . import __all__ as _abstract_all
+
+
+__all__ = _abstract_all + [
+    "Context",
+    "Device",
+    "Configuration",
+    "Interface",
+    "AlternateInterface",
+    "Endpoint",
+]
+
+
+def _map_exceptions(f):
+    def map_error(error):
+        match error:
+            case usb1.USBErrorInvalidParam() | usb1.USBErrorNotSupported():
+                raise ErrorNotSupported() from None
+            case usb1.USBErrorNotFound():
+                raise ErrorNotFound() from None
+            case usb1.USBErrorAccess():
+                raise ErrorAccess() from None
+            case usb1.USBErrorBusy():
+                raise ErrorBusy() from None
+            case usb1.USBErrorNoMem():
+                raise ErrorOutOfMemory() from None
+            case usb1.USBErrorNoDevice():
+                raise ErrorDisconnected() from None
+            case usb1.USBErrorPipe():
+                raise ErrorStall() from None
+            case usb1.USBErrorOverflow():
+                raise ErrorBabble() from None
+            case usb1.USBErrorInterrupted():
+                raise ErrorAborted() from None
+            case _:
+                raise Error(str(error)) from error
+
+    if inspect.iscoroutinefunction(f):
+        @functools.wraps(f)
+        async def wrapper(*args, **kwargs):
+            try:
+                return await f(*args, **kwargs)
+            except usb1.USBError as err:
+                map_error(err)
+    else:
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            try:
+                return f(*args, **kwargs)
+            except usb1.USBError as err:
+                map_error(err)
+    return wrapper
+
+
+def _map_request_type(request_type: RequestType) -> int:
+    match request_type:
+        case RequestType.Standard:
+            return usb1.REQUEST_TYPE_STANDARD
+        case RequestType.Class:
+            return usb1.REQUEST_TYPE_CLASS
+        case RequestType.Vendor:
+            return usb1.REQUEST_TYPE_VENDOR
+
+
+def _map_recipient(recipient: Recipient) -> int:
+    match recipient:
+        case Recipient.Device:
+            return usb1.RECIPIENT_DEVICE
+        case Recipient.Interface:
+            return usb1.RECIPIENT_INTERFACE
+        case Recipient.Endpoint:
+            return usb1.RECIPIENT_ENDPOINT
+        case Recipient.Other:
+            return usb1.RECIPIENT_OTHER
+
+
+class Context(AbstractContext):
+    class _PollerThread(threading.Thread):
+        def __init__(self, _impl: usb1.USBContext):
+            super().__init__()
+
+            self._impl = _impl
+            self._done = False
+
+        @property
+        def done(self) -> bool:
+            return self._done
+
+        def run(self):
+            # The poller thread spends most of its life in blocking `handleEvents()` calls and this
+            # can cause issues during interpreter shutdown. If it were a daemon thread (it isn't)
+            # then it would be instantly killed on interpreter shutdown and any locks it took could
+            # block some libusb1 objects being destroyed as their Python counterparts are garbage
+            # collected. Since it is not a daemon thread, `threading._shutdown()` (that is called
+            # by e.g. `exit()`) will join it, and so it must terminate during threading shutdown.
+            # Note that `atexit.register` is not enough as those callbacks are called after
+            # threading shutdown, and past the point where a deadlock would happen.
+            threading._register_atexit(self.stop)
+            while not self._done:
+                self._impl.handleEvents()
+
+        def stop(self):
+            self._done = True
+            self._impl.interruptEventHandler()
+            self.join()
+
+    def __init__(self):
+        self._impl = usb1.USBContext()
+        self._poller = self._PollerThread(self._impl)
+        self._on_connect = []
+        self._on_disconnect = []
+
+        self._impl.hotplugRegisterCallback(self._process_hotplug_event)
+        self._poller.start()
+
+    async def request_device(self, vendor_id: int, product_id: int):
+        pass # not necessary on libusb1
+
+    @_map_exceptions
+    async def get_devices(self) -> list['Device']:
+        return [
+            Device(self._poller, device)
+            for device in self._impl.getDeviceIterator(skip_on_error=True)
+        ]
+
+    @property
+    def has_hotplug_support(self) -> bool:
+        return self._impl.hasCapability(usb1.CAP_HAS_HOTPLUG)
+
+    def add_connect_callback(self, callback: Callable[['Device'], None]):
+        self._on_connect.append(callback)
+
+    def add_disconnect_callback(self, callback: Callable[['Device'], None]):
+        self._on_disconnect.append(callback)
+
+    def _process_hotplug_event(self, _impl, impl_device, event):
+        match event:
+            case usb1.HOTPLUG_EVENT_DEVICE_ARRIVED:
+                for callback in self._on_connect:
+                    callback(Device(self._poller, impl_device))
+
+            case usb1.HOTPLUG_EVENT_DEVICE_LEFT:
+                for callback in self._on_disconnect:
+                    callback(Device(self._poller, impl_device))
+
+    def __del__(self):
+        self._poller.stop()
+
+
+class Device(AbstractDevice):
+    def __init__(self, _poller: Context._PollerThread, _impl_device: usb1.USBDevice):
+        self._poller = _poller
+        self._impl_device = _impl_device
+        self._impl_handle: Optional[usb1.USBDeviceHandle] = None
+
+        self._manufacturer_name: Optional[str] = None
+        self._product_name: Optional[str] = None
+        self._serial_number: Optional[str] = None
+
+    @property
+    def _ensure_open(self) -> usb1.USBDeviceHandle:
+        if self._impl_handle is None:
+            raise ErrorNotOpen()
+        return self._impl_handle
+
+    @property
+    @_map_exceptions
+    def vendor_id(self) -> int:
+        return self._impl_device.getVendorID()
+
+    @property
+    @_map_exceptions
+    def product_id(self) -> int:
+        return self._impl_device.getProductID()
+
+    @property
+    @_map_exceptions
+    def manufacturer_name(self) -> Optional[str]:
+        if self._manufacturer_name is None:
+            self._manufacturer_name = self._ensure_open.getASCIIStringDescriptor(
+                self._impl_device.getManufacturerDescriptor())
+        return self._manufacturer_name
+
+    @property
+    @_map_exceptions
+    def product_name(self) -> Optional[str]:
+        if self._product_name is None:
+            self._product_name = self._ensure_open.getASCIIStringDescriptor(
+                self._impl_device.getProductDescriptor())
+        return self._product_name
+
+    @property
+    @_map_exceptions
+    def serial_number(self) -> Optional[str]:
+        if self._serial_number is None:
+            self._serial_number = self._ensure_open.getASCIIStringDescriptor(
+                self._impl_device.getSerialNumberDescriptor())
+        return self._serial_number
+
+    @property
+    @_map_exceptions
+    def version(self) -> int:
+        return self._impl_device.getbcdDevice()
+
+    @property
+    @_map_exceptions
+    def location(self) -> str:
+        return f"{self._impl_device.getBusNumber():03d}/{self._impl_device.getDeviceAddress():03d}"
+
+    @property
+    @_map_exceptions
+    def configuration(self) -> 'Configuration':
+        for configuration in self._impl_device.iterConfigurations():
+            if configuration.getConfigurationValue() == self._ensure_open.getConfiguration():
+                return Configuration(configuration)
+        else:
+            assert False
+
+    @property
+    @_map_exceptions
+    def configurations(self) -> list['Configuration']:
+        return [
+            Configuration(configuration)
+            for configuration in self._impl_device.iterConfigurations()
+        ]
+
+    @_map_exceptions
+    async def open(self):
+        if self._impl_handle is None:
+            self._impl_handle = self._impl_device.open()
+            try:
+                self._impl_handle.setAutoDetachKernelDriver(True)
+            except usb1.USBErrorNotSupported:
+                pass
+
+    @_map_exceptions
+    async def close(self):
+        if self._impl_handle is not None:
+            self._impl_handle.close()
+            self._impl_handle = None
+
+    @_map_exceptions
+    async def select_configuration(self, configuration: int):
+        self._ensure_open.setConfiguration(configuration)
+
+    @_map_exceptions
+    async def select_alternate_interface(self, interface: int, setting: int):
+        self._ensure_open.setInterfaceAltSetting(interface, setting)
+
+    @_map_exceptions
+    async def claim_interface(self, interface: int):
+        self._ensure_open.claimInterface(interface)
+
+    @_map_exceptions
+    async def release_interface(self, interface: int):
+        self._ensure_open.releaseInterface(interface)
+
+    @_map_exceptions
+    async def _perform_transfer(self, direction: Direction, setup) -> bytearray | None:
+        # libusb transfer cancellation is asynchronous, and moreover, it is necessary to wait for
+        # all transfers to finish cancelling before closing the event loop. To do this, use
+        # separate futures for result and cancel.
+        cancel_future = asyncio.Future()
+        result_future = asyncio.Future()
+
+        transfer = self._ensure_open.getTransfer()
+        setup(transfer)
+
+        def callback(transfer: usb1.USBTransfer):
+            if self._poller.done:
+                return # shutting down
+            if transfer.isSubmitted():
+                return # transfer not completed
+
+            match transfer.getStatus():
+                case usb1.TRANSFER_CANCELLED:
+                    cancel_future.set_result(None)
+                case _ if result_future.cancelled():
+                    pass
+                case usb1.TRANSFER_COMPLETED if direction == Direction.In:
+                    result_future.set_result(transfer.getBuffer()[:transfer.getActualLength()])
+                case usb1.TRANSFER_COMPLETED if direction == Direction.Out:
+                    result_future.set_result(None)
+                case usb1.TRANSFER_STALL:
+                    result_future.set_exception(ErrorStall())
+                case usb1.TRANSFER_NO_DEVICE:
+                    result_future.set_exception(ErrorDisconnected())
+                case status:
+                    result_future.set_exception(Error(
+                        f"libusb1 status: {usb1.libusb1.libusb_transfer_status(status)}"))
+
+        loop = asyncio.get_event_loop()
+        transfer.setCallback(lambda transfer: loop.call_soon_threadsafe(callback, transfer))
+        transfer.submit()
+        try:
+            return await result_future
+        finally:
+            if result_future.cancelled():
+                try:
+                    transfer.cancel()
+                    await cancel_future
+                except usb1.USBErrorNotFound:
+                    pass # already finished, one way or another
+
+    async def control_transfer_in(self, request_type: RequestType, recipient: Recipient,
+                                  request: int, value: int, index: int, length: int) -> bytearray:
+        def setup(transfer):
+            transfer.setControl(
+                _map_request_type(request_type) | _map_recipient(recipient) | usb1.ENDPOINT_IN,
+                request, value, index, length)
+        return memoryview(await self._perform_transfer(Direction.In, setup))
+
+    async def control_transfer_out(self, request_type: RequestType, recipient: Recipient,
+                                   request: int, value: int, index: int, data: bytearray):
+        def setup(transfer):
+            transfer.setControl(
+                _map_request_type(request_type) | _map_recipient(recipient) | usb1.ENDPOINT_OUT,
+                request, value, index, data)
+        await self._perform_transfer(Direction.Out, setup)
+
+    async def bulk_transfer_in(self, endpoint: int, length: int) -> bytearray:
+        def setup(transfer):
+            transfer.setBulk(endpoint, length)
+        return memoryview(await self._perform_transfer(Direction.In, setup))
+
+    async def bulk_transfer_out(self, endpoint: int, data: bytearray):
+        def setup(transfer):
+            transfer.setBulk(endpoint, data)
+        await self._perform_transfer(Direction.Out, setup)
+
+
+class Configuration(AbstractConfiguration):
+    def __init__(self, _impl: usb1.USBConfiguration):
+        self._impl = _impl
+
+    @property
+    def value(self) -> int:
+        return self._impl.getConfigurationValue()
+
+    @property
+    def interfaces(self) -> list['Interface']:
+        return [
+            Interface(number, interface)
+            for number, interface in enumerate(self._impl.iterInterfaces())
+        ]
+
+
+class Interface(AbstractInterface):
+    def __init__(self, _number: int, _impl: usb1.USBInterface):
+        self._number = _number
+        self._impl = _impl
+
+    @property
+    def number(self) -> int:
+        return self._number
+
+    @property
+    def alternates(self) -> list['AlternateInterface']:
+        return [
+            AlternateInterface(alternate)
+            for alternate in self._impl.iterSettings()
+        ]
+
+
+class AlternateInterface(AbstractAlternateInterface):
+    def __init__(self, _impl: usb1.USBInterfaceSetting):
+        self._impl = _impl
+
+    @property
+    def setting(self) -> int:
+        return self._impl.getAlternateSetting()
+
+    @property
+    def endpoints(self) -> list['Endpoint']:
+        return [
+            Endpoint(endpoint)
+            for endpoint in self._impl.iterEndpoints()
+        ]
+
+
+class Endpoint(AbstractEndpoint):
+    def __init__(self, _impl: usb1.USBEndpoint):
+        self._impl = _impl
+
+    @property
+    def number(self) -> int:
+        return self._impl.getAddress()
+
+    @property
+    def direction(self) -> Direction:
+        if self._impl.getAddress() & usb1.ENDPOINT_IN:
+            return Direction.In
+        else:
+            return Direction.Out
+
+    @property
+    def type(self) -> EndpointType:
+        match self._impl.getAttributes() & usb1.TRANSFER_TYPE_MASK:
+            case usb1.TRANSFER_TYPE_BULK:
+                return EndpointType.Bulk
+            case usb1.TRANSFER_TYPE_INTERRUPT:
+                return EndpointType.Interrupt
+            case usb1.TRANSFER_TYPE_ISOCHRONOUS:
+                return EndpointType.Isochronous
+            case _:
+                raise NotImplementedError(f"bmAttributes={self._impl.getAttributes():#04x}")
+
+    @property
+    def packet_size(self) -> int:
+        return self._impl.getMaxPacketSize()

--- a/software/glasgow/support/usb/webusb.py
+++ b/software/glasgow/support/usb/webusb.py
@@ -1,0 +1,271 @@
+from typing import Optional, Callable
+import functools
+import inspect
+import js
+import pyodide.ffi
+import pyodide.ffi.wrappers
+
+from . import *
+from . import __all__ as _abstract_all
+
+
+__all__ = _abstract_all + [
+    "Context",
+    "Device",
+    "Configuration",
+    "Interface",
+    "AlternateInterface",
+    "Endpoint",
+]
+
+
+def _map_result(result):
+    match result.status:
+        case "ok":
+            return result
+        case "stall":
+            raise ErrorStall()
+        case "babble":
+            raise ErrorBabble()
+        case _:
+            assert False
+
+
+def _map_exceptions(f):
+    def map_error(error):
+        match error.name:
+            case "InvalidAccessError":
+                raise ErrorNotSupported(error.message) from None
+            case "NotFoundError":
+                raise ErrorNotFound(error.message) from None
+            case "SecurityError":
+                raise ErrorAccess(error.message) from None
+            case "DataError":
+                raise ErrorOutOfMemory(error.message) from None
+            case "InvalidStateError":
+                raise ErrorNotOpen(error.message) from None
+            case "NetworkError":
+                raise ErrorDisconnected(error.message) from None
+            case "AbortError":
+                raise ErrorAborted(error.message) from None
+            case _:
+                raise Error(f"{error.name}: {error.message}") from error
+
+    if inspect.iscoroutinefunction(f):
+        @functools.wraps(f)
+        async def wrapper(*args, **kwargs):
+            try:
+                return await f(*args, **kwargs)
+            except pyodide.ffi.JsException as err:
+                map_error(err)
+    else:
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            try:
+                return f(*args, **kwargs)
+            except pyodide.ffi.JsException as err:
+                map_error(err)
+    return wrapper
+
+
+class Context(AbstractContext):
+    def __init__(self):
+        self._impl = js.navigator.usb
+        self._on_connect = []
+        self._on_disconnect = []
+
+        pyodide.ffi.wrappers.add_event_listener(
+            self._impl, "connect", self._process_connect_event)
+        pyodide.ffi.wrappers.add_event_listener(
+            self._impl, "disconnect", self._process_disconnect_event)
+
+    @_map_exceptions
+    async def request_device(self, vendor_id: int, product_id: int):
+        await self._impl.requestDevice({"filters": [
+            {"vendorId": vendor_id, "productId": product_id}
+        ]})
+
+    @_map_exceptions
+    async def get_devices(self) -> list['Device']:
+        return [Device(device) for device in await self._impl.getDevices()]
+
+    @property
+    def has_hotplug_support(self) -> bool:
+        return True
+
+    def add_connect_callback(self, callback: Callable[['Device'], None]):
+        self._on_connect.append(callback)
+
+    def _process_connect_event(self, event):
+        for callback in self._on_connect:
+            callback(Device(event.device))
+
+    def add_disconnect_callback(self, callback: Callable[['Device'], None]):
+        self._on_disconnect.append(callback)
+
+    def _process_disconnect_event(self, event):
+        for callback in self._on_disconnect:
+            callback(Device(event.device))
+
+
+class Device(AbstractDevice):
+    def __init__(self, _impl):
+        self._impl = _impl
+
+    @property
+    def vendor_id(self) -> int:
+        return self._impl.vendorId
+
+    @property
+    def product_id(self) -> int:
+        return self._impl.productId
+
+    @property
+    def manufacturer_name(self) -> Optional[str]:
+        return self._impl.manufacturerName
+
+    @property
+    def product_name(self) -> Optional[str]:
+        return self._impl.productName
+
+    @property
+    def serial_number(self) -> Optional[str]:
+        return self._impl.serialNumber
+
+    @property
+    def version(self) -> int:
+        return (
+            self._impl.deviceVersionMajor << 8 |
+            self._impl.deviceVersionMinor << 4 |
+            self._impl.deviceVersionSubminor
+        )
+
+    @property
+    def location(self) -> str:
+        return "<webusb>"
+
+    @property
+    def configuration(self) -> 'Configuration':
+        return Configuration(self._impl.configuration)
+
+    @property
+    def configurations(self) -> list['Configuration']:
+        return [Configuration(configuration) for configuration in self._impl.configurations]
+
+    @_map_exceptions
+    async def open(self):
+        await self._impl.open()
+
+    @_map_exceptions
+    async def close(self):
+        await self._impl.close()
+
+    @_map_exceptions
+    async def select_configuration(self, configuration: int):
+        await self._impl.selectConfiguration(configuration)
+
+    @_map_exceptions
+    async def select_alternate_interface(self, interface: int, setting: int):
+        await self._impl.selectAlternateInterface(interface, setting)
+
+    @_map_exceptions
+    async def claim_interface(self, interface: int):
+        await self._impl.claimInterface(interface)
+
+    @_map_exceptions
+    async def release_interface(self, interface: int):
+        await self._impl.releaseInterface(interface)
+
+    @_map_exceptions
+    async def control_transfer_in(self, request_type: RequestType, recipient: Recipient,
+                                  request: int, value: int, index: int, length: int) -> memoryview:
+        return _map_result(await self._impl.controlTransferIn({
+            "requestType": request_type.value,
+            "recipient": recipient.value,
+            "request": request,
+            "value": value,
+            "index": index,
+        }, length)).data.to_py()
+
+    @_map_exceptions
+    async def control_transfer_out(self, request_type: RequestType, recipient: Recipient,
+                                   request: int, value: int, index: int, data: bytes | bytearray):
+        await self._impl.controlTransferOut({
+            "requestType": request_type.value,
+            "recipient": recipient.value,
+            "request": request,
+            "value": value,
+            "index": index,
+        }, pyodide.ffi.to_js(data).buffer)
+
+    @_map_exceptions
+    async def bulk_transfer_in(self, endpoint: int, length: int) -> memoryview:
+        return _map_result(await self._impl.transferIn(endpoint, length)).data.to_py()
+
+    @_map_exceptions
+    async def bulk_transfer_out(self, endpoint: int, data: bytes | bytearray):
+        await self._impl.transferOut(endpoint, pyodide.ffi.to_js(data).buffer)
+
+
+class Configuration(AbstractConfiguration):
+    def __init__(self, _impl):
+        self._impl = _impl
+
+    @property
+    def value(self) -> int:
+        return self._impl.configurationValue
+
+    @property
+    def interfaces(self) -> list['Interface']:
+        return [Interface(interface) for interface in self._impl.interfaces]
+
+
+class Interface(AbstractInterface):
+    def __init__(self, _impl):
+        self._impl = _impl
+
+    @property
+    def number(self) -> int:
+        return self._impl.interfaceNumber
+
+    # @property
+    # def alternate(self) -> 'AlternateInterface':
+    #     return AlternateInterface(self._impl.alternate)
+
+    @property
+    def alternates(self) -> list['AlternateInterface']:
+        return [AlternateInterface(alternate) for alternate in self._impl.alternates]
+
+
+class AlternateInterface(AbstractAlternateInterface):
+    def __init__(self, _impl):
+        self._impl = _impl
+
+    @property
+    def setting(self) -> int:
+        return self._impl.alternateSetting
+
+    @property
+    def endpoints(self) -> list['Endpoint']:
+        return [Endpoint(endpoint) for endpoint in self._impl.endpoints]
+
+
+class Endpoint(AbstractEndpoint):
+    def __init__(self, _impl):
+        self._impl = _impl
+
+    @property
+    def number(self) -> int:
+        return self._impl.endpointNumber
+
+    @property
+    def direction(self) -> Direction:
+        return Direction(self._impl.direction)
+
+    @property
+    def type(self) -> EndpointType:
+        return EndpointType(self._impl.type)
+
+    @property
+    def packet_size(self) -> int:
+        return self._impl.packetSize

--- a/software/pdm.min.lock
+++ b/software/pdm.min.lock
@@ -5,7 +5,7 @@
 groups = ["default", "builtin-toolchain", "http", "numpy"]
 strategy = ["direct_minimal_versions"]
 lock_version = "4.5.0"
-content_hash = "sha256:5e68c6473c4fedab69d523751b5c766ebab8c6c86980c86b4f736133f5424c55"
+content_hash = "sha256:2a9c726999a2a3967db4ab2f5c1673e96251acb5e175415d142a14aa4fab235a"
 
 [[metadata.targets]]
 requires_python = "~=3.11"

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
   # `libusb1` is used to communicate with the device, and its API mirrors the stable API/ABI of
   # of the native `libusb1` library. It increases major version when dropping support for older
   # Python versions.
-  "libusb1>=3.3.0",
+  "libusb1>=3.3.0; sys_platform!='emscripten'",
   # `cobs` is used to multiplex communication streams in applets. It uses an ad-hoc versioning
   # system.
   "cobs>=1.2.1",


### PR DESCRIPTION
This is very much not mergeable yet. To be completed:
- [x] Don't use `aobject` for `GlasgowDevice`
- [x] Hotplug support
- [x] Logging of cancelled URBs