### PR TITLE
Exclude yowasp-yosys 0.64

### DIFF
--- a/software/pdm.min.lock
+++ b/software/pdm.min.lock
@@ -5,7 +5,7 @@
 groups = ["default", "builtin-toolchain", "http", "numpy"]
 strategy = ["direct_minimal_versions"]
 lock_version = "4.5.0"
-content_hash = "sha256:8c85200ed646b9603b9f46483913f92b1476b716e5b6b7a8feeb60634ee3b7a7"
+content_hash = "sha256:dd37fcce557acc1e4f2e531749dcb2ce3adab52874f162123463713871f12df6"
 
 [[metadata.targets]]
 requires_python = "~=3.13"
@@ -96,15 +96,15 @@ files = [
 
 [[package]]
 name = "click"
-version = "8.3.2"
+version = "8.3.3"
 requires_python = ">=3.10"
 summary = "Composable command line interface toolkit"
 dependencies = [
     "colorama; platform_system == \"Windows\"",
 ]
 files = [
-    {file = "click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d"},
-    {file = "click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5"},
+    {file = "click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613"},
+    {file = "click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2"},
 ]
 
 [[package]]
@@ -329,12 +329,12 @@ files = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.13"
 requires_python = ">=3.8"
 summary = "Internationalized Domain Names in Applications (IDNA)"
 files = [
-    {file = "idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea"},
-    {file = "idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"},
+    {file = "idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3"},
+    {file = "idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242"},
 ]
 
 [[package]]

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -70,7 +70,7 @@ builtin-toolchain = [
   # the lowest that has features transitively required by Glasgow.
   "yowasp-runtime>=1.42",
   # Most versions of Yosys and nextpnr work; the minimum versions listed here are known good.
-  "yowasp-yosys>=0.31.0.13,!=0.54.*,!=0.55.*,!=0.56.*",
+  "yowasp-yosys>=0.31.0.13,!=0.54.*,!=0.55.*,!=0.56.*,!=0.64.*",
   "yowasp-nextpnr-ice40>=0.1",
 ]
 


### PR DESCRIPTION
This fixes some test suite failures likely related to https://github.com/YosysHQ/yosys/issues/5802, but the link has not been explicitly confirmed.