### PR TITLE
Fix `glasgow run ...` exception on bad voltage.

### DIFF
--- a/software/glasgow/hardware/assembly.py
+++ b/software/glasgow/hardware/assembly.py
@@ -709,11 +709,11 @@ class HardwareAssembly(AbstractAssembly):
     async def configure_ports(self):
         for port, vio in self._voltages.items():
             if vio.sense is not None:
-                sensed = await self.device.mirror_voltage(port, str(vio.sense))
+                sensed = await self.device.mirror_voltage(str(port), str(vio.sense))
                 logger.info(
                     "port %s voltage set to %.1f V (sensed on port %s)", port, sensed, vio.sense)
             if vio.value is not None:
-                await self.device.set_voltage(port, vio.value)
+                await self.device.set_voltage(str(port), vio.value)
                 logger.info("port %s voltage set to %.1f V", port, vio.value)
 
         port_pulls = defaultdict(lambda: (set(), set()))


### PR DESCRIPTION
There were two places in `HardwareAssembly` where `GlasgowPort` was passed directly to a device function expecting a portspec (str). On an error, it tried to iterate over the passed `GlasgowPort` which threw an exception.