### PR TITLE
software/deploy-firmware: skip group addition if group already exists

### DIFF
--- a/software/deploy-firmware.sh
+++ b/software/deploy-firmware.sh
@@ -30,7 +30,7 @@ apt-get install -qq --no-install-recommends git make sdcc
 # apt-get would not be able to install packages.
 #
 # Create a user and a group with the UID/GID of the caller.
-groupadd --gid ${GID} caller
+groupadd --gid ${GID} caller || true
 useradd --uid ${UID} --gid ${GID} caller
 
 # Do the work.


### PR DESCRIPTION
Running the script on a distribution where the current user is using gid 100 fails, as that group already exists inside the image:

```
Setting up libgssapi-krb5-2:arm64 (1.20.1-2+deb12u3) ...
Setting up libgdbm-compat4:arm64 (1.23-3) ...
Setting up libperl5.36:arm64 (5.36.0-7+deb12u2) ...
Setting up libcurl3-gnutls:arm64 (7.88.1-10+deb12u12) ...
Setting up perl (5.36.0-7+deb12u2) ...
Setting up liberror-perl (0.17029-2) ...
Setting up git (1:2.39.5-0+deb12u2) ...
Processing triggers for libc-bin (2.36-9+deb12u10) ...
+ groupadd --gid 100 caller
groupadd: GID '100' already exists
```
(nonzero exit code, aborted build)

It's fine to skip group creation in this case, we care about the group to exist, not how it's called.