### PR TITLE
database.microchip.avr: Fix flash size for ATtiny45 and ATtiny85

### DIFF
--- a/software/glasgow/database/microchip/avr.py
+++ b/software/glasgow/database/microchip/avr.py
@@ -36,8 +36,8 @@ devices = [
                                        fuses_size=2),
     ATtiny("25",   (0x1e, 0x91, 0x08), program_size=1024,  program_page=32,  eeprom_size=128),
     ATtiny("26",   (0x1e, 0x91, 0x09), program_size=2048,  program_page=32,  eeprom_size=128, erase_time=15),
-    ATtiny("45",   (0x1e, 0x92, 0x06), program_size=2048,  program_page=64,  eeprom_size=256),
-    ATtiny("85",   (0x1e, 0x93, 0x0B), program_size=4096,  program_page=64,  eeprom_size=512),
+    ATtiny("45",   (0x1e, 0x92, 0x06), program_size=4096,  program_page=64,  eeprom_size=256),
+    ATtiny("85",   (0x1e, 0x93, 0x0B), program_size=8192,  program_page=64,  eeprom_size=512),
     ATtiny("1634", (0x1e, 0x94, 0x12), program_size=16384, program_page=32,  eeprom_size=256),
     # ATmega series
     ATmega("8",    (0x1e, 0x93, 0x07), program_size=8192,  program_page=64,  eeprom_size=512, erase_time=15),


### PR DESCRIPTION
Tested with ATtiny45, though fix for ATtiny85 should work as well.

<img width="1001" height="334" alt="image" src="https://github.com/user-attachments/assets/ec896261-4d32-430c-98d7-744651865092" />
