### PR TITLE
software/pyproject: exclude yosys 0.67 for now

### DIFF
--- a/software/pdm.min.lock
+++ b/software/pdm.min.lock
@@ -5,7 +5,7 @@
 groups = ["default", "builtin-toolchain", "http", "numpy"]
 strategy = ["direct_minimal_versions"]
 lock_version = "4.5.0"
-content_hash = "sha256:dd37fcce557acc1e4f2e531749dcb2ce3adab52874f162123463713871f12df6"
+content_hash = "sha256:30a0a11000dcf551893ace8c78a9a4e65506d15aeed4e2e8de488b837008aaea"
 
 [[metadata.targets]]
 requires_python = "~=3.13"

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -70,7 +70,7 @@ builtin-toolchain = [
   # the lowest that has features transitively required by Glasgow.
   "yowasp-runtime>=1.42",
   # Most versions of Yosys and nextpnr work; the minimum versions listed here are known good.
-  "yowasp-yosys>=0.31.0.13,!=0.54.*,!=0.55.*,!=0.56.*,!=0.64.*",
+  "yowasp-yosys>=0.31.0.13,!=0.54.*,!=0.55.*,!=0.56.*,!=0.64.*,!=0.67.*",
   "yowasp-nextpnr-ice40>=0.1",
 ]
 


### PR DESCRIPTION
As seen in https://github.com/GlasgowEmbedded/glasgow/pull/1196#issuecomment-4996070301, there seems to be a regression with yosys 0.67, so exclude it for now.