### PR TITLE
firmware: implement current measurement via the ina233 used in revC3, *do not* bump API level

### DIFF
--- a/firmware/adc_ina233.c
+++ b/firmware/adc_ina233.c
@@ -58,7 +58,17 @@ static bool iobuf_reset_ina233(uint8_t i2c_addr) {
   if(!i2c_reg8_write(i2c_addr, INA233_REG_MFR_ALERT_MASK, &regval, 1))
     return false;
 
-  // TODO: write cal register to allow current measurement
+  // Write calibration register to enable current measurement.
+  // R_shunt = 0.15 ohm, I_max = 0.546 A (from schematic: 81.9 mV / 0.15 ohm)
+  // Current_LSB = I_max / 2^15 = 16.66 uA/LSB
+  // CAL = 0.00512 / (R_shunt * Current_LSB) = 0.00512 / (0.15 * 16.66e-6) = 2048
+  {
+    __pdata uint8_t cal_bytes[2];
+    cal_bytes[0] = 0x00; // 2048 & 0xFF
+    cal_bytes[1] = 0x08; // 2048 >> 8
+    if(!i2c_reg8_write(i2c_addr, INA233_REG_MFR_CALIBRATION, cal_bytes, 2))
+      return false;
+  }
 
   return true;
 }
@@ -101,6 +111,25 @@ bool iobuf_measure_voltage_ina233(uint8_t selector, __xdata uint16_t *millivolts
         return false;
 
       *millivolts = code_bytes_to_millivolts_ina233(code_bytes);
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool iobuf_measure_current_ina233(uint8_t selector, __xdata uint16_t *raw) {
+  __code const struct buffer_desc *buffer;
+  for(buffer = buffers; buffer->selector; buffer++) {
+    if(selector == buffer->selector) {
+      __pdata uint8_t code_bytes[2];
+      if(!i2c_reg8_read(buffer->address, INA233_REG_READ_IIN, code_bytes, 2))
+        return false;
+
+      // Return raw register value (LSB first from INA233).
+      // Conversion to amps done on host: amps = raw * Current_LSB
+      // Current_LSB = I_max / 2^15 = 0.546 / 32768 = 16.66 uA
+      *raw = ((uint16_t)code_bytes[1] << 8) | code_bytes[0];
       return true;
     }
   }

--- a/firmware/glasgow.h
+++ b/firmware/glasgow.h
@@ -28,7 +28,7 @@ enum {
 
 enum {
   // API compatibility level
-  CUR_API_LEVEL  = 0x05,
+  CUR_API_LEVEL  = 0x06,
 };
 
 // PORTA pins
@@ -174,6 +174,7 @@ bool iobuf_poll_alert_adc081c(__xdata uint8_t *mask, bool clear);
 // ADC API (TI INA233)
 bool iobuf_init_adc_ina233();
 bool iobuf_measure_voltage_ina233(uint8_t selector, __xdata uint16_t *millivolts);
+bool iobuf_measure_current_ina233(uint8_t selector, __xdata uint16_t *raw);
 bool iobuf_set_alert_ina233(uint8_t mask,
                      __xdata const uint16_t *low_millivolts,
                      __xdata const uint16_t *high_millivolts);

--- a/firmware/main.c
+++ b/firmware/main.c
@@ -314,6 +314,7 @@ enum {
   USB_REQ_IOBUF_ENABLE = 0x19,
   USB_REQ_LIMIT_VOLT   = 0x1A,
   USB_REQ_PULL         = 0x1B,
+  USB_REQ_SENSE_CURR   = 0x1E,
   USB_REQ_TEST_LEDS    = 0x1C,
   USB_REQ_TEST_PULLS   = 0x1D,
   // Cypress requests
@@ -656,6 +657,30 @@ void handle_pending_usb_setup() {
       result = iobuf_measure_voltage_ina233(arg_mask, (__xdata uint16_t *)EP0BUF);
     else
       result = iobuf_measure_voltage_adc081c(arg_mask, (__xdata uint16_t *)EP0BUF);
+
+    if(!result) {
+      goto stall_ep0_return;
+    } else {
+      SETUP_EP0_IN_BUF(2);
+    }
+
+    return;
+  }
+
+  // Current sense request
+  if(req_dir_in &&
+     req->bRequest == USB_REQ_SENSE_CURR &&
+     req->wLength == 2) {
+    uint8_t  arg_mask = req->wIndex;
+    pending_setup = false;
+    bool result;
+
+    while(EP0CS & _BUSY);
+
+    if(glasgow_config.revision >= GLASGOW_REV_C2)
+      result = iobuf_measure_current_ina233(arg_mask, (__xdata uint16_t *)EP0BUF);
+    else
+      result = false; // no current measurement on older hardware
 
     if(!result) {
       goto stall_ep0_return;


### PR DESCRIPTION
Now with just the firmware / C edits, and one-line edit to device.py to match API levels. See #1164 for discussion.