### PR TITLE
Block yowasp-yosys 0.56

### DIFF
--- a/software/pdm.min.lock
+++ b/software/pdm.min.lock
@@ -5,7 +5,7 @@
 groups = ["default", "builtin-toolchain", "http", "numpy"]
 strategy = ["direct_minimal_versions"]
 lock_version = "4.5.0"
-content_hash = "sha256:f70ed3a1c040429b00ef80562afe91d3c8d59f32fbbeb5303a1fd1048a548259"
+content_hash = "sha256:b702a6bc4183702ef9f29c5e0c8f04d14339521abbb2a6e9cc774b1f4fe746ca"
 
 [[metadata.targets]]
 requires_python = "~=3.11"

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -66,7 +66,7 @@ builtin-toolchain = [
   # the lowest that has features transitively required by Glasgow.
   "yowasp-runtime>=1.42",
   # Most versions of Yosys and nextpnr work; the minimum versions listed here are known good.
-  "yowasp-yosys>=0.31.0.13,!=0.54.*,!=0.55.*",
+  "yowasp-yosys>=0.31.0.13,!=0.54.*,!=0.55.*,!=0.56.*",
   "yowasp-nextpnr-ice40>=0.1",
 ]
 


### PR DESCRIPTION
yowap-yosys 0.56 breaks Glasgow builds. Block it in the same way as 0.54 and 0.55.

Fixes #994