### PR TITLE
firmware: don't bake GIT_REVISION into firmware

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -13,18 +13,3 @@ CFLAGS    = -DSYNCDELAYLEN=16 -DCONF_SIZE=$(CONF_SIZE)
 
 LIBFX2    = ../vendor/libfx2/firmware/library
 include $(LIBFX2)/fx2rules.mk
-
-# Make executes makefiles in two stages: first it builds a dependency graph and determines freshness, and then it
-# starts to actually build the targets. By the time it starts to build, any updates to the freshness of files on
-# disk will be ignored; therefore we need to build the `version.h` target during the first stage. In practical
-# terms this is accomplished by building it as a part of an immediate assignment.
-#
-# Yes, this is awful. I am so proud of it =^_^=
-GIT_REV_SHORT   = $(shell git log -1 --abbrev=8 --pretty=%h HEAD .)
-ifneq ($(shell git diff-index --exit-code HEAD -- .),)
-GIT_TREE_DIRTY  = .dirty
-endif
-VERSION_H_RULE := $(shell \
-	echo "#define GIT_REVISION \"$(GIT_REV_SHORT)$(GIT_TREE_DIRTY)\"" >.version.h && \
-	if ! diff -q .version.h version.h 2>/dev/null ; then mv .version.h version.h; else rm -f .version.h; fi \
-)

--- a/firmware/main.c
+++ b/firmware/main.c
@@ -8,7 +8,6 @@
 #include <fx2eeprom.h>
 #include <usbmicrosoft.h>
 #include "glasgow.h"
-#include "version.h"
 
 // bcdDevice is a 16-bit number where the high byte indicates the API revision and the low byte
 // indicates the hardware revision. If the firmware is not flashed (only the FX2 header is present)
@@ -157,7 +156,7 @@ usb_configuration_set_c usb_configs[] = {
 
 usb_ascii_string_c usb_strings[] = {
   [0] = "whitequark research\0\0\0", // CONFIG_SIZE_MANUFACTURER characters long
-  [1] = "Glasgow Interface Explorer (git " GIT_REVISION ")",
+  [1] = "Glasgow Interface Explorer",
   [2] = "XX-XXXXXXXXXXXXXXXX",
 };
 

--- a/software/deploy-firmware.sh
+++ b/software/deploy-firmware.sh
@@ -23,7 +23,7 @@ set -ex
 
 # Install dependencies.
 apt-get update -qq
-apt-get install -qq --no-install-recommends git make sdcc
+apt-get install -qq --no-install-recommends make sdcc
 
 # Any commands that create new files in the host mount must be invoked with the caller UID/GID, or
 # else the created files will be owned by root. We can't use `docker run --user` because then


### PR DESCRIPTION
This certainly causes the firmware to be a different one on every commit, and it'd become impossible to update the generated firmware alongside (as the commit ID is CA and would change).

There's also no commit ID to determine if we're just dealing with a raw archive of a specific revision, without a `.git` directory.

If we want to reintroduce some version ID into the firmware, it probably should be something that doesn't change on each commit, and is overridable externally, so build systems/packagers can pass the version string externally.

Asking `pdm` for the version string [^1] might check these boxes; we can define a less noisy version_format, it can be overridden with PDM_BUILD_SCM_VERSION, and a fallback can be defined, but maybe not baking one in at all for the sake of reproducibility is better?

[^1]: https://backend.pdm-project.org/metadata/