### PR TITLE
[nit] Fix typo in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,7 +16,7 @@
 /software/glasgow/database/xilinx/xc9500xl.py           @wanda-phi
 /software/glasgow/database/xilinx/xpla3.py              @wanda-phi
 
-/software/glasgow/applet/internal/calibrate_clock       @i-infra
+/software/glasgow/applet/measure/calibrate_clock        @i-infra
 
 /software/glasgow/applet/servo/                         @tpwrules
 


### PR DESCRIPTION
Sorry for the commit noise. Accidentally forgot to update `CODEOWNERS` after we decided where to put the `calibrate_clock` applet we merged earlier today. Path is currently incorrect, this one-line PR fixes it.