### PR TITLE
Add onboard DRAM support and memtest applet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 *.vcd
 *.gtkw
+*.surf.ron
 *.log
 /*.v
 /*.bin

--- a/docs/manual/src/applets/internal/benchmark.rst
+++ b/docs/manual/src/applets/internal/benchmark.rst
@@ -1,5 +1,5 @@
 ``benchmark``
-====================
+=============
 
 .. _applet.internal.benchmark:
 

--- a/docs/manual/src/applets/internal/index.rst
+++ b/docs/manual/src/applets/internal/index.rst
@@ -9,3 +9,4 @@ Internal test
     :maxdepth: 2
 
     benchmark
+    memtest

--- a/docs/manual/src/applets/internal/memtest.rst
+++ b/docs/manual/src/applets/internal/memtest.rst
@@ -1,0 +1,7 @@
+``memtest``
+===========
+
+.. _applet.internal.memtest:
+
+.. autoprogram:: glasgow.applet.internal.memtest:MemoryTestApplet._get_argparser_for_sphinx("memtest")
+    :prog: glasgow run memtest

--- a/software/glasgow/abstract.py
+++ b/software/glasgow/abstract.py
@@ -11,8 +11,9 @@ import math
 from amaranth import *
 from amaranth.lib import io
 
-from glasgow.gateware.ports import PortGroup
 from glasgow.support import logging
+from glasgow.gateware.ports import PortGroup
+from glasgow.gateware import octoram
 
 
 __all__ = [
@@ -355,6 +356,11 @@ class AbstractAssembly(metaclass=ABCMeta):
     def add_inout_pipe(self, in_stream, out_stream, *, in_flush=C(0),
                        in_fifo_depth=None, in_buffer_size=None,
                        out_fifo_depth=None, out_buffer_size=None) -> AbstractInOutPipe:
+        pass
+
+    # Many of these interfaces are subject to change. This one is *particularly* subject to change.
+    @abstractmethod
+    def add_dynamic_memory(self, size: None | int = None) -> tuple[octoram.Signature, range]:
         pass
 
     @abstractmethod

--- a/software/glasgow/applet/internal/memtest/__init__.py
+++ b/software/glasgow/applet/internal/memtest/__init__.py
@@ -1,0 +1,321 @@
+import asyncio
+import logging
+
+from amaranth import *
+from amaranth.utils import exact_log2
+from amaranth.lib import enum, data, wiring, stream
+from amaranth.lib.wiring import In, Out
+
+from glasgow.gateware import octoram
+from glasgow.abstract import AbstractAssembly
+from glasgow.applet import GlasgowAppletV2
+
+
+__all__ = []
+
+
+class Pattern(enum.Enum, shape=4):
+    Const0 = 0
+    Const1 = 1
+    ConstA = 2
+    Const5 = 3
+    Alt01  = 4
+    Alt10  = 5
+    PRBS   = 6
+
+
+class PatternGenerator(wiring.Component):
+    mode:  In(Pattern)
+    addr:  In(32)
+
+    start: In(1)
+    data:  Out(stream.Signature(data.ArrayLayout(8, 2), always_valid=True))
+
+    def elaborate(self, platform):
+        m = Module()
+
+        seed = Signal(16)
+        m.d.comb += seed.eq(self.addr[:16] ^ self.addr[16:])
+
+        lfsr = Signal(16)
+        with m.If(self.start):
+            m.d.sync += lfsr.eq(Mux(seed != 0, seed, 1))
+        with m.Elif(self.data.ready):
+            m.d.sync += lfsr.eq(Cat(lfsr[15] ^ lfsr[14] ^ lfsr[12] ^ lfsr[3], lfsr))
+
+        with m.Switch(self.mode):
+            with m.Case(Pattern.Const0):
+                m.d.comb += self.data.payload.eq( 0)
+            with m.Case(Pattern.Const1):
+                m.d.comb += self.data.payload.eq(~0)
+            with m.Case(Pattern.ConstA):
+                m.d.comb += self.data.payload[0].eq(0xAA)
+                m.d.comb += self.data.payload[1].eq(0xAA)
+            with m.Case(Pattern.Const5):
+                m.d.comb += self.data.payload[0].eq(0x55)
+                m.d.comb += self.data.payload[1].eq(0x55)
+            with m.Case(Pattern.Alt01):
+                m.d.comb += self.data.payload[0].eq( 0)
+                m.d.comb += self.data.payload[1].eq(~0)
+            with m.Case(Pattern.Alt10):
+                m.d.comb += self.data.payload[0].eq(~0)
+                m.d.comb += self.data.payload[1].eq( 0)
+            with m.Case(Pattern.PRBS):
+                m.d.comb += self.data.payload.eq(lfsr)
+
+        return m
+
+
+class MemoryTestComponent(wiring.Component):
+    pattern:    In(Pattern)
+    start_addr: In(32)
+    stop_addr:  In(32)
+    block_size: In(12)
+    repeat:     In(1)
+    curr_addr:  Out(32)
+
+    error_addr: Out(32)
+    error_gold: Out(16)
+    error_data: Out(16)
+
+    active:     In(1)
+    cycles:     Out(16)
+    errors:     Out(16)
+
+    def __init__(self, bus, *, sys_clk_period):
+        self._bus = bus
+        self._sys_clk_period = sys_clk_period
+
+        super().__init__()
+
+    def elaborate(self, platform):
+        m = Module()
+
+        curr_addr = Signal(32)
+        curr_size = Signal.like(self.block_size)
+        m.d.comb += self.curr_addr.eq(curr_addr)
+
+        m.d.comb += self._bus.commands.p.addr.eq(curr_addr)
+        m.d.comb += self._bus.commands.p.size.eq(self.block_size >> 1)
+
+        m.submodules.pat_gen = pat_gen = PatternGenerator()
+        m.d.comb += pat_gen.mode.eq(self.pattern)
+
+        bit_errors = Signal(range(17))
+        m.d.comb += bit_errors.eq(sum(self._bus.r_data.p[0].data ^ pat_gen.data.p[0]) +
+                                  sum(self._bus.r_data.p[1].data ^ pat_gen.data.p[1]))
+
+        reset_cycles = int(5e-6 / self._sys_clk_period) # tRST=2us (APS51208N-OBRx)
+        reset_timer  = Signal(range(reset_cycles), init=reset_cycles - 1)
+
+        with m.FSM():
+            with m.State("Test Start"):
+                with m.If(self.active):
+                    m.d.sync += self.errors.eq(0)
+                    m.d.sync += curr_addr.eq(self.start_addr)
+                    m.next = "Interface Reset"
+
+            with m.State("Interface Reset"):
+                m.d.comb += self._bus.commands.p.type.eq(octoram.Command.GlobalReset)
+                m.d.comb += self._bus.commands.valid.eq(1)
+                with m.If(self._bus.commands.valid & self._bus.commands.ready):
+                    m.d.sync += reset_timer.eq(reset_timer.init)
+                    m.next = "Interface Reset Wait"
+
+            with m.State("Interface Reset Wait"):
+                with m.If(reset_timer != 0):
+                    m.d.sync += reset_timer.eq(reset_timer - 1)
+                with m.Else():
+                    m.next = "Block Write Command"
+
+            with m.State("Block Write Command"):
+                m.d.comb += self._bus.commands.p.type.eq(octoram.Command.WriteMemRow)
+                m.d.comb += self._bus.commands.valid.eq(1)
+                with m.If(self._bus.commands.valid & self._bus.commands.ready):
+                    m.d.comb += pat_gen.start.eq(1)
+                    m.d.sync += curr_size.eq(0)
+                    m.next = "Block Write Data"
+
+            with m.State("Block Write Data"):
+                with m.If(curr_size == self.block_size):
+                    m.next = "Block Read Command"
+                with m.Else():
+                    m.d.comb += [
+                        self._bus.w_data.p[0].data.eq(pat_gen.data.p[0]),
+                        self._bus.w_data.p[1].data.eq(pat_gen.data.p[1]),
+                        self._bus.w_data.valid.eq(pat_gen.data.valid),
+                        pat_gen.data.ready.eq(self._bus.w_data.ready),
+                    ]
+                    with m.If(self._bus.w_data.valid & self._bus.w_data.ready):
+                        m.d.sync += curr_size.eq(curr_size + 2)
+
+            with m.State("Block Read Command"):
+                m.d.comb += self._bus.commands.p.type.eq(octoram.Command.ReadMemRow)
+                m.d.comb += self._bus.commands.valid.eq(1)
+                with m.If(self._bus.commands.valid & self._bus.commands.ready):
+                    m.d.comb += pat_gen.start.eq(1)
+                    m.d.sync += curr_size.eq(0)
+                    m.next = "Block Read Data"
+
+            with m.State("Block Read Data"):
+                with m.If(curr_size == self.block_size):
+                    with m.If(curr_addr == self.stop_addr):
+                        m.next = "Cycle End"
+                    with m.Else():
+                        m.next = "Block Write Command"
+                with m.Else():
+                    m.d.comb += self._bus.r_data.ready.eq(1)
+                    with m.If(self._bus.r_data.valid & self._bus.r_data.ready):
+                        m.d.comb += pat_gen.data.ready.eq(1)
+                        with m.If(self.errors == 0):
+                            m.d.sync += self.error_addr.eq(curr_addr)
+                            m.d.sync += self.error_gold.eq(pat_gen.data.payload)
+                            m.d.sync += self.error_data.eq(self._bus.r_data.payload)
+                        with m.If(self.errors + bit_errors < (1 << len(bit_errors))):
+                            m.d.sync += self.errors.eq(self.errors + bit_errors)
+                        with m.Else():
+                            m.d.sync += self.errors.eq(~0) # saturate
+                        m.d.sync += curr_size.eq(curr_size + 2)
+                        m.d.sync += curr_addr.eq(curr_addr + 2)
+
+            with m.State("Cycle End"):
+                m.d.sync += self.cycles.eq(self.cycles + 1)
+                with m.If(self.repeat):
+                    m.next = "Test Start"
+                with m.Else():
+                    m.next = "Test End"
+
+            with m.State("Test End"):
+                with m.If(~self.active):
+                    m.d.sync += self.cycles.eq(0)
+                    m.next = "Test Start"
+
+        return m
+
+
+class MemoryTestInterface:
+    def __init__(self, logger: logging.Logger, assembly: AbstractAssembly):
+        self._logger = logger
+        self._level  = logging.DEBUG if self._logger.name == __name__ else logging.TRACE
+
+        mem_bus, _mem_range = assembly.add_dynamic_memory()
+        component = assembly.add_submodule(MemoryTestComponent(mem_bus,
+            sys_clk_period=assembly.sys_clk_period))
+
+        self._pattern    = assembly.add_rw_register(component.pattern)
+        self._start_addr = assembly.add_rw_register(component.start_addr)
+        self._stop_addr  = assembly.add_rw_register(component.stop_addr)
+        self._block_size = assembly.add_rw_register(component.block_size)
+        self._repeat     = assembly.add_rw_register(component.repeat)
+        self._curr_addr  = assembly.add_ro_register(component.curr_addr)
+
+        self._error_addr = assembly.add_ro_register(component.error_addr)
+        self._error_gold = assembly.add_ro_register(component.error_gold)
+        self._error_data = assembly.add_ro_register(component.error_data)
+
+        self._active     = assembly.add_rw_register(component.active)
+        self._cycles     = assembly.add_ro_register(component.cycles)
+        self._errors     = assembly.add_ro_register(component.errors)
+
+    def _log(self, message: str, *args):
+        self._logger.log(self._level, "memtest: " + message, *args)
+
+    async def run(self, region: range, *, patterns: tuple[Pattern] = Pattern) -> int:
+        """Test memory within :py:`region`.
+
+        Returns the number of bit errors, saturating to 65535; zero means the test succeeded.
+        """
+        assert 1 <= exact_log2(region.step) <= 12
+        assert region.start % 2 == 0 and region.stop % 2 == 0
+        assert (region.stop - region.start) % region.step == 0
+
+        await self._start_addr.set(region.start)
+        await self._stop_addr.set(region.stop)
+        await self._block_size.set(region.step)
+        for pattern in patterns:
+            try:
+                await self._pattern.set(pattern)
+                await self._active.set(1)
+                while (await self._cycles.get()) < 1:
+                    await asyncio.sleep(0.1)
+                errors = await self._errors.get()
+                if errors > 0:
+                    self._logger.warning("address %08x: expected %04x, actual %04x (%s)",
+                        await self._error_addr.get(),
+                        await self._error_gold.get(),
+                        await self._error_data.get(),
+                        pattern)
+                    return errors
+            finally:
+                await self._active.set(0)
+        return 0
+
+
+class MemoryTestApplet(GlasgowAppletV2):
+    logger = logging.getLogger(__name__)
+    help = "diagnose issues with onboard RAM"
+    description = """
+    Run a simple memory test procedure to diagnose memory issues. Our patented memtest67™ algorithm
+    works as follows:
+
+    * For each pattern in (``Const0``, ``Const1``, ``Alt01``, ``Alt10``, ``PRBS``) do:
+        * For each sequential block of specified size in the specified region, do:
+            * Write pattern sequence to memory block
+            * Read memory block and compare with pattern sequence
+    """
+    required_revision = "D0"
+
+    @classmethod
+    def add_build_arguments(cls, parser, access):
+        pass
+
+    def build(self, args):
+        with self.assembly.add_applet(self):
+            self.memtest_ifaces = [
+                MemoryTestInterface(self.logger, self.assembly),
+                MemoryTestInterface(self.logger, self.assembly),
+            ]
+
+    @classmethod
+    def add_run_arguments(cls, parser):
+        def address(arg):
+            return int(arg, 16)
+
+        parser.add_argument(
+            "-c", "--channel", metavar="INDEX", type=int, choices=(0, 1), required=True,
+            help="memory channel (one of: 0, 1)")
+        parser.add_argument(
+            "-a", "--start-addr", metavar="HEX-ADDR", type=address, default=0,
+            help="start of region (default: zero)")
+        parser.add_argument(
+            "-b", "--stop-addr", metavar="HEX-ADDR", type=address, default=64 << 20,
+            help="end of region, exclusive (default: 64 MB)")
+        parser.add_argument(
+            "-s", "--block-size", metavar="SIZE", type=int,
+            choices=tuple(1<<n for n in range(1, 12)), default=2048,
+            help="block size (power of two, 2..2048, default: 2048)")
+        parser.add_argument(
+            "-n", "--cycles", metavar="COUNT", type=int, default=1,
+            help="repeat memory test COUNT times")
+
+    async def run(self, args):
+        region = range(args.start_addr, args.stop_addr, args.block_size)
+        failed = False
+        for cycle in range(args.cycles):
+            bit_errors = await self.memtest_ifaces[args.channel].run(region)
+            if bit_errors == 0:
+                self.logger.info("cycle %3d/%3d PASS",
+                    1 + cycle, args.cycles)
+            else:
+                self.logger.error("cycle %3d/%3d FAIL (%d bit errors)",
+                    1 + cycle, args.cycles, bit_errors)
+                failed = True
+        if not failed:
+            self.logger.info("test PASS")
+        else:
+            self.logger.error("test FAIL")
+
+    @classmethod
+    def tests(cls):
+        from . import test
+        return test.MemoryTestAppletTestCase

--- a/software/glasgow/applet/internal/memtest/test.py
+++ b/software/glasgow/applet/internal/memtest/test.py
@@ -1,0 +1,28 @@
+from glasgow.applet import GlasgowAppletV2TestCase, synthesis_test, applet_v2_simulation_test
+
+from . import MemoryTestApplet, Pattern
+
+
+class MemoryTestAppletTestCase(GlasgowAppletV2TestCase, applet=MemoryTestApplet):
+    @synthesis_test
+    def test_build(self):
+        self.assertBuilds()
+
+    @applet_v2_simulation_test()
+    async def test_simulation(self, applet: MemoryTestApplet, ctx):
+        region = range(0x000, 0x800, 0x200)
+
+        # `iface.run()` would run `asyncio.sleep()`, which we don't support.
+        for iface in applet.memtest_ifaces:
+            await iface._start_addr.set(region.start)
+            await iface._stop_addr.set(region.stop)
+            await iface._block_size.set(region.step)
+            for pattern in Pattern:
+                await iface._pattern.set(pattern)
+                await iface._active.set(1)
+                while (await iface._cycles.get()) < 1:
+                    await ctx.tick()
+                errors = await iface._errors.get()
+                assert errors == 0
+                await iface._active.set(0)
+                await ctx.tick()

--- a/software/glasgow/cli.py
+++ b/software/glasgow/cli.py
@@ -24,7 +24,7 @@ from .support.plugin import PluginRequirementsUnmet, PluginLoadError
 from .abstract import ClockingError
 from .hardware.device import GlasgowDeviceError, GlasgowDevice, GlasgowDeviceConfig
 from .hardware.device import FX2BootloaderDevice, VID_QIHW, PID_GLASGOW
-from .hardware.toolchain import ToolchainNotFound
+from .hardware.toolchain import ToolchainNotFound, ToolOutOfDate
 from .hardware.build_plan import GatewareBuildError
 from .hardware.assembly import HardwareAssembly
 from .legacy import DeprecatedTarget
@@ -1055,6 +1055,10 @@ async def main() -> int:
     except (PluginRequirementsUnmet, PluginLoadError) as e:
         logger.error(e)
         print(e.metadata.description)
+        return 3
+
+    except ToolOutOfDate as e:
+        logger.error(e)
         return 3
 
     except ToolchainNotFound as e:

--- a/software/glasgow/gateware/iostream.py
+++ b/software/glasgow/gateware/iostream.py
@@ -1,3 +1,4 @@
+
 from amaranth import *
 from amaranth.lib import data, wiring, stream, io
 from amaranth.lib.wiring import In, Out
@@ -6,7 +7,7 @@ from amaranth.vendor import SiliconBluePlatform, LatticePlatform
 from .stream import SkidBuffer
 
 
-__all__ = ["IOStreamer"]
+__all__ = ["IOStreamer", "HalfRateIOStreamer"]
 
 
 def _i_signature(ports, *, ratio=1, meta_layout=0, always_valid=False, always_ready=False):
@@ -214,5 +215,64 @@ class IOStreamer(wiring.Component):
         m.d.comb += skid_buffer.i.valid.eq(io_buffer.o.p.meta.valid)
 
         wiring.connect(m, wiring.flipped(self.o), skid_buffer.o)
+
+        return m
+
+
+class HalfRateIOStreamer(wiring.Component):
+    def __init__(self, ports, *, ratio, offset=0, init=None, meta_layout=0):
+        assert ratio in (2, 4), "HalfRateIOStreamer supports DDR and QDR I/O only"
+
+        self._ports  = ports
+        self._ratio  = ratio
+        self._offset = offset
+        self._init   = init
+        self._meta_layout = meta_layout
+
+        super().__init__({
+            "i":  In(IOStreamer.i_signature(ports, ratio=ratio, meta_layout=meta_layout)),
+            "o": Out(IOStreamer.o_signature(ports, ratio=ratio, meta_layout=meta_layout)),
+        })
+
+    @property
+    def ratio(self):
+        return self._ratio
+
+    def elaborate(self, platform):
+        m = Module()
+
+        m.submodules.inner = inner = IOStreamer(
+            ports=self._ports, ratio=self._ratio//2, offset=self._offset, init=self._init,
+            meta_layout=self._meta_layout,
+        )
+
+        fst_half = slice(0, 2)
+        snd_half = slice(2, 4)
+
+        i_phase = Signal()
+        for name, port in self._ports:
+            if port.direction in (io.Direction.Bidir, io.Direction.Output):
+                m.d.comb += inner.i.p.port[name].o.eq(
+                    Mux(i_phase, self.i.p.port[name].o[snd_half], self.i.p.port[name].o[fst_half]))
+                m.d.comb += inner.i.p.port[name].oe.eq(self.i.p.port[name].oe)
+        m.d.comb += inner.i.p.meta.eq(self.i.p.meta)
+
+        m.d.comb += inner.i.valid.eq(self.i.valid)
+        with m.If(inner.i.valid & inner.i.ready):
+            m.d.sync += i_phase.eq(~i_phase)
+            m.d.comb += self.i.ready.eq(i_phase)
+
+        o_phase = Signal()
+        for name, port in self._ports:
+            if port.direction in (io.Direction.Bidir, io.Direction.Input):
+                with m.If(inner.o.valid & ~o_phase):
+                    m.d.sync += self.o.p.port[name].i[fst_half].eq(inner.o.p.port[name].i)
+                m.d.comb += self.o.p.port[name].i[snd_half].eq(inner.o.p.port[name].i)
+        m.d.comb += self.o.p.meta.eq(inner.o.p.meta)
+
+        m.d.comb += inner.o.ready.eq(~o_phase | self.o.ready)
+        m.d.comb += self.o.valid.eq(inner.o.valid & o_phase)
+        with m.If(inner.o.valid & inner.o.ready):
+            m.d.sync += o_phase.eq(~o_phase)
 
         return m

--- a/software/glasgow/gateware/iostream.py
+++ b/software/glasgow/gateware/iostream.py
@@ -105,15 +105,19 @@ class StreamIOBuffer(wiring.Component):
             case 2, LatticePlatform():
                 latency = 4 # t1=3, t2=1
             case _:
-                raise NotImplementedError("latency not known for this kind of buffer")
+                raise NotImplementedError("latency not known for this ratio and platform")
         return latency + -(self._offset // -self._ratio) # ceiling division
 
     def elaborate(self, platform):
         m = Module()
 
-        match self._ratio:
-            case 1: buffer_cls = io.FFBuffer
-            case 2: buffer_cls = SimulatableDDRBuffer
+        match self._ratio, platform:
+            case 1, _:
+                buffer_cls = io.FFBuffer
+            case 2, _:
+                buffer_cls = SimulatableDDRBuffer
+            case _:
+                raise NotImplementedError("buffer not implemented for this ratio and platform")
 
         for name, port in self._ports:
             m.submodules[name] = buffer = buffer_cls(port.direction, port)
@@ -121,17 +125,17 @@ class StreamIOBuffer(wiring.Component):
                 m.d.comb += buffer.o.eq(self.i.p.port[name].o)
                 m.d.comb += buffer.oe.eq(self.i.p.port[name].oe)
             if port.direction in (io.Direction.Input, io.Direction.Bidir):
-                match self._ratio, self._offset:
-                    case 1, _:
-                        m.d.comb += self.o.p.port[name].i.eq(buffer.i)
-                    case 2, offset if offset % self._ratio == 0:
-                        m.d.comb += self.o.p.port[name].i.eq(buffer.i)
-                    case 2, offset if offset % self._ratio == 1:
-                        m.d.sync += self.o.p.port[name].i[0].eq(buffer.i[1])
-                        m.d.comb += self.o.p.port[name].i[1].eq(buffer.i[0])
-                    case _, _:
-                        raise NotImplementedError(
-                            f"Unsupported ratio {self._ratio} and offset {self._offset}")
+                buffer_i = Signal(data.ArrayLayout(len(port), self._ratio))
+                m.d.comb += buffer_i.eq(buffer.i) # FFBuffer doesn't use ArrayLayout, normalize
+
+                i_window = Signal(data.ArrayLayout(len(port), self._ratio * 2))
+                for idx in range(self._ratio):
+                    m.d.sync += i_window[idx].eq(buffer_i[idx])
+                    m.d.comb += i_window[self._ratio + idx].eq(buffer_i[idx])
+
+                offset = self._ratio - (self._offset % self._ratio)
+                for idx in range(self._ratio):
+                    m.d.comb += self.o.p.port[name].i[idx].eq(i_window[offset + idx])
 
         meta = self.i.p.meta
         for n in range(self._latency(platform)):

--- a/software/glasgow/gateware/iostream.py
+++ b/software/glasgow/gateware/iostream.py
@@ -9,6 +9,33 @@ from .stream import SkidBuffer
 __all__ = ["IOStreamer"]
 
 
+def _i_signature(ports, *, ratio=1, meta_layout=0, always_valid=False, always_ready=False):
+    return stream.Signature(data.StructLayout({
+        "port": data.StructLayout({
+            name: data.StructLayout({
+                "o":  data.ArrayLayout(len(port), ratio),
+                "oe": 1
+            })
+            for name, port in ports
+            if port.direction in (io.Direction.Output, io.Direction.Bidir)
+        }),
+        "meta": meta_layout
+    }), always_valid=always_valid, always_ready=always_ready)
+
+
+def _o_signature(ports, *, ratio=1, meta_layout=0, always_valid=False, always_ready=False):
+    return stream.Signature(data.StructLayout({
+        "port": data.StructLayout({
+            name: data.StructLayout({
+                "i": data.ArrayLayout(len(port), ratio)
+            })
+            for name, port in ports
+            if port.direction in (io.Direction.Input, io.Direction.Bidir)
+        }),
+        "meta": meta_layout
+    }), always_valid=always_valid, always_ready=always_ready)
+
+
 class SimulatableDDRBuffer(io.DDRBuffer):
     def elaborate(self, platform):
         if not isinstance(self._port, io.SimulationPort):
@@ -56,27 +83,10 @@ class StreamIOBuffer(wiring.Component):
         self._offset = offset
 
         super().__init__({
-            "i": In(stream.Signature(data.StructLayout({
-                "port": data.StructLayout({
-                    name: data.StructLayout({
-                        "o":  data.ArrayLayout(len(port), ratio),
-                        "oe": 1
-                    })
-                    for name, port in ports
-                    if port.direction in (io.Direction.Output, io.Direction.Bidir)
-                }),
-                "meta": meta_layout,
-            }), always_valid=True, always_ready=True)),
-            "o": Out(stream.Signature(data.StructLayout({
-                "port": data.StructLayout({
-                    name: data.StructLayout({
-                        "i": data.ArrayLayout(len(port), ratio),
-                    })
-                    for name, port in ports
-                    if port.direction in (io.Direction.Input, io.Direction.Bidir)
-                }),
-                "meta": meta_layout,
-            }), always_valid=True, always_ready=True))
+            "i": In(_i_signature(ports, ratio=ratio, meta_layout=meta_layout,
+                always_valid=True, always_ready=True)),
+            "o": Out(_o_signature(ports, ratio=ratio, meta_layout=meta_layout,
+                always_valid=True, always_ready=True)),
         })
 
     @property
@@ -135,30 +145,11 @@ class StreamIOBuffer(wiring.Component):
 class IOStreamer(wiring.Component):
     @staticmethod
     def i_signature(ports, *, ratio=1, meta_layout=0):
-        return stream.Signature(data.StructLayout({
-            "port": data.StructLayout({
-                name: data.StructLayout({
-                    "o":  data.ArrayLayout(len(port), ratio),
-                    "oe": 1
-                })
-                for name, port in ports
-                if port.direction in (io.Direction.Output, io.Direction.Bidir)
-            }),
-            "meta": meta_layout
-        }))
+        return _i_signature(ports, ratio=ratio, meta_layout=meta_layout)
 
     @staticmethod
     def o_signature(ports, *, ratio=1, meta_layout=0):
-        return stream.Signature(data.StructLayout({
-            "port": data.StructLayout({
-                name: data.StructLayout({
-                    "i": data.ArrayLayout(len(port), ratio)
-                })
-                for name, port in ports
-                if port.direction in (io.Direction.Input, io.Direction.Bidir)
-            }),
-            "meta": meta_layout
-        }))
+        return _o_signature(ports, ratio=ratio, meta_layout=meta_layout)
 
     def __init__(self, ports, *, ratio=1, offset=0, init=None, meta_layout=0):
         assert ratio in (1, 2), "IOStreamer supports SDR and DDR I/O only"

--- a/software/glasgow/gateware/iostream.py
+++ b/software/glasgow/gateware/iostream.py
@@ -1,10 +1,10 @@
-
 from amaranth import *
 from amaranth.lib import data, wiring, stream, io
 from amaranth.lib.wiring import In, Out
 from amaranth.vendor import SiliconBluePlatform, LatticePlatform
 
-from .stream import SkidBuffer
+from glasgow.hardware.platform import ecp5
+from glasgow.gateware.stream import SkidBuffer
 
 
 __all__ = ["IOStreamer", "HalfRateIOStreamer"]
@@ -104,6 +104,8 @@ class StreamIOBuffer(wiring.Component):
                 latency = 2 # t1=1, t2=1
             case 2, LatticePlatform():
                 latency = 4 # t1=3, t2=1
+            case 4, LatticePlatform():
+                latency = 6 # t1=3, t2=3
             case _:
                 raise NotImplementedError("latency not known for this ratio and platform")
         return latency + -(self._offset // -self._ratio) # ceiling division
@@ -116,6 +118,8 @@ class StreamIOBuffer(wiring.Component):
                 buffer_cls = io.FFBuffer
             case 2, _:
                 buffer_cls = SimulatableDDRBuffer
+            case 4, LatticePlatform():
+                buffer_cls = ecp5.QDRBuffer
             case _:
                 raise NotImplementedError("buffer not implemented for this ratio and platform")
 
@@ -157,7 +161,7 @@ class IOStreamer(wiring.Component):
         return _o_signature(ports, ratio=ratio, meta_layout=meta_layout)
 
     def __init__(self, ports, *, ratio=1, offset=0, init=None, meta_layout=0):
-        assert ratio in (1, 2), "IOStreamer supports SDR and DDR I/O only"
+        assert ratio in (1, 2, 4), "IOStreamer supports SDR/DDR/QDR I/O only"
 
         self._ports  = ports
         self._ratio  = ratio

--- a/software/glasgow/gateware/octoram.py
+++ b/software/glasgow/gateware/octoram.py
@@ -1,0 +1,548 @@
+# Ref: APS51208N-OBRx DDR Octal SPI PSRAM Datasheet
+# Accession: G00130
+
+from amaranth import *
+from amaranth.lib import enum, data, wiring, stream, io, cdc
+from amaranth.lib.wiring import In, Out, connect, flipped
+
+from .ports import PortGroup
+from .stream import Queue, AsyncQueue, StreamBuffer, stream_get, stream_put
+from .iostream import IOStreamer, HalfRateIOStreamer
+
+
+__all__ = [
+    "Operation", "Enframer", "Deframer", "Streamer",
+    "Command", "Signature", "Controller", "SimulationController", "AsyncControllerECP5",
+]
+
+
+class Operation(enum.Enum, shape=2):
+    Idle   = 0
+    Write  = 1
+    Read   = 2
+
+
+class Sample(data.Struct):
+    valid: 1
+    epoch: 1
+
+
+class Enframer(wiring.Component):
+    def __init__(self, ports, *, chip_count=None):
+        super().__init__({
+            "octets": In(stream.Signature(data.StructLayout({
+                "oper": Operation,
+                "chip": range(1 + (chip_count or len(ports.cs))),
+                "data": data.ArrayLayout(8, 2),
+                "mask": data.ArrayLayout(1, 2),
+                "epoch": 1,
+            }))),
+            "frames": Out(IOStreamer.i_signature(ports, ratio=4, meta_layout=Sample)),
+        })
+
+    def elaborate(self, platform):
+        m = Module()
+
+        for n in range(4):
+            m.d.comb += self.frames.p.port.cs.o[n].eq((1 << self.octets.p.chip)[1:])
+        m.d.comb += self.frames.p.port.cs.oe.eq(1)
+
+        with m.If(self.octets.p.chip != 0):
+            m.d.comb += [
+                self.frames.p.port.clk.o[0].eq(0),
+                self.frames.p.port.clk.o[1].eq(1),
+                self.frames.p.port.clk.o[2].eq(1),
+                self.frames.p.port.clk.o[3].eq(0),
+            ]
+        m.d.comb += self.frames.p.port.clk.oe.eq(1)
+
+        with m.If(self.octets.p.oper == Operation.Write):
+            m.d.comb += [
+                self.frames.p.port.dq.o[0].eq(self.octets.p.data[0]),
+                self.frames.p.port.dq.o[1].eq(self.octets.p.data[0]),
+                self.frames.p.port.dq.o[2].eq(self.octets.p.data[1]),
+                self.frames.p.port.dq.o[3].eq(self.octets.p.data[1]),
+                self.frames.p.port.dq.oe.eq(1),
+                self.frames.p.port.dqs.o[0].eq(self.octets.p.mask[0]),
+                self.frames.p.port.dqs.o[1].eq(self.octets.p.mask[0]),
+                self.frames.p.port.dqs.o[2].eq(self.octets.p.mask[1]),
+                self.frames.p.port.dqs.o[3].eq(self.octets.p.mask[1]),
+                self.frames.p.port.dqs.oe.eq(1),
+            ]
+
+        m.d.comb += self.frames.p.meta.epoch.eq(self.octets.p.epoch)
+        with m.If(self.octets.p.oper == Operation.Read):
+            m.d.comb += self.frames.p.meta.valid.eq(1)
+
+        m.d.comb += self.frames.valid.eq(self.octets.valid)
+        m.d.comb += self.octets.ready.eq(self.frames.ready)
+
+        return m
+
+
+class Deframer(wiring.Component):
+    def __init__(self, ports):
+        super().__init__({
+            "frames": In(IOStreamer.o_signature(ports, ratio=4, meta_layout=Sample)),
+            "octets": Out(stream.Signature(data.StructLayout({
+                "data": data.ArrayLayout(8, 2),
+                "epoch": 1,
+            }))),
+        })
+
+    def elaborate(self, platform):
+        m = Module()
+
+        dq0  = self.frames.p.port.dq.i[0]
+        dq1  = self.frames.p.port.dq.i[2]
+        dqs0 = self.frames.p.port.dqs.i[0]
+        dqs1 = self.frames.p.port.dqs.i[2]
+
+        dq1_prev = Signal.like(dq1)
+        has_prev = Signal()
+        with m.If(self.frames.valid):
+            m.d.sync += dq1_prev.eq(dq1)
+            m.d.sync += has_prev.eq(dqs1 & self.frames.p.meta.valid)
+            with m.If(dqs0):
+                m.d.comb += [
+                    self.octets.p.data[0].eq(dq0),
+                    self.octets.p.data[1].eq(dq1),
+                    self.octets.valid.eq(self.frames.p.meta.valid),
+                ]
+            with m.If(dqs1 & has_prev):
+                m.d.comb += [
+                    self.octets.p.data[0].eq(dq1_prev),
+                    self.octets.p.data[1].eq(dq0),
+                    self.octets.valid.eq(self.frames.p.meta.valid),
+                ]
+
+        m.d.comb += self.octets.p.epoch.eq(self.frames.p.meta.epoch)
+        m.d.comb += self.frames.ready.eq(self.octets.ready | ~self.octets.valid)
+
+        return m
+
+
+class Streamer(wiring.Component):
+    def __init__(self, ports, *, offset=0, chip_count=None, half_rate):
+        assert chip_count is None or len(ports.cs) <= chip_count
+        assert (len(ports.cs) >= 1 and
+                ports.cs.direction in (io.Direction.Output, io.Direction.Bidir))
+        assert (len(ports.clk) == 1 and
+                ports.clk.direction in (io.Direction.Output, io.Direction.Bidir))
+        assert (len(ports.dq) == 8 and
+                ports.dq.direction == io.Direction.Bidir)
+        assert (len(ports.dqs) == 1 and
+                ports.dqs.direction == io.Direction.Bidir)
+
+        self._ports = PortGroup(
+            cs =ports.cs .with_direction("o"),
+            clk=ports.clk.with_direction("o"),
+            dq =ports.dq .with_direction("io"),
+            dqs=ports.dqs.with_direction("io"),
+        )
+        self._offset = offset
+        self._chip_count = chip_count or len(ports.cs)
+
+        self._half_rate = half_rate
+
+        super().__init__({
+            "i_stream": In(stream.Signature(data.StructLayout({
+                "oper": Operation,
+                "chip": range(1 + self._chip_count),
+                "data": data.ArrayLayout(8, 2),
+                "mask": data.ArrayLayout(1, 2),
+                "epoch": 1,
+            }))),
+            "o_stream": Out(stream.Signature(data.StructLayout({
+                "data": data.ArrayLayout(8, 2),
+                "epoch": 1,
+            }))),
+        })
+
+    def elaborate(self, platform):
+        m = Module()
+
+        if self._half_rate:
+            io_streamer_cls = HalfRateIOStreamer
+        else:
+            io_streamer_cls = IOStreamer
+
+        m.submodules.enframer = enframer = Enframer(ports=self._ports, chip_count=self._chip_count)
+        connect(m, enframer=enframer.octets, controller=flipped(self.i_stream))
+
+        m.submodules.io_streamer = io_streamer = io_streamer_cls(self._ports, ratio=4,
+            offset=self._offset, meta_layout=Sample, init={
+                "cs":  {"o": 0, "oe": 1}, # deselected
+                "clk": {"o": 0, "oe": 1}, # idles low
+            })
+        connect(m, io_streamer=io_streamer.i, enframer=enframer.frames)
+
+        m.submodules.o_buf = o_buf = StreamBuffer(io_streamer.o.p.shape())
+        connect(m, buffer=o_buf.i, io_streamer=io_streamer.o)
+
+        m.submodules.deframer = deframer = Deframer(ports=self._ports)
+        connect(m, deframer=deframer.frames, io_streamer=o_buf.o)
+
+        connect(m, controller=flipped(self.o_stream), deframer=deframer.octets)
+
+        return m
+
+
+class Command(enum.Enum, shape=3):
+    # All Read/Write command codes are swapped between -OBx and and -OCx series!
+    GlobalReset  = 0
+    ReadMemWrap  = 1
+    WriteMemWrap = 2
+    ReadMemRow   = 3
+    WriteMemRow  = 4
+    ReadReg      = 5
+    WriteReg     = 6
+
+
+class Signature(wiring.Signature):
+    """Native OPI memory bus."""
+
+    def __init__(self):
+        super().__init__({
+            "commands": Out(stream.Signature(data.StructLayout({
+                "type": Command,
+                "addr": 32,
+                "size": range(self.max_burst_size), # in beats; 0 means `self.max_burst_size`
+            }))),
+            "w_data": Out(stream.Signature(data.ArrayLayout(data.StructLayout({
+                "data": 8,
+                "mask": 1,
+            }), 2))),
+            "r_data": In(stream.Signature(data.ArrayLayout(data.StructLayout({
+                "data": 8,
+            }), 2))),
+        })
+
+    @property
+    def max_burst_size(self):
+        """Largest burst supported by the interface; equal to DRAM row size."""
+        return 2048
+
+
+class Controller(wiring.Component):
+    """OPI PSRAM controller.
+
+    Supports only AP Memory APSxxx08N-OBR devices.
+    """
+
+    bus: In(Signature())
+    latency: In(range(32))
+
+    def __init__(self, ports, *, offset=0, half_rate=True):
+        self._ports     = ports
+        self._offset    = offset
+        self._half_rate = half_rate
+
+        super().__init__()
+
+    def elaborate(self, platform):
+        m = Module()
+
+        max_burst_size = self.bus.signature.max_burst_size
+
+        m.submodules.streamer = ram = Streamer(self._ports,
+            offset=self._offset, half_rate=self._half_rate)
+
+        # Command/address FSM and data read FSM valid to synchronize for variable latency to work
+        # because the former will continue issuing reads until stopped, and the latter will cause
+        # the former to stop but cannot do anything about "in-flight" reads.
+        # Note: the logic below assumes zero-length reads/writes are impossible (which they are
+        # because of how `size` is encoded.)
+        wr_epoch = Signal()
+        rd_epoch = Signal()
+        m.submodules.fifo = fifo = Queue(shape=range(max_burst_size + 1), depth=1)
+
+        def perform(oper: Operation, *,
+                    data: tuple[Value, Value] = (C(0), C(0)),
+                    mask: tuple[Value, Value] = (C(0), C(0)),
+                    valid: Value = C(1),
+                    ready: Value | None = None):
+            m.d.comb += [
+                ram.i_stream.p.oper.eq(oper),
+                ram.i_stream.p.chip.eq(1),
+                ram.i_stream.p.data[0].eq(data[0]),
+                ram.i_stream.p.mask[0].eq(mask[0]),
+                ram.i_stream.p.data[1].eq(data[1]),
+                ram.i_stream.p.mask[1].eq(mask[1]),
+                ram.i_stream.p.epoch.eq(wr_epoch),
+                ram.i_stream.valid.eq(valid),
+            ]
+            if ready is not None:
+                m.d.comb += ready.eq(ram.i_stream.ready)
+
+        # on APS*-OBx and APS*-OCx devices, the command encoding differs by flipping high bit;
+        # we implement -OBx semantics only
+        command = Signal(8)
+        with m.Switch(self.bus.commands.p.type):
+            with m.Case(Command.GlobalReset):   m.d.comb += command.eq(0xFF)
+            with m.Case(Command.ReadMemWrap):   m.d.comb += command.eq(0x00)
+            with m.Case(Command.WriteMemWrap):  m.d.comb += command.eq(0x80)
+            with m.Case(Command.ReadMemRow):    m.d.comb += command.eq(0x20)
+            with m.Case(Command.WriteMemRow):   m.d.comb += command.eq(0xA0)
+            with m.Case(Command.ReadReg):       m.d.comb += command.eq(0x40)
+            with m.Case(Command.WriteReg):      m.d.comb += command.eq(0xC0)
+
+        address = Signal(32)
+        # on APS*-OBx devices, RA and CA have no gaps, and on APS*-OCx devices there is a gap
+        # within the column address; we implement -OBx semantics only
+        m.d.comb += address.eq(self.bus.commands.p.addr)
+
+        count = Signal(range(max_burst_size + 1))
+        m.d.comb += fifo.i.payload.eq(count)
+
+        with m.FSM(name="wr_fsm"):
+            t_lat = Signal.like(self.latency)   # latency timer
+            t_rec = Signal(range(16))           # CE recovery timer
+
+            with m.State("Command"):
+                m.d.sync += count.eq(
+                    Mux(self.bus.commands.p.size == 0, max_burst_size, self.bus.commands.p.size))
+                m.d.sync += t_rec.eq(3)
+                perform(Operation.Write,
+                    # on APS*-OBx devices, the 1st negedge valids to be INST as well
+                    # on APS*-OCx devices, the 1st negedge is don't care
+                    data=(command, command),
+                    valid=self.bus.commands.valid,
+                )
+                with m.If(ram.i_stream.valid & ram.i_stream.ready):
+                    m.next = "Address 3/2"
+
+            with m.State("Address 3/2"):
+                # these bits are Don't Care for `Command.GlobalReset`
+                perform(Operation.Write, data=(address[24:32], address[16:24]))
+                with m.If(ram.i_stream.valid & ram.i_stream.ready):
+                    m.next = "Address 1/0"
+
+            with m.State("Address 1/0"):
+                # these bits are Don't Care for `Command.GlobalReset`
+                perform(Operation.Write, data=(address[ 8:16], address[ 0: 8]))
+                with m.If(ram.i_stream.valid & ram.i_stream.ready):
+                    # Latency Code table:
+                    # - Memory Read:    LC to LC×2
+                    # - Memory Write:   LC
+                    # - Register Read:  LC
+                    # - Register Write: 0
+                    # latency is counted from 2nd address byte, not 1st dummy byte, so we subtract
+                    # 1 from the computed latency here
+                    with m.Switch(self.bus.commands.p.type):
+                        with m.Case(Command.GlobalReset):
+                            # valids one more CLK pulse
+                            m.next = "Reset Clock"
+                        with m.Case(Command.WriteReg):
+                            m.d.sync += count.eq(1)
+                            m.next = "Write Data"
+                        with m.Case(Command.ReadReg):
+                            m.next = "Read Sync"
+                        with m.Case(Command.WriteMemWrap, Command.WriteMemRow):
+                            m.d.sync += t_lat.eq(self.latency - 1)
+                            m.next = "Write Latency"
+                        with m.Case(Command.ReadMemWrap, Command.ReadMemRow):
+                            m.next = "Read Sync"
+                        with m.Default():
+                            m.next = "Error"
+
+            with m.State("Reset Clock"):
+                perform(Operation.Idle)
+                with m.If(ram.i_stream.valid & ram.i_stream.ready):
+                    m.next = "Deselect"
+
+            with m.State("Write Latency"):
+                perform(Operation.Idle)
+                with m.If(ram.i_stream.valid & ram.i_stream.ready):
+                    m.d.sync += t_lat.eq(t_lat - 1)
+                    with m.If(t_lat - 1 == 0):
+                        m.next = "Write Data"
+
+            with m.State("Write Data"):
+                perform(Operation.Write,
+                    data=(self.bus.w_data.p[0].data, self.bus.w_data.p[1].data),
+                    mask=(self.bus.w_data.p[0].mask, self.bus.w_data.p[1].mask),
+                    valid=self.bus.w_data.valid,
+                    ready=self.bus.w_data.ready
+                )
+                with m.If(ram.i_stream.valid & ram.i_stream.ready):
+                    m.d.sync += count.eq(count - 1)
+                    with m.If(count - 1 == 0):
+                        m.next = "Deselect"
+
+            with m.State("Read Sync"):
+                m.d.comb += fifo.i.valid.eq(1)
+                with m.If(fifo.i.valid & fifo.i.ready):
+                    m.next = "Read Data"
+
+            with m.State("Read Data"):
+                perform(Operation.Read)
+                with m.If(ram.i_stream.valid & ram.i_stream.ready):
+                    with m.If(wr_epoch != rd_epoch): # reader increments rd_epoch when done
+                        m.d.sync += wr_epoch.eq(wr_epoch + 1)
+                        m.next = "Deselect"
+
+            with m.State("Deselect"):
+                m.d.comb += ram.i_stream.p.oper.eq(Operation.Idle)
+                m.d.comb += ram.i_stream.valid.eq(1)
+                with m.If(ram.i_stream.valid & ram.i_stream.ready):
+                    m.d.sync += t_rec.eq(t_rec - 1)
+                    with m.If(t_rec == 0):
+                        m.d.comb += self.bus.commands.ready.eq(1)
+                        m.next = "Command"
+
+            with m.State("Error"):
+                pass
+
+        m.d.comb += [
+            self.bus.r_data.p[0].data.eq(ram.o_stream.p.data[0]),
+            self.bus.r_data.p[1].data.eq(ram.o_stream.p.data[1]),
+        ]
+
+        remain = Signal.like(fifo.o.payload)
+        with m.If(fifo.o.valid & (rd_epoch == ram.o_stream.p.epoch)):
+            m.d.comb += self.bus.r_data.valid.eq(ram.o_stream.valid)
+            m.d.comb += ram.o_stream.ready.eq(self.bus.r_data.ready)
+            with m.If(ram.o_stream.valid & ram.o_stream.ready):
+                with m.If(remain + 1 == fifo.o.payload):
+                    m.d.comb += fifo.o.ready.eq(1)
+                    m.d.sync += remain.eq(0)
+                    m.d.sync += rd_epoch.eq(rd_epoch + 1)
+                with m.Else():
+                    m.d.sync += remain.eq(remain + 1)
+        with m.Else():
+            m.d.comb += ram.o_stream.ready.eq(1)
+
+        return m
+
+
+class SimulationController(wiring.Component):
+    """Behavioral simulation of a memory controller.
+
+    Only supports ``GlobalReset``, ``WriteMemRow``, and ``ReadMemRow`` commands.
+    """
+
+    bus: In(Signature())
+    latency: In(range(32))
+
+    def __init__(self, size):
+        assert size % 2 == 0
+
+        self.memory = bytearray(size)
+
+        super().__init__()
+
+    def elaborate(self, platform):
+        return Module()
+
+    async def testbench(self, ctx):
+        init_latency = 5
+        ctx.set(self.latency, init_latency)
+
+        while True:
+            command = await stream_get(ctx, self.bus.commands)
+            match command.type:
+                case Command.GlobalReset:
+                    ctx.set(self.latency, init_latency)
+
+                case Command.WriteMemRow:
+                    await ctx.tick().repeat(2 + ctx.get(self.latency))
+
+                    assert command.addr % 2 == 0
+                    for offset in range(0, command.size << 1, 2):
+                        pointer = command.addr + offset
+                        word = await stream_get(ctx, self.bus.w_data)
+                        if not word[0].mask:
+                            self.memory[pointer + 0] = word[0].data
+                        if not word[1].mask:
+                            self.memory[pointer + 1] = word[1].data
+
+                case Command.ReadMemRow:
+                    # Act as-if fixed latency mode was always used.
+                    await ctx.tick().repeat(2 + ctx.get(self.latency) * 2)
+
+                    assert command.addr % 2 == 0
+                    for offset in range(0, command.size << 1, 2):
+                        pointer = command.addr + offset
+                        await stream_put(ctx, self.bus.r_data, [
+                            {"data": self.memory[pointer + 0]},
+                            {"data": self.memory[pointer + 1]},
+                        ])
+
+
+class AsyncControllerECP5(wiring.Component):
+    """PSRAM controller specialized for the ECP5 platform.
+
+    Requires a clock domain named ``edge`` connected to a PLL ``CLKOP`` or ``CLKOS`` output,
+    and a clock domain named ``logic`` produced using a ``CLKDIVF`` instance as follows:
+
+    .. code::
+
+        m.domains.logic = ClockDomain(local=True)
+        m.submodules.logic_rst = cdc.ResetSynchronizer(ResetSignal("edge"), domain="logic")
+        m.submodules.logic_div = Instance("CLKDIVF",
+            i_RST=ResetSignal("edge"),
+            i_CLKI=ClockSignal("edge"),
+            o_CDIVX=ClockSignal("logic"),
+        )
+
+    There are only four ``CLKDIVF`` primitives per device. When using multiple memory controllers,
+    these primitives should be shared if at all possible.
+
+    The memory chip will be clocked at one half of the ``edge`` domain frequency, and transfer
+    one ``w_data`` or ``r_data`` payload per clock.
+
+    The ``latency`` input should be strapped to a constant value.
+    """
+
+    bus: In(Signature())
+    latency: In(range(32))
+
+    def __init__(self, ports, *, offset=0):
+        self._ports  = ports
+        self._offset = offset
+
+        super().__init__()
+
+    def elaborate(self, platform):
+        m = Module()
+
+        # ECP5 has a peculiar clocking arrangement where there are two types of clock interconnect,
+        # "primary clocks" (PCLK) and "edge clocks" (ECLK). Ignoring fabric inputs/outputs (which
+        # generally have high delay and jitter):
+        #  - Only edge clocks can be used to drive IO gearboxes like ODDRX2.
+        #  - Primary clocks may be generated from edge clocks via CLKDIVF, and no other way.
+        #  - Edge clocks can be driven by dedicated clock input pins, injected by PLLs,
+        #    bridged via ECLKBRIDGE, or produced by DLLDEL primitives.
+        #  - PLLs can inject edge clocks (via CLKOP/CLKOS) or primary clocks (via any output), this
+        #    can only generate edge clocks on the same side of the device (east/west).
+        #  - ECLKBRIDGECS can be used to bridge an edge clock from one side's PLL to another's IOs.
+        #
+        # Assuming we don't want to burn an entire PLL on the memory controller, by far the best
+        # implementation strategy is to bring in an edge clock (only), which is generated outside
+        # of the controller. The controller will then generate a logic clock with the appropriate
+        # phase via CLKDIVF. Regardless of its frequency, commands and data are transferred via
+        # async FIFOs; the memory clock frequency can now be changed by adjusting the memory
+        # controller edge clock frequency, which is convenient.
+
+        m.submodules.inner = inner = DomainRenamer("logic")(Controller(self._ports,
+            offset=self._offset, half_rate=False))
+        m.submodules.lat_sync = cdc.FFSynchronizer(self.latency, inner.latency,
+            o_domain="logic")
+
+        m.submodules.cmd_fifo = cmd_fifo = AsyncQueue(shape=self.bus.commands.p.shape(), depth=4,
+            i_domain="sync", o_domain="logic")
+        wiring.connect(m, cmd_fifo.i, wiring.flipped(self.bus.commands))
+        wiring.connect(m, inner.bus.commands, cmd_fifo.o)
+
+        m.submodules.wr_fifo = wr_fifo = AsyncQueue(shape=self.bus.w_data.p.shape(), depth=8,
+            i_domain="sync", o_domain="logic")
+        wiring.connect(m, wr_fifo.i, wiring.flipped(self.bus.w_data))
+        wiring.connect(m, inner.bus.w_data, wr_fifo.o)
+
+        m.submodules.rd_fifo = rd_fifo = AsyncQueue(shape=self.bus.r_data.p.shape(), depth=8,
+            i_domain="logic", o_domain="sync")
+        wiring.connect(m, inner.bus.r_data, rd_fifo.i)
+        wiring.connect(m, rd_fifo.o, wiring.flipped(self.bus.r_data))
+
+        return m

--- a/software/glasgow/hardware/assembly.py
+++ b/software/glasgow/hardware/assembly.py
@@ -7,7 +7,7 @@ import asyncio
 
 from amaranth import *
 from amaranth.hdl import ShapeCastable
-from amaranth.lib import wiring, io
+from amaranth.lib import wiring, io, cdc
 from amaranth.vendor import SiliconBluePlatform
 from amaranth.build import ResourceError
 
@@ -19,6 +19,7 @@ from ..gateware.i2c import I2CTarget
 from ..gateware.registers import I2CRegisters
 from ..gateware.fx2_crossbar import FX2Crossbar
 from ..gateware.stream import Queue
+from ..gateware import octoram, pll
 from ..abstract import *
 from .platform.rev_ab import GlasgowRevABPlatform
 from .platform.rev_c import GlasgowRevC0Platform, GlasgowRevC123Platform
@@ -499,6 +500,7 @@ class HardwareAssembly(AbstractAssembly):
         self._in_streams    = [] # (domain, in_stream, in_flush, fifo_depth)
         self._out_streams   = [] # (domain, out_stream, fifo_depth)
         self._pipes         = [] # in_pipe|out_pipe|inout_pipe
+        self._memories      = [] # (domain, bus)
         self._resets        = [] # (signal, when)
         self._voltages      = [] # (port, vio)
         self._pulls         = {} # (port, number): state
@@ -605,6 +607,17 @@ class HardwareAssembly(AbstractAssembly):
         self._pipes.append(inout_pipe)
         return inout_pipe
 
+    def add_dynamic_memory(self, size=None) -> tuple[octoram.Signature, range]:
+        # In the future we will likely allow sharing memories; for now this is not available.
+        assert self._artifact is None, "cannot add a dynamic memory to a sealed assembly"
+        assert self._revision >= "D0", "DRAM is not available prior to revision D0"
+        assert size is None or size <= 64*0x100000, "memory must be less than 64 MB in size"
+        assert len(self._memories) < 2, "only two memory channels are available"
+        self._current_logger.debug(f"allocating DRAM channel {len(self._memories)}")
+        bus = octoram.Signature().flip().create()
+        self._memories.append((self._domain, bus))
+        return bus, range(64*0x100000)
+
     def set_port_voltage(self, port: GlasgowPort, vio: GlasgowVio):
         self._current_logger.debug("setting port %s voltage to %s V", port, vio)
         self._voltages.append((port, vio))
@@ -675,6 +688,34 @@ class HardwareAssembly(AbstractAssembly):
             elif isinstance(register, HardwareRORegister):
                 register_addr = i2c_registers.add_existing_ro(Value.cast(signal))
             assert register_addr == register._address
+
+        if self._memories:
+            # The location constraint should not be needed with new enough nextpnr-ecp5, but is
+            # included here as insurance. TODO: remove this once nextpnr-0.11 is used.
+            plan = pll.ClockPlan(self.sys_clk_period, location="X70/Y49/EHXPLL_LR")
+            m.domains.dram_edge = plan.add_domain(pll.ecp5.Channel(period=1/240e6, usage="edge"))
+            m.submodules.dram_pll = plan.create(self._platform)
+
+            # See the comment in `AsyncControllerECP5`.
+            m.domains.dram_logic = ClockDomain(local=True)
+            m.submodules.logic_rst = cdc.ResetSynchronizer(ResetSignal("dram_edge"),
+                domain="dram_logic")
+            m.submodules.logic_div = Instance("CLKDIVF",
+                i_RST=ResetSignal("dram_edge"),
+                i_CLKI=ClockSignal("dram_edge"),
+                o_CDIVX=ClockSignal("dram_logic"),
+            )
+
+            for channel, (domain, mem_bus) in enumerate(self._memories):
+                mem_ports = self._platform.request("octoram", channel,
+                    dir={"cs": "-", "clk": "-", "dq": "-", "dqs": "-"})
+                m.submodules[f"mem_ctrl{channel}"] = mem_ctrl = DomainRenamer({
+                    "edge":  "dram_edge",
+                    "logic": "dram_logic",
+                    "sync":  domain.name,
+                })(octoram.AsyncControllerECP5(mem_ports))
+                m.d.comb += mem_ctrl.latency.eq(5)
+                wiring.connect(m, wiring.flipped(mem_bus), mem_ctrl.bus)
 
         m.submodules.fx2_crossbar = fx2_crossbar = FX2Crossbar(fx2_pins)
 

--- a/software/glasgow/hardware/assembly.py
+++ b/software/glasgow/hardware/assembly.py
@@ -720,7 +720,6 @@ class HardwareAssembly(AbstractAssembly):
             pass
 
         toolchain = find_toolchain(tools=self._platform.required_tools)
-        assert toolchain is not None
         # nextpnr-ecp5 *must* include commit `7c667eeba362a8538396f9c4dc9bd1a168b35fa3`, or any
         # applet that uses IO gearboxes will be broken due to PLL placement issues.
         toolchain.assert_version("nextpnr-ecp5", ("0", "10", "88"))

--- a/software/glasgow/hardware/assembly.py
+++ b/software/glasgow/hardware/assembly.py
@@ -719,6 +719,12 @@ class HardwareAssembly(AbstractAssembly):
         except ResourceError:
             pass
 
+        toolchain = find_toolchain(tools=self._platform.required_tools)
+        assert toolchain is not None
+        # nextpnr-ecp5 *must* include commit `7c667eeba362a8538396f9c4dc9bd1a168b35fa3`, or any
+        # applet that uses IO gearboxes will be broken due to PLL placement issues.
+        toolchain.assert_version("nextpnr-ecp5", ("0", "10", "88"))
+
         match self._platform:
             case SiliconBluePlatform():
                 # TODO: https://github.com/GlasgowEmbedded/glasgow/issues/1203
@@ -738,8 +744,6 @@ class HardwareAssembly(AbstractAssembly):
             synth_opts="-abc9",
             nextpnr_opts=nextpnr_opts,
         )
-        toolchain = find_toolchain(tools=self._platform.required_tools)
-        assert toolchain is not None
         product_name = self._platform.bitstream_filename("top")
         self._artifact = GlasgowBuildPlan(build_plan, toolchain, product_name)
         return self._artifact

--- a/software/glasgow/hardware/platform/ecp5.py
+++ b/software/glasgow/hardware/platform/ecp5.py
@@ -1,4 +1,8 @@
+import operator
+
 from amaranth import *
+from amaranth.hdl._ir import RequirePosedge
+from amaranth.lib import wiring, io, data
 from amaranth.vendor import LatticeECP5Platform
 
 from . import GlasgowPlatform
@@ -10,3 +14,202 @@ __all__ = ["GlasgowECP5Platform"]
 class GlasgowECP5Platform(GlasgowPlatform, LatticeECP5Platform):
     def bitstream_filename(self, design_name):
         return f"{design_name}.bit"
+
+
+# This is copied from `amaranth.vendor._lattice.InnerBuffer` as-is.
+class _InnerBuffer(wiring.Component):
+    """A private component used to implement ``lib.io`` buffers.
+
+    Works like ``lib.io.Buffer``, with the following differences:
+
+    - ``port.invert`` is ignored (handling the inversion is the outer buffer's responsibility)
+    - ``t`` is per-pin inverted output enable
+    """
+
+    def __init__(self, direction, port):
+        self.direction = direction
+        self.port = port
+        members = {}
+        if direction is not io.Direction.Output:
+            members["i"] = wiring.In(len(port))
+        if direction is not io.Direction.Input:
+            members["o"] = wiring.Out(len(port))
+            members["t"] = wiring.Out(len(port))
+        super().__init__(wiring.Signature(members).flip())
+
+    def elaborate(self, platform):
+        m = Module()
+
+        if isinstance(self.port, io.SingleEndedPort):
+            io_port = self.port.io
+        elif isinstance(self.port, io.DifferentialPort):
+            io_port = self.port.p
+        else:
+            raise TypeError(f"Unknown port type {self.port!r}")
+
+        for bit in range(len(self.port)):
+            name = f"buf{bit}"
+            if self.direction is io.Direction.Input:
+                m.submodules[name] = Instance("IB",
+                    i_I=io_port[bit],
+                    o_O=self.i[bit],
+                )
+            elif self.direction is io.Direction.Output:
+                m.submodules[name] = Instance("OBZ",
+                    i_T=self.t[bit],
+                    i_I=self.o[bit],
+                    o_O=io_port[bit],
+                )
+            elif self.direction is io.Direction.Bidir:
+                m.submodules[name] = Instance("BB",
+                    i_T=self.t[bit],
+                    i_I=self.o[bit],
+                    o_O=self.i[bit],
+                    io_B=io_port[bit],
+                )
+            else:
+                assert False # :nocov:
+
+        return m
+
+
+# Patterned after `io.DDRBuffer`, but with somewhat more questionable design choices. Would likely
+# not be accepted upstream as-is for a number of reasons; a major one is that IDDRX2F.ALIGNWD input
+# is not connected at all.
+class QDRBuffer(wiring.Component):
+    class Signature(wiring.Signature):
+        def __init__(self, direction, width):
+            self._direction = io.Direction(direction)
+            self._width = operator.index(width)
+            members = {}
+            if self._direction is not io.Direction.Output:
+                members["i"] = wiring.In(data.ArrayLayout(self._width, 4))
+            if self._direction is not io.Direction.Input:
+                members["o"] = wiring.Out(data.ArrayLayout(self._width, 4))
+                members["oe"] = wiring.Out(1, init=int(self._direction is io.Direction.Output))
+            super().__init__(members)
+
+        @property
+        def direction(self):
+            return self._direction
+
+        @property
+        def width(self):
+            return self._width
+
+        def __eq__(self, other):
+            return (type(self) is type(other) and self.direction == other.direction and
+                    self.width == other.width)
+
+        def __repr__(self):
+            return f"QDRBuffer.Signature({self.direction}, {self.width})"
+
+    def __init__(self, direction, port, *, i_domain=None, o_domain=None):
+        if not isinstance(port, io.PortLike):
+            raise TypeError(f"'port' must be a 'PortLike', not {port!r}")
+        self._port = port
+        super().__init__(QDRBuffer.Signature(direction, len(port)).flip())
+        if self.signature.direction is not io.Direction.Output:
+            self._i_domain = i_domain or "sync"
+        else:
+            if i_domain is not None:
+                raise ValueError("Output buffer doesn't have an input domain")
+            self._i_domain = None
+        if self.signature.direction is not io.Direction.Input:
+            self._o_domain = o_domain or "sync"
+        else:
+            if o_domain is not None:
+                raise ValueError("Input buffer doesn't have an output domain")
+            self._o_domain = None
+        if port.direction is io.Direction.Input and self.direction is not io.Direction.Input:
+            raise ValueError(f"Input port cannot be used with {self.direction.name} buffer")
+        if port.direction is io.Direction.Output and self.direction is not io.Direction.Output:
+            raise ValueError(f"Output port cannot be used with {self.direction.name} buffer")
+
+    @property
+    def port(self):
+        return self._port
+
+    @property
+    def direction(self):
+        return self.signature.direction
+
+    @property
+    def i_domain(self):
+        return self._i_domain
+
+    @property
+    def o_domain(self):
+        return self._o_domain
+
+    def elaborate(self, platform):
+        assert isinstance(platform, LatticeECP5Platform), "QDR buffers are only supported on ECP5"
+
+        m = Module()
+
+        m.submodules.buf = buf = _InnerBuffer(self.direction, self.port)
+        inv_mask = sum(inv << bit for bit, inv in enumerate(self.port.invert))
+
+        if self.direction is not io.Direction.Output:
+            m.submodules += RequirePosedge(self.i_domain)
+            i0_inv = Signal(len(self.port))
+            i1_inv = Signal(len(self.port))
+            i2_inv = Signal(len(self.port))
+            i3_inv = Signal(len(self.port))
+            for bit in range(len(self.port)):
+                m.submodules[f"i_ddr{bit}"] = Instance("IDDRX2F",
+                    # https://github.com/YosysHQ/nextpnr/issues/1749
+                    # i_ALIGNWD=0,
+                    i_SCLK=ClockSignal(self.i_domain),
+                    i_ECLK=ClockSignal("edge"),
+                    i_RST=ResetSignal("edge"),
+                    i_D=buf.i[bit],
+                    o_Q0=i0_inv[bit],
+                    o_Q1=i1_inv[bit],
+                    o_Q2=i2_inv[bit],
+                    o_Q3=i3_inv[bit],
+                )
+            m.d.comb += self.i[0].eq(i0_inv ^ inv_mask)
+            m.d.comb += self.i[1].eq(i1_inv ^ inv_mask)
+            m.d.comb += self.i[2].eq(i2_inv ^ inv_mask)
+            m.d.comb += self.i[3].eq(i3_inv ^ inv_mask)
+
+        if self.direction is not io.Direction.Input:
+            m.submodules += RequirePosedge(self.o_domain)
+            o0_inv = Signal(len(self.port))
+            o1_inv = Signal(len(self.port))
+            o2_inv = Signal(len(self.port))
+            o3_inv = Signal(len(self.port))
+            m.d.comb += [
+                o0_inv.eq(self.o[0] ^ inv_mask),
+                o1_inv.eq(self.o[1] ^ inv_mask),
+                o2_inv.eq(self.o[2] ^ inv_mask),
+                o3_inv.eq(self.o[3] ^ inv_mask),
+            ]
+            for bit in range(len(self.port)):
+                m.submodules[f"o_ddr{bit}"] = Instance("ODDRX2F",
+                    i_SCLK=ClockSignal(self.o_domain),
+                    i_ECLK=ClockSignal("edge"),
+                    i_RST=ResetSignal("edge"),
+                    i_D0=o0_inv[bit],
+                    i_D1=o1_inv[bit],
+                    i_D2=o2_inv[bit],
+                    i_D3=o3_inv[bit],
+                    o_Q=buf.o[bit],
+                )
+
+            oe = ~self.oe
+            for stage in range(2):
+                oe_reg = Signal(name=f"oe_delay{stage}")
+                m.d[self.o_domain] += oe_reg.eq(oe)
+                oe = oe_reg
+            for bit in range(len(buf.t)):
+                m.submodules[f"oe_ff{bit}"] = Instance("OFS1P3DX",
+                    i_SCLK=ClockSignal(self.o_domain),
+                    i_SP=Const(1),
+                    i_CD=ResetSignal("edge"),
+                    i_D=oe,
+                    o_Q=buf.t[bit],
+                )
+
+        return m

--- a/software/glasgow/hardware/platform/rev_d.py
+++ b/software/glasgow/hardware/platform/rev_d.py
@@ -41,14 +41,14 @@ class _GlasgowRevDPlatform(GlasgowECP5Platform):
         Resource("led", 3, Pins("A14", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
         Resource("led", 4, Pins("B14", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
 
-        Resource("octospi", 0,
+        Resource("octoram", 0,
             Subsignal("cs",  PinsN("R16", dir="o"), Attrs(PULLMODE="UP")),
             Subsignal("clk", Pins( "P16", dir="o")),
             Subsignal("dqs", Pins( "N16", dir="io")),
             Subsignal("dq",  Pins( "L15 K13 M15 L16 M16 L13 L12 K12", dir="io")),
             Attrs(IO_TYPE="LVCMOS18", SLEWRATE="FAST")
         ),
-        Resource("octospi", 1,
+        Resource("octoram", 1,
             Subsignal("cs",  PinsN("P11", dir="o"), Attrs(PULLMODE="UP")),
             Subsignal("clk", Pins( "M11", dir="o")),
             Subsignal("dqs", Pins( "R12", dir="io")),

--- a/software/glasgow/hardware/toolchain.py
+++ b/software/glasgow/hardware/toolchain.py
@@ -1,4 +1,4 @@
-from typing import Any, Self
+from typing import Any, Self, Literal, overload
 from collections.abc import Iterator
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
@@ -435,7 +435,12 @@ class Toolchain:
 _ALL_TOOLS = ["yosys", "nextpnr-ice40", "icepack", "nextpnr-ecp5", "ecppack"]
 
 
-def find_toolchain(tools=_ALL_TOOLS, *, quiet=False):
+@overload
+def find_toolchain(tools=_ALL_TOOLS, *, quiet: Literal[True]) -> Toolchain | None:
+    pass
+
+
+def find_toolchain(tools=_ALL_TOOLS, *, quiet: Literal[False] = False) -> Toolchain:
     """Discover a toolchain.
 
     Returns a :class:`Toolchain` that includes all of the requested tools chosen according to

--- a/software/glasgow/hardware/toolchain.py
+++ b/software/glasgow/hardware/toolchain.py
@@ -16,13 +16,17 @@ from glasgow.support import logging
 from glasgow.support.lazy import lazy
 
 
-__all__ = ["ToolchainNotFound", "Toolchain", "find_toolchain"]
+__all__ = ["ToolchainNotFound", "ToolOutOfDate", "Toolchain", "find_toolchain"]
 
 
 logger = logging.getLogger(__name__)
 
 
 class ToolchainNotFound(Exception):
+    pass
+
+
+class ToolOutOfDate(Exception):
     pass
 
 
@@ -137,7 +141,12 @@ class WasmTool(Tool):
         # Running Wasm tools for the first time can incur a significant delay, so use
         # the version from the Python package metadata (which is guaranteed to be the same).
         # This makes querying the version at least as fast as for the native tools.
-        return (*importlib.metadata.version(self.python_package).split("."),)
+        a, b, _c, *d = importlib.metadata.version(self.python_package).split(".")
+        # This is a bit of a mess. In practice, the third component of the Wasm tool version
+        # doesn't correspond to anything useful for versions we care about, so skip it to make
+        # native and Wasm tools return more or less the same version. The last component is
+        # the git commit distance, which is vital for properly handling pre-release packages.
+        return (a, b, *d)
 
     @property
     def identifier(self) -> bytes | None:
@@ -212,7 +221,12 @@ class SystemTool(Tool):
                     yield os.path.join(root, file)
 
         if self.name == "yosys":
-            if yosys_datdir := self.get_output([f"{self.command}-config", "--datdir"]):
+            if self.command.endswith("yowasp-yosys"):
+                # In the odd case of `GLASGOW_TOOLCHAIN=system YOSYS=yowasp-yosys` (which does
+                # still happen), we can't access importlib metadata. However, the version should
+                # never be the same for two different builds, so we don't have to hash data files.
+                return iter([])
+            elif yosys_datdir := self.get_output([f"{self.command}-config", "--datdir"]):
                 return iter_files(yosys_datdir)
             else:
                 return None
@@ -394,6 +408,18 @@ class Toolchain:
                 return None
             hasher.update(tool.identifier)
         return hasher.digest()[:16]
+
+    def assert_version(self, tool: str, required: tuple[str, ...]):
+        # This is pretty janky, but unfortunately we don't have a clean way to implement this.
+        def comparable(version: tuple[str, ...]):
+            return [int(chunk) for chunk in version[:len(required)]]
+        assert comparable(("0", "9")) < comparable(("0", "91"))
+
+        versions = self.versions
+        if tool in versions and comparable(versions[tool]) < comparable(required):
+            raise ToolOutOfDate(
+                f"tool {tool!r} is out of date: installed version {'.'.join(versions[tool])} "
+                f"is older than required version {'.'.join(required)}")
 
     def __str__(self) -> str:
         return ", ".join(f"{name} {'.'.join(ver or ('(unavailable)',))}"

--- a/software/glasgow/simulation/assembly.py
+++ b/software/glasgow/simulation/assembly.py
@@ -10,6 +10,7 @@ from glasgow.support import logging
 from glasgow.abstract import (AbstractAssembly, AbstractInOutPipe, AbstractInPipe, AbstractOutPipe,
                               AbstractRORegister, AbstractRWRegister,
                               GlasgowPin, GlasgowPort, GlasgowVio, PullState)
+from glasgow.gateware import octoram
 
 
 __all__ = ["SimulationPipe", "SimulationRORegister", "SimulationRWRegister", "SimulationAssembly"]
@@ -95,6 +96,7 @@ class SimulationAssembly(AbstractAssembly):
         self._modules  = [] # (elaboratable, name)
         self._benches  = [] # (constructor, background)
         self._jumpers  = [] # (pin_name...)
+        self._memories = 0
         self.__context = None
 
     @property
@@ -178,6 +180,13 @@ class SimulationAssembly(AbstractAssembly):
             self._benches.append((o_testbench, True))
 
         return SimulationPipe(self, i_buffer=i_buffer, o_buffer=o_buffer)
+
+    def add_dynamic_memory(self, size=64*0x100000) -> tuple[octoram.Signature, range]:
+        controller = octoram.SimulationController(size)
+        self._modules.append((controller, f"mem_ctrl{self._memories}"))
+        self._benches.append((controller.testbench, True)) # background
+        self._memories += 1
+        return controller.bus, range(size)
 
     def add_ro_register(self, signal) -> AbstractRORegister:
         return SimulationRORegister(self, signal)

--- a/software/pdm.min.lock
+++ b/software/pdm.min.lock
@@ -5,7 +5,7 @@
 groups = ["default", "builtin-toolchain", "http", "numpy"]
 strategy = ["direct_minimal_versions"]
 lock_version = "4.5.0"
-content_hash = "sha256:ad5af09833520279930b18a10d39185388918a14d49eb8ccb8e8dad781454300"
+content_hash = "sha256:4cb9b36e2510cf7120220d0ecffbe26a8b78e8b5b53f074ed40d0c2ea9577567"
 
 [[metadata.targets]]
 requires_python = "~=3.13"
@@ -57,7 +57,7 @@ files = [
 
 [[package]]
 name = "amaranth"
-version = "0.5.8"
+version = "0.5.9"
 requires_python = "~=3.8"
 summary = "Amaranth hardware definition language"
 dependencies = [
@@ -67,8 +67,8 @@ dependencies = [
     "pyvcd<0.5,>=0.2.2",
 ]
 files = [
-    {file = "amaranth-0.5.8-py3-none-any.whl", hash = "sha256:6c32bd3422c700d246904032c1252f0a84225d2bdf9e26de4bc7df2ec83a8b39"},
-    {file = "amaranth-0.5.8.tar.gz", hash = "sha256:a9d6221fdb002614e82ac3603d245827829f279e8eb5fc543c948ea3609328ea"},
+    {file = "amaranth-0.5.9-py3-none-any.whl", hash = "sha256:513dd14cf88af1e068c6564f77deb498039bdfffeddca4053740b897aeb4ea45"},
+    {file = "amaranth-0.5.9.tar.gz", hash = "sha256:c147a5ebe6cfc70e99608e020f5c8996b12de76eb4c4c1c3007863110cab2c01"},
 ]
 
 [[package]]

--- a/software/pdm.min.lock
+++ b/software/pdm.min.lock
@@ -5,7 +5,7 @@
 groups = ["default", "builtin-toolchain", "http", "numpy"]
 strategy = ["direct_minimal_versions"]
 lock_version = "4.5.0"
-content_hash = "sha256:4cb9b36e2510cf7120220d0ecffbe26a8b78e8b5b53f074ed40d0c2ea9577567"
+content_hash = "sha256:896a0f5fece78ee2309540175b02c39af8b85eb3a29b6fd279682ecb32c81855"
 
 [[metadata.targets]]
 requires_python = "~=3.13"
@@ -907,16 +907,22 @@ files = [
 
 [[package]]
 name = "wasmtime"
-version = "14.0.0"
-requires_python = ">=3.8"
+version = "44.0.0"
+requires_python = ">=3.9"
 summary = "A WebAssembly runtime powered by Wasmtime"
 files = [
-    {file = "wasmtime-14.0.0-py3-none-any.whl", hash = "sha256:708f3399d54b4304aa59c55351e06698c8d18073a70f3299eebe07e3987a7353"},
-    {file = "wasmtime-14.0.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:13a63d99c8f53526ec8ca061a223b9499ec7cf991e3946f6fcf002a807beb079"},
-    {file = "wasmtime-14.0.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3e1cb2a78ddce2040aa908690462deecab04924021f75de94b6ee32d0a907bc4"},
-    {file = "wasmtime-14.0.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:236a9f3fb04b29bb9e553de814f2b748f2087f3fdfa99ce552f637ddedcc2a59"},
-    {file = "wasmtime-14.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:ec9a7fcd01ba4b04ee8f4c9d169dcf0f0fe67aa7ff8d032629cd8a08caf30c51"},
-    {file = "wasmtime-14.0.0-py3-none-win_amd64.whl", hash = "sha256:2f3a3589b6ede7c96e5d1cd45f65f88d154ccc9e9ddb34f75b49ce6db5ab6497"},
+    {file = "wasmtime-44.0.0-py3-none-android_26_arm64_v8a.whl", hash = "sha256:5bc01e2f1dae1e85b19343a718bf2b1dc9f0fa6b9f8c5f2922b9fb4b29fb56bd"},
+    {file = "wasmtime-44.0.0-py3-none-android_26_x86_64.whl", hash = "sha256:2e7db391e7cd274c3608bf22a2b2706bfbcc44a233c9a62277f0f03f9e0f48ad"},
+    {file = "wasmtime-44.0.0-py3-none-any.whl", hash = "sha256:28903f584fd9707438551ed3878bad61d841be78c715db4e20bf30e43b185825"},
+    {file = "wasmtime-44.0.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:019923321cf9244ed48d8f3858e50a93500a523c44b31d7b93c8c30195c4b9aa"},
+    {file = "wasmtime-44.0.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:07e96eb5bbf40473ea51f2cb3b3f5358537e41644662e02115edf5bd7883c9ca"},
+    {file = "wasmtime-44.0.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:f8d5bbd234bb99f9e94e284fba67b5e899ddebe2d4be7384f78396bdd4ce27a6"},
+    {file = "wasmtime-44.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:e686644bcddfec89095c9fd982b0848ab5e494ece865517214a63430b2ed08f8"},
+    {file = "wasmtime-44.0.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7326e8cc02b583a7817cf50029d8e9b06c13d2f3573b3e677dbe51a8c52245d7"},
+    {file = "wasmtime-44.0.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a7840d7d81e59ff666067031b3bde727ff28f923c5040b1a3cae4d8d37340f18"},
+    {file = "wasmtime-44.0.0-py3-none-win_amd64.whl", hash = "sha256:4b5c52475148f827abd9feff4460689f6979c0333b612c6c3d9211c4b7c7258d"},
+    {file = "wasmtime-44.0.0-py3-none-win_arm64.whl", hash = "sha256:931cd4d886ae6a2a06f5cfe47bf6f7a3b2635fa512a81cd1c55975505ace8cc1"},
+    {file = "wasmtime-44.0.0.tar.gz", hash = "sha256:1e5e7a7046136054e12f82101a9b5ce30b02d4f92946e6fbe3e2fced61a6b1a5"},
 ]
 
 [[package]]
@@ -987,13 +993,13 @@ files = [
 
 [[package]]
 name = "yowasp-nextpnr-ecp5"
-version = "0.1.0.0.post403"
+version = "0.10.0.96.post806.dev0"
 summary = "nextpnr-ecp5 FPGA place and route tool"
 dependencies = [
-    "yowasp-runtime~=1.1",
+    "yowasp-runtime~=1.93",
 ]
 files = [
-    {file = "yowasp_nextpnr_ecp5-0.1.0.0.post403-py3-none-any.whl", hash = "sha256:542847d0af2bda4599c541d820f72673891d5330a58e97febad5946709315274"},
+    {file = "yowasp_nextpnr_ecp5-0.10.0.96.post806.dev0-py3-none-any.whl", hash = "sha256:3c44f47d43ee0b8dff935465ce0b562052ba1639d1bcd3ac41573081db8e9cb3"},
 ]
 
 [[package]]
@@ -1009,16 +1015,16 @@ files = [
 
 [[package]]
 name = "yowasp-runtime"
-version = "1.42"
-requires_python = "~=3.8"
+version = "1.93"
+requires_python = "~=3.9"
 summary = "Common runtime for YoWASP packages"
 dependencies = [
     "importlib-resources; python_version < \"3.9\"",
-    "platformdirs~=3.0",
-    "wasmtime<15,>=1.0",
+    "platformdirs<5,>=3.0",
+    "wasmtime<45,>=44.0.0",
 ]
 files = [
-    {file = "yowasp_runtime-1.42-py3-none-any.whl", hash = "sha256:d3897a3639a0178c8a63c8427762f6cd6dd0c11b26f534f2e602fbc177082f6d"},
+    {file = "yowasp_runtime-1.93-py3-none-any.whl", hash = "sha256:5b09725771133d70e806679bb53865a13a0fc8887e1c4a085aca497dbfcffb0b"},
 ]
 
 [[package]]

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -92,6 +92,7 @@ glasgow = "glasgow.cli:run_main"
 
 [project.entry-points."glasgow.applet"]
 selftest = "glasgow.applet.internal.selftest:SelfTestApplet"
+memtest = "glasgow.applet.internal.memtest:MemoryTestApplet"
 benchmark = "glasgow.applet.internal.benchmark:BenchmarkApplet"
 calibrate-clock = "glasgow.applet.measure.calibrate_clock:CalibrateClockApplet"
 curve-trace = "glasgow.applet.measure.curve_trace:CurveTraceApplet"

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -194,3 +194,4 @@ build-backend = "pdm.backend"
 [tool.pdm.scripts]
 "update-pdm.min.lock".cmd = "pdm lock -L pdm.min.lock -S direct_minimal_versions"
 test.cmd = "python -m unittest"
+repl.cmd = "python -m asyncio"

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   # `typing_extensions` provides shims for such features. It uses SemVer.
   "typing_extensions>=4.8,<5",
   # Amaranth is the core of the Glasgow software/gateware interoperability layer. It uses SemVer.
-  "amaranth>=0.5.8,<0.6",
+  "amaranth>=0.5.9,<0.6",
   # `packaging` is used in the plugin system, `support.plugin`. It uses CalVer: the major version
   # is the two last digits of the year and the minor version is the release within that year.
   "packaging>=23.0",

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -69,10 +69,12 @@ builtin-toolchain = [
   # `yowasp-runtime` is a dependency of other toolchain components, and it is constrained here to
   # the lowest that has features transitively required by Glasgow.
   "yowasp-runtime>=1.42",
-  # Most versions of Yosys and nextpnr work; the minimum versions listed here are known good.
+  # Most versions of Yosys and nextpnr-ice40 work; the minimum versions listed here are known good.
   "yowasp-yosys>=0.31.0.13,!=0.54.*,!=0.55.*,!=0.56.*,!=0.64.*",
   "yowasp-nextpnr-ice40>=0.1",
-  "yowasp-nextpnr-ecp5>=0.1",
+  # nextpnr-ecp5 *must* include commit `7c667eeba362a8538396f9c4dc9bd1a168b35fa3`, or any applet
+  # that uses IO gearboxes will be broken due to PLL placement issues.
+  "yowasp-nextpnr-ecp5>=0.10.0.88.post806.dev0",
 ]
 
 # The rest of the optional dependences belong to plugins (applets, loggers, etc.)

--- a/software/tests/gateware/test_iostream.py
+++ b/software/tests/gateware/test_iostream.py
@@ -96,9 +96,6 @@ class IOStreamerTestCase(unittest.TestCase):
         data_to_receive = [first_data_to_receive] + data_to_send[:-1]
         meta_to_send = [random.randrange(1 << data_width) for _ in range(active_cycles)]
 
-        expected_sample = []
-        actually_sampled = []
-
         async def o_stream_consumer_tb(ctx):
             meta_index = data_index = 0
             for o_ready_bit in o_ready_bits:
@@ -109,7 +106,7 @@ class IOStreamerTestCase(unittest.TestCase):
                         meta_index += 1
                         for j in range(ratio):
                             assert payload.port.data_in.i[j] == data_to_receive[data_index], \
-                                "Wrong data received (index,actual,expecred) = " + \
+                                "Wrong data received (index,actual,expected) = " + \
                                 f"{j},0x{payload.port.data_in.i[j]:02x},0x{data_to_receive[data_index]:02x}"
                             data_index += 1
                 else:

--- a/software/tests/gateware/test_octoram.py
+++ b/software/tests/gateware/test_octoram.py
@@ -1,0 +1,238 @@
+import unittest
+from contextlib import contextmanager
+
+from amaranth import *
+from amaranth.sim import Simulator, BrokenTrigger
+from amaranth.lib import io
+
+from glasgow.gateware.ports import PortGroup
+from glasgow.gateware.stream import stream_get, stream_put
+from glasgow.gateware.octoram import *
+
+
+def simulate_psram(ports, *, data=bytearray(0x100000), part="APS51208N-OBR"):
+    class CSDeasserted(Exception):
+        pass
+
+    async def watch_cs(cs_o, triggers):
+        try:
+            *values, posedge_cs_o = await triggers.posedge(cs_o)
+        except BrokenTrigger: # Workaround for amaranth-lang/amaranth#1508
+            # Both our original trigger and posedge of cs happened at the same time.
+            # Prioritize CS being deasserted.
+            raise CSDeasserted
+        if posedge_cs_o == 1:
+            raise CSDeasserted
+        return values
+
+    async def bus_nop(ctx):
+        cs, clk, dq, dqs = ports.cs, ports.clk, ports.dq, ports.dqs
+        await watch_cs(cs.o, ctx.posedge(clk.o))
+        await watch_cs(cs.o, ctx.negedge(clk.o))
+
+    async def bus_get(ctx, *, with_dqs=False):
+        cs, clk, dq, dqs = ports.cs, ports.clk, ports.dq, ports.dqs
+        _, dq0_oe, dq0_o, dqs0_oe, dqs0_o = \
+            await watch_cs(cs.o, ctx.posedge(clk.o).sample(
+                dq.oe, dq.o, dqs.oe, dqs.o))
+        _, dq1_oe, dq1_o, dqs1_oe, dqs1_o = \
+            await watch_cs(cs.o, ctx.negedge(clk.o).sample(
+                dq.oe, dq.o, dqs.oe, dqs.o))
+        assert (dq0_oe, dq1_oe) == (0xff, 0xff)
+        if with_dqs:
+            assert (dqs0_oe, dqs1_oe) == (1, 1)
+            return dq0_o, dqs0_o, dq1_o, dqs1_o
+        else:
+            return dq0_o, dq1_o
+
+    async def bus_put(ctx, data0, data1):
+        cs, clk, dq, dqs = ports.cs, ports.clk, ports.dq, ports.dqs
+        _, dq0_oe, dqs0_oe = \
+            await watch_cs(cs.o, ctx.posedge(clk.o).sample(dq.oe, dqs.oe))
+        ctx.set(dq.i, data0); ctx.set(dqs.i, 1)
+        _, dq1_oe, dqs1_oe = \
+            await watch_cs(cs.o, ctx.negedge(clk.o).sample(dq.oe, dqs.oe))
+        ctx.set(dq.i, data1); ctx.set(dqs.i, 0)
+        assert (dq0_oe, dqs0_oe, dq1_oe, dqs1_oe) == (0, 0, 0, 0)
+
+    async def testbench_aps51208n_obr(ctx):
+        latency  = 5
+        col_mask = 0x7ff
+
+        await ctx.negedge(ports.cs.o)
+        while True:
+            try:
+                inst0, _     = await bus_get(ctx)
+                addr3, addr2 = await bus_get(ctx)
+                addr1, addr0 = await bus_get(ctx)
+                addr = (addr3<<24)|(addr2<<16)|(addr1<<8)|(addr0<<0)
+
+                if inst0 == 0xff: # Reset
+                    continue
+
+                elif inst0 == 0xA0: # Sync Write (2K Linear Burst)
+                    for _ in range(latency - 1):
+                        await bus_nop(ctx)
+
+                    while True:
+                        data0, mask0, data1, mask1 = await bus_get(ctx, with_dqs=True)
+                        if not mask0: data[addr+0] = data0
+                        if not mask1: data[addr+1] = data1
+                        addr = (addr & ~col_mask) | ((addr + 2) & col_mask)
+
+                elif inst0 == 0x20: # Sync Read (2K Linear Burst)
+                    for _ in range((latency << 1) - 1):
+                        await bus_nop(ctx)
+
+                    while True:
+                        data0 = data[addr+0]
+                        data1 = data[addr+1]
+                        addr = (addr & ~col_mask) | ((addr + 2) & col_mask)
+                        await bus_put(ctx, data0, data1)
+
+            except CSDeasserted:
+                await ctx.negedge(ports.cs.o)
+                continue
+
+    match part:
+        case "APS51208N-OBR": return testbench_aps51208n_obr
+        case _: assert False
+
+
+class IntegrationTestCase(unittest.TestCase):
+    def setUp(self):
+        ports = self.ports = PortGroup()
+        ports.cs  = ~io.SimulationPort("o",  1)
+        ports.clk =  io.SimulationPort("o",  1)
+        ports.dq  =  io.SimulationPort("io", 8)
+        ports.dqs =  io.SimulationPort("io", 1)
+
+        self.traces = [
+            ports.cs.o,
+            ports.clk.o,
+            ports.dq.oe,
+            ports.dq.o,
+            ports.dq.i,
+            ports.dqs.oe,
+            ports.dqs.o,
+            ports.dqs.i,
+        ]
+
+    @contextmanager
+    def run_test(self, dut, name="test"):
+        testbench_psram = simulate_psram(self.ports)
+
+        sim = Simulator(dut)
+        sim.add_clock(1e-6)
+        yield sim
+        sim.add_testbench(testbench_psram, background=True)
+        with sim.write_vcd(f"{name}.vcd", f"{name}.gtkw", traces=self.traces):
+            sim.run()
+
+    def test_streamer(self):
+        dut = Streamer(self.ports, half_rate=True)
+
+        async def testbench_input(ctx):
+            async def bus_idle():
+                await stream_put(ctx, dut.i_stream,
+                    {"oper": Operation.Idle})
+
+            async def bus_put(oper, *, data=[0, 0], mask=[0, 0]):
+                await stream_put(ctx, dut.i_stream,
+                    {"oper": oper, "chip": 1, "data": data, "mask": mask})
+
+            await ctx.tick()
+            await bus_idle()
+
+            await bus_put(Operation.Write, data=[0xA0, 0x00])
+            await bus_put(Operation.Write, data=[0x00, 0x00])
+            await bus_put(Operation.Write, data=[0x00, 0x04])
+            for _ in range(4):
+                await bus_put(Operation.Idle)
+            await bus_put(Operation.Write, data=[0x11, 0x22])
+            await bus_put(Operation.Write, data=[0x33, 0x44], mask=[1, 0])
+            await bus_idle()
+
+            await bus_put(Operation.Write, data=[0x20, 0x00])
+            await bus_put(Operation.Write, data=[0x00, 0x00])
+            await bus_put(Operation.Write, data=[0x00, 0x02])
+            for _ in range(9):
+                await bus_put(Operation.Idle)
+            for _ in range(5):
+                await bus_put(Operation.Read)
+            await bus_idle()
+
+        async def testbench_output(ctx):
+            async def bus_get():
+                payload = await stream_get(ctx, dut.o_stream)
+                return payload.data[0], payload.data[1]
+
+            assert (value := await bus_get()) == (0x00, 0x00), f"{value[0]:02x}, {value[1]:02x}"
+            assert (value := await bus_get()) == (0x11, 0x22), f"{value[0]:02x}, {value[1]:02x}"
+            assert (value := await bus_get()) == (0x00, 0x44), f"{value[0]:02x}, {value[1]:02x}"
+            assert (value := await bus_get()) == (0x00, 0x00), f"{value[0]:02x}, {value[1]:02x}"
+
+        with self.run_test(dut) as sim:
+            sim.add_testbench(testbench_input)
+            sim.add_testbench(testbench_output)
+
+    @contextmanager
+    def run_controller_test(self, dut):
+        m = Module()
+        m.submodules.dut = dut
+
+        # Add dummy `sync` domain for testing SimulationController.
+        m.d.sync += Signal().eq(0)
+
+        async def testbench_command(ctx):
+            ctx.set(dut.latency, 5)
+            await ctx.tick()
+
+            await stream_put(ctx, dut.bus.commands, {
+                "type": Command.WriteMemRow,
+                "addr": 0x4,
+                "size": 2,
+            })
+            await stream_put(ctx, dut.bus.commands, {
+                "type": Command.ReadMemRow,
+                "addr": 0x2,
+                "size": 4,
+            })
+            # test epoch mechanism
+            await stream_put(ctx, dut.bus.commands, {
+                "type": Command.ReadMemRow,
+                "addr": 0x4,
+                "size": 1,
+            })
+
+        async def testbench_input(ctx):
+            await stream_put(ctx, dut.bus.w_data,
+                [{"data": 0x11, "mask": 0}, {"data": 0x22, "mask": 0}])
+            await stream_put(ctx, dut.bus.w_data,
+                [{"data": 0x33, "mask": 1}, {"data": 0x44, "mask": 0}])
+
+        async def testbench_output(ctx):
+            assert (value := await stream_get(ctx, dut.bus.r_data)) == \
+                [{"data": 0x00}, {"data": 0x00}], f"{value}"
+            assert (value := await stream_get(ctx, dut.bus.r_data)) == \
+                [{"data": 0x11}, {"data": 0x22}], f"{value}"
+            assert (value := await stream_get(ctx, dut.bus.r_data)) == \
+                [{"data": 0x00}, {"data": 0x44}], f"{value}"
+            assert (value := await stream_get(ctx, dut.bus.r_data)) == \
+                [{"data": 0x00}, {"data": 0x00}], f"{value}"
+            assert (value := await stream_get(ctx, dut.bus.r_data)) == \
+                [{"data": 0x11}, {"data": 0x22}], f"{value}"
+
+        with self.run_test(m) as sim:
+            sim.add_testbench(testbench_command)
+            sim.add_testbench(testbench_input)
+            sim.add_testbench(testbench_output)
+            yield sim
+
+    def test_controller(self):
+        with self.run_controller_test(Controller(self.ports)):
+            pass
+
+    def test_sim_controller(self):
+        with self.run_controller_test(ctrl := SimulationController(0x100000)) as sim:
+            sim.add_testbench(ctrl.testbench, background=True)


### PR DESCRIPTION
This is a complete, albeit simplistic, integration of the OPI PSRAM controller. The assembly now provides a new method, `assembly.add_dynamic_memory()`, which returns a memory bus. The applet can manipulate this memory bus in any way it wants.

Currently, the memory bus is dedicated (i.e. up to two calls to `add_dynamic_memory()` are possible and each call receives its own memory channel), but in the future we may implement memory sharing. To this end, the function returns a memory range that the applet may use.

HyperFIFO will be added in a separate PR.