### PR TITLE
Fix PRN and Curve Trace applets

### DIFF
--- a/software/glasgow/applet/measure/prn_noise/__init__.py
+++ b/software/glasgow/applet/measure/prn_noise/__init__.py
@@ -227,13 +227,13 @@ class PRNNoiseInterface:
         """
         seed = seed & 0xFFFFFFFF
         self._log("start seed=%#010x", seed)
-        await self._pipe.send(struct.pack("<BI", _Command.Start, seed))
+        await self._pipe.send(struct.pack("<BI", _Command.Start.value, seed))
         await self._pipe.flush()
 
     async def stop(self):
         """Stop noise output (hold pin low)."""
         self._log("stop")
-        await self._pipe.send(bytes([_Command.Stop]))
+        await self._pipe.send(bytes([_Command.Stop.value]))
         await self._pipe.flush()
 
 

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -91,6 +91,7 @@ glasgow = "glasgow.cli:run_main"
 selftest = "glasgow.applet.internal.selftest:SelfTestApplet"
 benchmark = "glasgow.applet.internal.benchmark:BenchmarkApplet"
 calibrate-clock = "glasgow.applet.measure.calibrate_clock:CalibrateClockApplet"
+curve-trace = "glasgow.applet.measure.curve_trace:CurveTraceApplet"
 generate-prn-noise = "glasgow.applet.measure.prn_noise:GeneratePRNNoiseApplet"
 
 analyzer = "glasgow.applet.interface.analyzer:AnalyzerApplet"


### PR DESCRIPTION
`applet.measure.cuve_trace`: expose the curve trace applet

`applet.measure.prn_noise`: properly serialize amaranth enum