### PR TITLE
manual: initial checkin of zh_CN localization

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,12 +150,19 @@ jobs:
       - name: Build documentation
         env:
           DOCS_IS_PRODUCTION: ${{ (github.repository == 'GlasgowEmbedded/glasgow' && github.event.ref == 'refs/heads/main') && 'yes' || 'no' }}
-        run: pdm run build
-      - name: Upload documentation archive
+        run: |
+          pdm run build
+          pdm run build-cn
+      - name: Upload documentation archive (en_US)
         uses: actions/upload-artifact@v4
         with:
           name: docs
           path: docs/manual/build
+      - name: Upload documentation archive (zh_CN)
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-cn
+          path: docs/manual/build-cn
 
   required: # group all required workflows into one to avoid reconfiguring this in Actions settings
     needs:

--- a/docs/manual/.gitignore
+++ b/docs/manual/.gitignore
@@ -4,5 +4,7 @@
 /.venv
 
 # Sphinx
-/build
+/build*
 /check
+/locale/pot/
+/locale/**/*.mo

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/audio/dac.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/audio/dac.po
@@ -1,0 +1,136 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/audio/dac.rst:2
+msgid "``audio-dac``"
+msgstr ""
+
+#: ../../src/applets/audio/dac.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run audio-dac"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Play sound using a 1-bit sigma-delta DAC, i.e. pulse density modulation."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Currently, the supported sample formats are:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "1..16 channel signed/unsigned 8-bit,"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "1..16 channel signed/unsigned 16-bit little endian."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Other formats may be converted to it using:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "For example, to play an ogg file:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "To use the DAC as a PulseAudio sink, add the following line to default.pa:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Then run:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O lines 'o' to PINS (default: 'A0', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set sample width to WIDTH bytes (default: 1)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "interpret samples as signed"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "interpret samples as unsigned"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set modulation frequency to FREQ MHz (default: maximum)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set sample rate to RATE Hz (default: 8000)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run audio-dac connect"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "listen at PCM-ENDPOINT, either unix:PATH or tcp:HOST:PORT"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run audio-dac play"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "read PCM data from FILE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "loop the input samples"
+msgstr ""
+
+#: ../../src/applets/audio/dac.rst:14
+msgid "API reference"
+msgstr ""
+
+#: glasgow.applet.audio.dac.AudioDACInterface.sample_clock:1 of
+msgid "Sampling clock divisor."
+msgstr ""
+
+#: glasgow.applet.audio.dac.AudioDACInterface.modulation_clock:1 of
+msgid "Modulation clock divisor."
+msgstr ""
+
+#: glasgow.applet.audio.dac.AudioDACInterface.write:1 of
+msgid "Send samples to the DAC to be played in round robin order."
+msgstr ""
+
+#: glasgow.applet.audio.dac.AudioDACInterface.flush:1 of
+msgid "Ensure any past writes have reached the device FIFO."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/audio/index.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/audio/index.po
@@ -1,0 +1,32 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/audio/index.rst:4
+msgid "Audio"
+msgstr ""
+
+#: glasgow.applet.audio:1 of
+msgid "The ``audio`` taxon groups applets implementing audio interfaces, that is, interfaces for periodic transfers of 1d arrays of samples of pressure wave properties."
+msgstr ""
+
+#: glasgow.applet.audio:4 of
+msgid "Examples: I²S, sigma-delta audio frequency DAC. Counterexamples: software-defined radio DAC (use taxon ``radio``)."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/bridge/flashrom.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/bridge/flashrom.po
@@ -1,0 +1,84 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/bridge/flashrom.rst:2
+msgid "``spi-flashrom``"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run spi-flashrom"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Expose SPI via a socket using the flashrom serprog protocol; see https://flashrom.org."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "This applet has the same default pin assignment as the `memory-25x` applet; see its description for details."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Usage:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "It is also possible to flash 25-series flash chips using the `memory-25x` applet, which does not require a third-party tool. The advantage of using the `spi-flashrom` applet is that flashrom offers compatibility with a wider variety of devices, some of which may not be supported by the `memory-25x` applet."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "listen at ENDPOINT, either unix:PATH or tcp:HOST:PORT"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'cs' to PIN (default: 'A5', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'sck' to PIN (default: 'A1', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'copi' to PIN (default: 'A2', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'cipo' to PIN (default: 'A4', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'wp' to PIN (default: 'A3', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'hold' to PIN (default: 'A0', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set SCK frequency to FREQ kHz (default: 100)"
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/bridge/index.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/bridge/index.po
@@ -1,0 +1,32 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/bridge/index.rst:4
+msgid "External tools"
+msgstr ""
+
+#: glasgow.applet.bridge:1 of
+msgid "The ``bridge`` taxon groups applets that interface with external (out-of-tree) tools."
+msgstr ""
+
+#: glasgow.applet.bridge:3 of
+msgid "Examples: an applet whose sole function is to interface with flashrom or probe-rs. Counterexamples: an applet that provides a socket but the protocol is either Glasgow-specific, or generic and not specific to any particular tool; an applet that provides both in-tree end-user functionality, and a subcommand to interface with an external tool."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/bridge/jtag_openocd.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/bridge/jtag_openocd.po
@@ -1,0 +1,84 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/bridge/jtag_openocd.rst:2
+msgid "``jtag-openocd``"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run jtag-openocd"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Expose JTAG via a socket using the OpenOCD remote bitbang protocol."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Usage with TCP sockets:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Usage with Unix domain sockets:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "If you use TRST# and/or SRST# pins, the 'reset_config none' option above must be replaced with 'reset_config trst', 'reset_config srst', or 'reset_config trst_and_srst'."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "listen at ENDPOINT, either unix:PATH or tcp:HOST:PORT"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tck' to PIN (default: 'A0', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tms' to PIN (default: 'A1', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tdi' to PIN (default: 'A2', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tdo' to PIN (default: 'A3', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'trst' to PIN (optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'srst' to PIN (optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set TCK frequency to FREQ kHz (default: 100)"
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/bridge/jtag_xvc.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/bridge/jtag_xvc.po
@@ -1,0 +1,68 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/bridge/jtag_xvc.rst:2
+msgid "``jtag-xvc``"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run jtag-xvc"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Expose JTAG via a socket using the Xilinx Virtual Cable protocol, version 1.0."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "To connect to the DUT in Vivado, use the following Tcl command:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "listen at ENDPOINT, either unix:PATH or tcp:HOST:PORT (default: tcp:localhost:2542)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tck' to PIN (default: 'A0', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tms' to PIN (default: 'A1', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tdi' to PIN (default: 'A2', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tdo' to PIN (default: 'A3', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "override TCK frequency to always be FREQ kHz (default: configured by client)"
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/bridge/probe_rs.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/bridge/probe_rs.po
@@ -1,0 +1,60 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/bridge/probe_rs.rst:2
+msgid "``probe-rs``"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run probe-rs"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Expose SWD via a socket that can be used with `probe-rs <https://probe.rs>`_. JTAG debugging is not supported (yet)."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The current protocol version is ``probe-rs,v01``, which is available in probe-rs 0.30.0 or later."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "listen at ENDPOINT, either unix:PATH or tcp:HOST:PORT (default: connect via USB)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'swclk' to PIN (default: 'A0', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'swdio' to PIN (default: 'A1', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'srst' to PIN (optional)"
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/control/clock.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/control/clock.po
@@ -1,0 +1,77 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/control/clock.rst:2
+msgid "``control-clock``"
+msgstr ""
+
+#: ../../src/applets/control/clock.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run control-clock"
+msgstr ""
+
+#: ../../<autoprogram>:1
+#, python-format
+msgid "Generates a 50% duty cycle square wave with a specified frequency by dividing the FPGA system clock. Achievable frequencies are integer fractions of 24 MHz (for revC and later)."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'clk' to PIN (default: 'A0', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set clock frequency to FREQ kHz (default: 1000)"
+msgstr ""
+
+#: ../../src/applets/control/clock.rst:14
+msgid "API reference"
+msgstr ""
+
+#: glasgow.applet.control.clock.ClockDriveInterface.enable:1 of
+msgid "Enable and configure clock."
+msgstr ""
+
+#: glasgow.applet.control.clock.ClockDriveInterface.enable:3 of
+msgid "Sets the clock frequency to :py:`frequency` Hz and configures the clock pin as push-pull. If the clock pin is already configured as push-pull, then the change in frequency is done as follows: the current half-cycle has the old period, and the next half-cycle has the new period."
+msgstr ""
+
+#: glasgow.applet.control.clock.ClockDriveInterface.enable:8 of
+msgid "Returns the actual frequency used, which may be equal or less than :py:`frequency`."
+msgstr ""
+
+#: glasgow.applet.control.clock.ClockDriveInterface.disable:1 of
+msgid "Disable clock."
+msgstr ""
+
+#: glasgow.applet.control.clock.ClockDriveInterface.disable:3 of
+msgid "Disables the oscillator and configures the clock pin as Hi-Z."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/control/gpio.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/control/gpio.po
@@ -1,0 +1,123 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/control/gpio.rst:2
+msgid "``control-gpio``"
+msgstr ""
+
+#: ../../src/applets/control/gpio.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run control-gpio"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Sample and drive individual I/O pins via the CLI, the REPL, or a script."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "CLI pin actions can be used to configure a pin to be driven strongly (``A0=0`` or ``A0=1``), to be driven weakly using a pull resistor (``A0=H`` or ``A0=L``), undriven (``A0=Z``), or specified without a value (``A0``) to sample a pin. The actions are executed in the order they are provided on the command line."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Socket pin actions may be used to interface with the applet from an external application. Send each action over the socket in the same format as the CLI pin action described above, terminating with a ``\\n``. (Spaces are ignored.) When sampling a pin, the value is sent back over the socket terminated with a `\\n``, otherwise no response is provided."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "pins to drive or sample, e.g.: 'A0=1', 'A1=L', 'B5'"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O lines 'pins' to PINS (required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "listen at ENDPOINT, either unix:PATH or tcp:HOST:PORT"
+msgstr ""
+
+#: ../../src/applets/control/gpio.rst:14
+msgid "API reference"
+msgstr ""
+
+#: glasgow.applet.control.gpio.GPIOInterface.count:1 of
+msgid "Number of pins."
+msgstr ""
+
+#: glasgow.applet.control.gpio.GPIOInterface.pull:1 of
+msgid "Configure pull-up or pull-down for pin :py:`index`."
+msgstr ""
+
+#: glasgow.applet.control.gpio.GPIOInterface.input:1 of
+msgid "Configure pin :py:`index` as input."
+msgstr ""
+
+#: ../../src/applets/control/gpio.rst
+msgid "Raises"
+msgstr ""
+
+#: glasgow.applet.control.gpio.GPIOInterface.get:3
+#: glasgow.applet.control.gpio.GPIOInterface.input:3
+#: glasgow.applet.control.gpio.GPIOInterface.output:3
+#: glasgow.applet.control.gpio.GPIOInterface.set:3 of
+msgid "If :py:`index` does not specify a valid pin index."
+msgstr ""
+
+#: glasgow.applet.control.gpio.GPIOInterface.output:1 of
+msgid "Configure pin :py:`index` as output, initially driving :py:`value`."
+msgstr ""
+
+#: glasgow.applet.control.gpio.GPIOInterface.get:1 of
+msgid "Sample state of pin :py:`index`."
+msgstr ""
+
+#: glasgow.applet.control.gpio.GPIOInterface.set:1 of
+msgid "Update value driven by pin :py:`index` to be :py:`value`."
+msgstr ""
+
+#: glasgow.applet.control.gpio.GPIOInterface.set:4 of
+msgid "If pin :py:`index` is not configured as an ouptut."
+msgstr ""
+
+#: glasgow.applet.control.gpio.GPIOInterface.get_all:1 of
+msgid "Sample state of every pin simultaneously."
+msgstr ""
+
+#: glasgow.applet.control.gpio.GPIOInterface.get_all:3 of
+msgid "In the returned value, the least significant bit corresponds to the first pin in the port provided to the constructor."
+msgstr ""
+
+#: glasgow.applet.control.gpio.GPIOInterface.set_all:1 of
+msgid "Update value of every pin simultaneously."
+msgstr ""
+
+#: glasgow.applet.control.gpio.GPIOInterface.set_all:3 of
+msgid "In :py:`value`, the least significant bit corresponds to the first pin in the port provided to the constructor. The bits corresponding to pins that are configured as inputs, as well as the bits that do not correspond to any pins, are ignored."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/control/index.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/control/index.po
@@ -1,0 +1,36 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/control/index.rst:4
+msgid "Device control"
+msgstr ""
+
+#: glasgow.applet.control:1 of
+msgid "The ``control`` taxon groups applets implementing control interfaces, that is, interfaces for changing the volatile or non-volatile state of a device."
+msgstr ""
+
+#: glasgow.applet.control:4 of
+msgid "This taxon is an exclusion taxon, i.e. if a more specific taxon exists, it should be used. For example, ``memory`` and ``program`` applets also change volatile or non-volatile state of a device."
+msgstr ""
+
+#: glasgow.applet.control:7 of
+msgid "Examples: PLL frequency, DAC total level, USB PD I²C interface. Counterexamples: DAC total level plus bitstream (use taxon ``stream``), AVR SPI flashing (use taxon ``program``)."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/control/mdio.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/control/mdio.po
@@ -1,0 +1,88 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/control/mdio.rst:2
+msgid "``control-mdio``"
+msgstr ""
+
+#: ../../src/applets/control/mdio.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run control-mdio"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Configure Ethernet PHYs and query their status via the standard two-wire MDC/MDIO management interface. Both Clause 22 and Clause 45 operations are supported."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'mdc' to PIN (default: 'A0', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'mdio' to PIN (default: 'A1', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set MDC frequency to FREQ kHz (default: 1000)"
+msgstr ""
+
+#: ../../src/applets/control/mdio.rst:14
+msgid "API reference"
+msgstr ""
+
+#: glasgow.applet.control.mdio.ControlMDIOInterface.clock:1 of
+msgid "MDC clock divisor."
+msgstr ""
+
+#: glasgow.applet.control.mdio.ControlMDIOInterface.c22_read:1 of
+msgid "Read Clause 22 (SMI/MIIM) register ``reg`` of PHY ``phy``."
+msgstr ""
+
+#: glasgow.applet.control.mdio.ControlMDIOInterface.c22_write:1 of
+msgid "Write ``value`` to Clause 22 (MIIM) register ``reg`` of PHY ``phy``."
+msgstr ""
+
+#: glasgow.applet.control.mdio.ControlMDIOInterface.c45_read:1 of
+msgid "Read Clause 45 (MDIO) register ``reg`` of MMD ``dev`` of PHY ``phy``."
+msgstr ""
+
+#: glasgow.applet.control.mdio.ControlMDIOInterface.c45_write:1 of
+msgid "Write ``value`` to Clause 45 (MDIO) register ``reg`` of MMD ``dev`` of PHY ``phy``."
+msgstr ""
+
+#: glasgow.applet.control.mdio.ControlMDIOInterface.get_phy_id:1 of
+msgid "Read PHY identification."
+msgstr ""
+
+#: glasgow.applet.control.mdio.ControlMDIOInterface.get_phy_id:3 of
+msgid "Returns a tuple :py:`(oui24, model, rev)`, where :py:`oui24` is the OUI in the canonical (non-bit-reversed) representation; in it, two least significant bits are always 0."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/control/servo.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/control/servo.po
@@ -1,0 +1,96 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/control/servo.rst:2
+msgid "``control-servo``"
+msgstr ""
+
+#: ../../src/applets/control/servo.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run control-servo"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Control RC/hobby servomotors using the common pulse width modulation protocol where a pulse of 1000 µs corresponds to a minimum position and a pulse of 2000 µs corresponds to a maximum position. The frequency of the updates is not strictly constrained by the protocol, and is fixed at 50 Hz in this applet."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "This protocol is also used in common brushless motor ESC (electronic speed control) modules. For unidirectional ESCs, a pulse of 1000 µs corresponds to 0 rpm and a pulse of 2000 µs to maximum rpm. For bidirectional ESCs, a pulse of 1000 us corresponds to maximum rpm backwards, and 2000 µs to maximum rpm forwards."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'out' to PIN (default: 'A0', required)"
+msgstr ""
+
+#: ../../src/applets/control/servo.rst:14
+msgid "API reference"
+msgstr ""
+
+#: glasgow.applet.control.servo.ServoInterface.enable:1 of
+msgid "Enable or disable the servo."
+msgstr ""
+
+#: glasgow.applet.control.servo.ServoInterface.enable:3 of
+msgid "When disabled, no pulses are sent over the control line."
+msgstr ""
+
+#: glasgow.applet.control.servo.ServoInterface.disable:1 of
+msgid "Disable the servo."
+msgstr ""
+
+#: glasgow.applet.control.servo.ServoInterface.disable:3 of
+msgid "Calls :py:`self.enable(False)`."
+msgstr ""
+
+#: glasgow.applet.control.servo.ServoInterface.set_value:1 of
+msgid "Set servo control value."
+msgstr ""
+
+#: glasgow.applet.control.servo.ServoInterface.set_value:3 of
+msgid ":py:`value` is an integer number of microseconds in the range of 1000 to 2000 inclusive. Note that the interpretation of this value varies depending on the connected device:"
+msgstr ""
+
+#: glasgow.applet.control.servo.ServoInterface.set_value:6 of
+msgid "For a servo proper, 1500 corresponds to the neutral position."
+msgstr ""
+
+#: glasgow.applet.control.servo.ServoInterface.set_value:7 of
+msgid "For an unidirectional ESC, 1000 is 0 rpm and 2000 is maximum rpm."
+msgstr ""
+
+#: glasgow.applet.control.servo.ServoInterface.set_value:8 of
+msgid "For a bidirectional ESC, 1000 is maximum rpm backwards and 2000 is maximum rpm forwards."
+msgstr ""
+
+#: glasgow.applet.control.servo.ServoInterface.set_value:10 of
+msgid "The servo is enabled after the value is configured."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/control/si535x.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/control/si535x.po
@@ -1,0 +1,134 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/control/si535x.rst:2
+msgid "``control-si535x``"
+msgstr ""
+
+#: ../../src/applets/control/si535x.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run control-si535x"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Access registers of Skyworks Si535x programmable clock generators."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'scl' to PIN (default: 'A0', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'sda' to PIN (default: 'A1', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "I2C address of the controller (default: 0x60)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run control-si535x configure-si5351"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "ClockBuilder Pro CSV configuration to configure"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "comma-separated list of outputs to enable after configuration (for \"Powered-up with Output Disabled\" mode)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run control-si535x read"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "register address"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "number of registers to read"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run control-si535x write"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "data to write, as hex bytes"
+msgstr ""
+
+#: ../../src/applets/control/si535x.rst:14
+msgid "API reference"
+msgstr ""
+
+#: glasgow.applet.control.si535x.Si535xInterface.read:1 of
+msgid "Read a register or several consecutive registers starting at :py:`address`."
+msgstr ""
+
+#: glasgow.applet.control.si535x.Si535xInterface.read:3 of
+msgid "Returns an :class:`int` if :py:`count is None`, and :class:`bytes` otherwise."
+msgstr ""
+
+#: ../../src/applets/control/si535x.rst
+msgid "Raises"
+msgstr ""
+
+#: glasgow.applet.control.si535x.Si535xInterface.configure_si5351:6
+#: glasgow.applet.control.si535x.Si535xInterface.read:5
+#: glasgow.applet.control.si535x.Si535xInterface.write:3 of
+msgid "If communication fails."
+msgstr ""
+
+#: glasgow.applet.control.si535x.Si535xInterface.write:1 of
+msgid "Write a register or several consecutive registers starting at :py:`address`."
+msgstr ""
+
+#: glasgow.applet.control.si535x.Si535xInterface.parse_file:1 of
+msgid "Parse a ClockBuilder Pro CSV register file."
+msgstr ""
+
+#: glasgow.applet.control.si535x.Si535xInterface.parse_file:3 of
+msgid "Returns a list of 2-tuples :py:`(register, value)`."
+msgstr ""
+
+#: glasgow.applet.control.si535x.Si535xInterface.parse_file:5 of
+msgid "If the file contains invalid data."
+msgstr ""
+
+#: glasgow.applet.control.si535x.Si535xInterface.configure_si5351:1 of
+msgid "Configure a Si5351A/B/C device."
+msgstr ""
+
+#: glasgow.applet.control.si535x.Si535xInterface.configure_si5351:3 of
+msgid "Accepts a list of 2-tuples :py:`(register, value)` (as returned by :meth:`parse_file`) and a bit mask :py:`enable` where a 1 in a position `n` enables `n`-th output."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/debug/arc.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/debug/arc.po
@@ -1,0 +1,100 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/debug/arc.rst:2
+msgid "``debug-arc``"
+msgstr ""
+
+#: ../../src/applets/debug/arc.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run debug-arc"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Debug ARC processors via the JTAG interface."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The list of supported devices is:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "ARC6xx"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "ARC7xx"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "There is currently no debug server implemented. This applet only allows manipulating Memory, Core and Aux spaces via a Python REPL."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tck' to PIN (default: 'A0', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tms' to PIN (default: 'A1', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tdi' to PIN (default: 'A2', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tdo' to PIN (default: 'A3', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'trst' to PIN (optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set TCK frequency to FREQ kHz (default: 100)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "give up scanning IRs longer than LENGTH bits (default: 128)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "give up scanning DRs longer than LENGTH bits (default: 1024)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set IR lengths of each TAP to corresponding IR-LENGTH (default: autodetect)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "select TAP #INDEX for communication (default: select only TAP)"
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/debug/arm.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/debug/arm.po
@@ -1,0 +1,84 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/debug/arm.rst:2
+msgid "``debug-arm``"
+msgstr ""
+
+#: ../../src/applets/debug/arm.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run debug-arm"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Debug ARM processors with CoreSight support via the JTAG interface."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tck' to PIN (default: 'A0', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tms' to PIN (default: 'A1', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tdi' to PIN (default: 'A2', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tdo' to PIN (default: 'A3', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'trst' to PIN (optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set TCK frequency to FREQ kHz (default: 100)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "give up scanning IRs longer than LENGTH bits (default: 128)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "give up scanning DRs longer than LENGTH bits (default: 1024)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set IR lengths of each TAP to corresponding IR-LENGTH (default: autodetect)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "select TAP #INDEX for communication (default: select only TAP)"
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/debug/arm7.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/debug/arm7.po
@@ -1,0 +1,112 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/debug/arm7.rst:2
+msgid "``debug-arm7``"
+msgstr ""
+
+#: ../../src/applets/debug/arm7.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run debug-arm7"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Debug ARM7TDMI processors via the JTAG interface."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "This applet supports displaying CPU state, dumping a memory region, and running a GDB remote protocol server for a debugger. All debugger features are implemented except for memory watchpoints. (This processor has errata that makes watchpoints essentially unusable, as well as impacting breakpoints.)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The applet should work on all big-endian and little-endian ARM7TDMI CPUs, and has been tested on a big-endian SoC (Yamaha SWLL)."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The CPU must be the only TAP in the JTAG chain."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tck' to PIN (default: 'A0', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tms' to PIN (default: 'A1', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tdo' to PIN (default: 'A2', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tdi' to PIN (default: 'A3', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'trst' to PIN (optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "target endianness (default: little)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set TCK frequency to FREQ kHz (default: 1000)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run debug-arm7 dump-memory"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "start at ADDRESS"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "dump LENGTH bytes"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "dump contents to FILENAME"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run debug-arm7 dump-state"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run debug-arm7 gdb"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "listen at GDB-ENDPOINT, either unix:PATH or tcp:HOST:PORT (default: tcp::1234)"
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/debug/index.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/debug/index.po
@@ -1,0 +1,40 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/debug/index.rst:4
+msgid "MCU debugging"
+msgstr ""
+
+#: glasgow.applet.debug:1 of
+msgid "The ``debug`` taxon groups applets implementing interfaces to microprocessor or microcontroller debug functions, such as manipulating memory and core state, and pausing and resuming execution. The differentiating characteristic for this taxon is manipulation of control flow."
+msgstr ""
+
+#: glasgow.applet.debug:5 of
+msgid "These applets may provide a higher level interface that can be used with an external debugger, like gdb, or any other appropriate interface. If the debug functions may be used for manipulating non-volatile memories, a different applet would be provided for that under the ``program`` taxon."
+msgstr ""
+
+#: glasgow.applet.debug:9 of
+msgid "The names of applets in this taxon start with the processor architecture they work with, and may be differentiated further, by architecture variant and/or debug transport."
+msgstr ""
+
+#: glasgow.applet.debug:12 of
+msgid "Examples: MIPS EJTAG, AVR debugWIRE. Counterexamples: AVR SPI (use taxon ``program``)."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/debug/mips.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/debug/mips.po
@@ -1,0 +1,140 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/debug/mips.rst:2
+msgid "``debug-mips``"
+msgstr ""
+
+#: ../../src/applets/debug/mips.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run debug-mips"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Debug MIPS processors via the EJTAG interface."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "This applet supports dumping CPU state, which is also useful to check if the CPU is recognized correctly, and running a GDB remote protocol server for a debugger. The supported debugger features are:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Starting, stopping and single-stepping."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Hardware and software breakpoints."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Register and memory reads and writes."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Notable omissions include:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Floating point."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Tracepoints and watchpoints."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The applet has been written with 32- and 64-bit CPUs with EJTAG 1.x-5.x in mind, but has only been tested with the following configurations:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "MIPS32 R1 big endian with EJTAG 1.x/2.0 (Broadcom BCM6358);"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "MIPS32 R1 big endian with EJTAG 2.6 (Infineon ADM5120)."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Other configurations might or might not work. In particular, it certainly does not currently work on little-endian CPUs. Sorry about that."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tck' to PIN (default: 'A0', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tms' to PIN (default: 'A1', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tdi' to PIN (default: 'A2', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tdo' to PIN (default: 'A3', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'trst' to PIN (optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set TCK frequency to FREQ kHz (default: 100)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "give up scanning IRs longer than LENGTH bits (default: 128)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "give up scanning DRs longer than LENGTH bits (default: 1024)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set IR lengths of each TAP to corresponding IR-LENGTH (default: autodetect)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "select TAP #INDEX for communication (default: select only TAP)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run debug-mips dump-state"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run debug-mips gdb"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "listen at GDB-ENDPOINT, either unix:PATH or tcp:HOST:PORT (default: tcp::1234)"
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/index.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/index.po
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/index.rst:2
+msgid "Applet index"
+msgstr ""
+
+#: ../../src/applets/index.rst:6
+msgid "Note that not every applet is documented here yet; see ``glasgow run --help`` for a complete list."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/interface/i2c_controller.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/interface/i2c_controller.po
@@ -1,0 +1,180 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/interface/i2c_controller.rst:2
+msgid "``i2c-controller``"
+msgstr ""
+
+#: ../../src/applets/interface/i2c_controller.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run i2c-controller"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Initiate transactions on the I²C bus."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The following optional bus features are supported:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Clock stretching"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Device ID"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'scl' to PIN (default: 'A0', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'sda' to PIN (default: 'A1', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set SCL frequency to FREQ kHz (default: 100, range: 100...4000)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run i2c-controller scan"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "read device ID from devices responding to scan"
+msgstr ""
+
+#: ../../src/applets/interface/i2c_controller.rst:14
+msgid "API reference"
+msgstr ""
+
+#: glasgow.applet.interface.i2c_controller.I2CControllerInterface.clock:1 of
+msgid "SCL clock divisor."
+msgstr ""
+
+#: glasgow.applet.interface.i2c_controller.I2CControllerInterface.transaction:1
+#: of
+msgid "Perform a transaction."
+msgstr ""
+
+#: glasgow.applet.interface.i2c_controller.I2CControllerInterface.transaction:3
+#: of
+msgid "While a transaction is active, calls to :meth:`write` and :meth:`read` do not generate a STOP condition; only one STOP condition is generated once the transaction ends. This also means that each call to :meth:`write` or :meth:`read` after the first such call in a transaction will generate a repeated START condition."
+msgstr ""
+
+#: glasgow.applet.interface.i2c_controller.I2CControllerInterface.transaction:8
+#: of
+msgid "For example, to perform ``S 0x50 nW 0x01 A Sr 0x50 R 0x?? nA 0x?? P`` (read of two bytes from a 24-series single address byte EEPROM, starting at address 0x01), use the following code:"
+msgstr ""
+
+#: glasgow.applet.interface.i2c_controller.I2CControllerInterface.transaction:18
+#: of
+msgid "An empty transaction (where the body does not call :meth:`write` or :meth:`read`) is allowed and produces no bus activity. (A START condition followed by a STOP condition is prohibited by the I²C specification.)"
+msgstr ""
+
+#: glasgow.applet.interface.i2c_controller.I2CControllerInterface.write:1 of
+msgid "Write bytes."
+msgstr ""
+
+#: glasgow.applet.interface.i2c_controller.I2CControllerInterface.write:3 of
+msgid "Generates a START condition followed by a WRITE target address (:py:`(address << 1) | 0`), writes data, then generates a STOP condition (unless used within a transaction)."
+msgstr ""
+
+#: ../../src/applets/interface/i2c_controller.rst
+msgid "Raises"
+msgstr ""
+
+#: glasgow.applet.interface.i2c_controller.I2CControllerInterface.write:6 of
+msgid "If either the target address or the written data receives a not-acknowledgement."
+msgstr ""
+
+#: glasgow.applet.interface.i2c_controller.I2CControllerInterface.read:1 of
+msgid "Read bytes."
+msgstr ""
+
+#: glasgow.applet.interface.i2c_controller.I2CControllerInterface.read:3 of
+msgid "Generates a START condition followed by a READ target address (:py:`(address << 1) | 1`), reads data, then generates a STOP condition (unless used within a transaction)."
+msgstr ""
+
+#: glasgow.applet.interface.i2c_controller.I2CControllerInterface.read:6 of
+msgid "The I²C bus design requires :py:`count` to be 1 or more."
+msgstr ""
+
+#: glasgow.applet.interface.i2c_controller.I2CControllerInterface.read:8 of
+msgid "If the target address receives a not-acknowledgement."
+msgstr ""
+
+#: glasgow.applet.interface.i2c_controller.I2CControllerInterface.ping:1 of
+msgid "Check address for presence."
+msgstr ""
+
+#: glasgow.applet.interface.i2c_controller.I2CControllerInterface.ping:3 of
+msgid "Generates a START condition followed by a WRITE target address, then generates a STOP condition (unless used within a transaction). This is done using a :meth:`write` call with no data."
+msgstr ""
+
+#: glasgow.applet.interface.i2c_controller.I2CControllerInterface.ping:7 of
+msgid "Returns :py:`True` if the target adddress receives an acknowledgement, :py:`False` otherwise."
+msgstr ""
+
+#: glasgow.applet.interface.i2c_controller.I2CControllerInterface.scan:1 of
+msgid "Scan address range for presence."
+msgstr ""
+
+#: glasgow.applet.interface.i2c_controller.I2CControllerInterface.scan:3 of
+msgid "Calls :meth:`ping` for each of :py:`addresses`. The default address range includes every non-reserved I²C address."
+msgstr ""
+
+#: glasgow.applet.interface.i2c_controller.I2CControllerInterface.scan:6 of
+msgid "Returns the set of addresses receiving an acknowledgement."
+msgstr ""
+
+#: glasgow.applet.interface.i2c_controller.I2CControllerInterface.device_id:1
+#: of
+msgid "Retrieve Device ID."
+msgstr ""
+
+#: glasgow.applet.interface.i2c_controller.I2CControllerInterface.device_id:3
+#: of
+msgid "The standard I²C Device ID command (which uses the reserved address :py:`0b1111_100`) must not be confused with various vendor-specific device identifiers (which use a vendor-specific mechanism). This command is optional and rarely implemented."
+msgstr ""
+
+#: glasgow.applet.interface.i2c_controller.I2CControllerInterface.device_id:7
+#: of
+msgid "Returns a 3-tuple :py:`(manufacturer, part_ident, revision)`."
+msgstr ""
+
+#: glasgow.applet.interface.i2c_controller.I2CControllerInterface.device_id:9
+#: of
+msgid "If the command is not implemented."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/interface/index.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/interface/index.po
@@ -1,0 +1,36 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/interface/index.rst:4
+msgid "I/O interfaces"
+msgstr ""
+
+#: glasgow.applet.interface:1 of
+msgid "The ``interface`` taxon is the most fundamental and generic applet taxon. It groups applets implementing interfaces that are used for purposes that do not fit into any single other taxon."
+msgstr ""
+
+#: glasgow.applet.interface:4 of
+msgid "Because the ``interface`` taxon is so important, the applet names in this taxon are not prefixed with the taxon name."
+msgstr ""
+
+#: glasgow.applet.interface:7 of
+msgid "Examples: SPI, I²C. Counterexamples: MIDI (use taxon ``audio``)."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/interface/jtag_pinout.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/interface/jtag_pinout.po
@@ -1,0 +1,52 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/interface/jtag_pinout.rst:2
+msgid "``jtag-pinout``"
+msgstr ""
+
+#: ../../src/applets/interface/jtag_pinout.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run jtag-pinout"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Determine JTAG pin functions given a set of pins."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O lines 'pins' to PINS (required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set clock period to FREQ kHz (default: 10)"
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/interface/jtag_probe.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/interface/jtag_probe.po
@@ -1,0 +1,140 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/interface/jtag_probe.rst:2
+msgid "``jtag-probe``"
+msgstr ""
+
+#: ../../src/applets/interface/jtag_probe.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run jtag-probe"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Identify, test and debug integrated circuits and board assemblies via IEEE 1149.1 JTAG."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tck' to PIN (default: 'A0', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tms' to PIN (default: 'A1', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tdi' to PIN (default: 'A2', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tdo' to PIN (default: 'A3', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'trst' to PIN (optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set TCK frequency to FREQ kHz (default: 100)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "give up scanning IRs longer than LENGTH bits (default: 128)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "give up scanning DRs longer than LENGTH bits (default: 1024)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set IR lengths of each TAP to corresponding IR-LENGTH (default: autodetect)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run jtag-probe enumerate-ir"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "THIS COMMAND CAN PERMANENTLY DAMAGE DEVICE UNDER TEST."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "IEEE 1149.1 requires every unimplemented IR value to select the BYPASS DR. By selecting every possible IR value and measuring DR lengths, it is possible to discover IR values that definitively correspond to non-BYPASS DRs."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Due to the design of JTAG state machine, measuring DR length requires going through Capture-DR and Update-DR states for instructions that may have IRREVERSIBLE or UNDEFINED behavior. Although this command updates the DR with the data just captured from it, IEEE 1149.1 does not require this operation to be idempotent. Additionally, many devices are not strictly compliant and in practice may perform IRREVERSIBLE or UNDEFINED actions during operations that IEEE 1149.1 requires to be benign, such as selecting an unimplemented instruction, or shifting into DR. USE THIS COMMAND AT YOUR OWN RISK."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "DR length measurement can have one of the following four results:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "DR[n], n > 1: non-BYPASS n-bit DR."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "DR[1]: (likely) BYPASS or (less likely) non-BYPASS 1-bit DR. This result is not shown because most IR values correspond to DR[1]."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "DR[0]: TDI connected directly to TDO. This is not allowed by IEEE 1149.1, but is very common in practice."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "DR[?]: (commonly) no connection to TDO or (less commonly) complex logic connected between TDI and TDO that is active during Shift-DR. This is not allowed by IEEE 1149.1, but is common in practice."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "enumerate IR values for TAP(s) #INDEX"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run jtag-probe scan"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Reset the JTAG TAPs and shift IDCODE or BYPASS register values out to determine the count and (if available) identity of the devices in the scan chain."
+msgstr ""
+
+#: ../../src/applets/interface/jtag_probe.rst:14
+msgid "API reference"
+msgstr ""
+
+#: ../../src/applets/interface/jtag_probe.rst:16
+msgid "Todo"
+msgstr ""
+
+#: ../../src/applets/interface/jtag_probe.rst:18
+msgid "Add API documentation for ``jtag-probe``."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/interface/jtag_svf.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/interface/jtag_svf.po
@@ -1,0 +1,100 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/interface/jtag_svf.rst:2
+msgid "``jtag-svf``"
+msgstr ""
+
+#: ../../src/applets/interface/jtag_svf.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run jtag-svf"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Play SVF test vectors via the JTAG interface."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "This applet currently does not implement some SVF features:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "PIOMAP and PIO are not supported;"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The SCK clock in RUNTEST is not supported."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "If any commands requiring these features are encountered, the applet terminates itself."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "test vector to play"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tck' to PIN (default: 'A0', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tms' to PIN (default: 'A1', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tdi' to PIN (default: 'A2', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tdo' to PIN (default: 'A3', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'trst' to PIN (optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set TCK frequency to FREQ kHz (default: 100)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "give up scanning IRs longer than LENGTH bits (default: 128)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "give up scanning DRs longer than LENGTH bits (default: 1024)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set IR lengths of each TAP to corresponding IR-LENGTH (default: autodetect)"
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/interface/qspi_analyzer.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/interface/qspi_analyzer.po
@@ -1,0 +1,108 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/interface/qspi_analyzer.rst:2
+msgid "``qspi-analyzer``"
+msgstr ""
+
+#: ../../src/applets/interface/qspi_analyzer.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run qspi-analyzer"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Capture transactions on the extended variant of the SPI bus with four I/O channels."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "QSPI data is captured in a clock domain driven by the SCK pin and reset by the CS# pin. This approach enables capturing data at very high SCK frequencies (up to 96 MHz), but requires a small delay between the last SCK rising edge and CS# rising edge, otherwise the last byte of a transaction will not be captured correctly. Typically, QSPI controllers do provide this delay."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Signal integrity is exceptionally important for this applet. When using flywires, twist every signal wire (at the very least, CS# and SCK wires) with a ground wire connected to ground at both ends, otherwise the captured data will likely be nonsense."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Both quad-IO and dual-IO captures are supported. If only IO0 and IO1 pins are provided, the capture proceeds as if IO2 and IO3 were fixed at 0."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The capture file format is Comma Separated Values, in the following line format:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "``<DATA>``, where <DATA> is a hexadecimal nibble sequence with each four bits corresponding to samples of HOLD#, WP#, CIPO, COPI (from MSB to LSB)."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "If your DUT is a 25-series SPI Flash memory, use the `tool memory-25x` to extract data from capture files. If quad-IO commands are not in use, the `spi-analyzer` applet can reduce the likelihood of an overflow."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "save communications to FILE as hex sequences"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'cs' to PIN (default: 'A0', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'sck' to PIN (default: 'A1', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O lines 'copi', 'cipo', 'wp', 'hold' to PINS (default: 'A2,A3,A4,A5', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set FPGA trace buffer size to BYTES (must be power of 2, default: 16384)"
+msgstr ""
+
+#: ../../src/applets/interface/qspi_analyzer.rst:14
+msgid "API reference"
+msgstr ""
+
+#: glasgow.applet.interface.qspi_analyzer.QSPIAnalyzerInterface.capture:1 of
+msgid "Capture a transaction."
+msgstr ""
+
+#: glasgow.applet.interface.qspi_analyzer.QSPIAnalyzerInterface.capture:3 of
+msgid "It is not possible to determine the mode of any given bus cycle, or the direction of any given bit, so the transaction is captured as a byte sequence."
+msgstr ""
+
+#: ../../src/applets/interface/qspi_analyzer.rst
+msgid "Raises"
+msgstr ""
+
+#: glasgow.applet.interface.qspi_analyzer.QSPIAnalyzerInterface.capture:6 of
+msgid "When the FPGA buffer overflows. The last few transactions before the overflow occurred     may be dropped as well."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/interface/qspi_controller.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/interface/qspi_controller.po
@@ -1,0 +1,436 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/interface/qspi_controller.rst:2
+msgid "``qspi-controller``"
+msgstr ""
+
+#: ../../src/applets/interface/qspi_controller.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run qspi-controller"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Initiate transactions on the extended variant of the SPI bus with four I/O channels."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "This applet can control a wide range of devices, primarily memories, that use multi-bit variants of the SPI bus. Electrically, they are all compatible, with the names indicating differences in protocol logic:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "\"SPI\" uses COPI/CIPO for both commands and data;"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "\"dual-SPI\" uses COPI/CIPO for commands and IO0/IO1 for data;"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "\"quad-SPI\" uses COPI/CIPO for commands and IO0/IO1/IO2/IO3 for data;"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "\"QPI\" uses IO0/IO1/IO2/IO3 for both commands and data."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "In this list, COPI and CIPO refer to IO0 and IO1 respectively used as fixed direction I/O. Note that vendors often make further distinction between modes, e.g. between \"dual output SPI\" and \"dual I/O SPI\"; refer to the vendor documentation for details."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The command line interface only initiates SPI mode transfers. Use the REPL for other modes."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "hex bytes to exchange with the device in SPI mode"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'sck' to PIN (default: 'A0', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O lines 'copi', 'cipo', 'io2', 'io3' to PINS (default: 'A1,A2,A3,A4', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'cs' to PIN (default: 'A5', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set SCK frequency to FREQ kHz (default: 1000)"
+msgstr ""
+
+#: ../../src/applets/interface/qspi_controller.rst:14
+msgid "API reference"
+msgstr ""
+
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface:1 of
+msgid "Pull-ups are enabled on all :py:`io` pins."
+msgstr ""
+
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.clock:1 of
+msgid "SCK clock divisor."
+msgstr ""
+
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.select:1 of
+msgid "Perform a transaction."
+msgstr ""
+
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.select:3 of
+msgid "Starting a transaction configures the first transfer within the transaction to assert the :py:`index`-th chip select signal; ending a transaction deasserts the chip select signal. Methods :meth:`write`, :meth:`read`, :meth:`exchange`, and :meth:`dummy` may be called only while a transaction is active to transfer data on the bus."
+msgstr ""
+
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.select:8 of
+msgid "For example, to read 16 bytes from an SPI NOR flash at address :py:`0x001234` using the Fast Read (0Bh) command, use the following code:"
+msgstr ""
+
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.select:19
+#: of
+msgid "An empty transaction (where the body does not call :meth:`write`, :meth:`read`, :meth:`exchange`, or :meth:`dummy`) is allowed and does not cause any chip select activity."
+msgstr ""
+
+#: ../../src/applets/interface/qspi_controller.rst
+msgid "Raises"
+msgstr ""
+
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.select:22
+#: of
+msgid "If recursively called inside a transaction."
+msgstr ""
+
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.select:23
+#: of
+msgid "If :py:`index` is greater than 7."
+msgstr ""
+
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.exchange:1
+#: of
+msgid "Exchange bytes."
+msgstr ""
+
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.exchange:3
+#: of
+msgid "Clock :py:`octets` out via the IO0 (COPI) pin while clocking return value in via the IO1 (CIPO) pin. Unlike :meth:`write` and :meth:`read`, this method always uses x1 transfer rate."
+msgstr ""
+
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.dummy:11
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.exchange:7
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.read:6
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.write:5 of
+msgid "If called outside of a transaction."
+msgstr ""
+
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.write:1 of
+msgid "Write bytes."
+msgstr ""
+
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.write:3 of
+msgid "Clock :py:`octets` out via :py:`x` IOn pins, corresponding to single, dual, or quad SPI."
+msgstr ""
+
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.read:1 of
+msgid "Read bytes."
+msgstr ""
+
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.read:3 of
+msgid "Clock :py:`count` octets in via :py:`x` IOn pins, corresponding to single, dual, or quad SPI."
+msgstr ""
+
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.dummy:1 of
+msgid "Clock dummy cycles."
+msgstr ""
+
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.dummy:3 of
+msgid "Clock :py:`count` dummy cycles. One octet corresponds to 8 dummy cycles in single SPI mode, 4 dummy cycles in dual SPI mode, and 2 dummy cycles in quad SPI mode. Some devices may require a non-multiple"
+msgstr ""
+
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.dummy:9 of
+msgid "The state of IOn pins is undefined during this operation."
+msgstr ""
+
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.delay_ms:1
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.delay_us:1
+#: of
+msgid "Delay operations."
+msgstr ""
+
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.delay_us:3
+#: of
+msgid "Delays the following QSPI bus operations by :py:`duration` microseconds."
+msgstr ""
+
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.delay_ms:3
+#: of
+msgid "Delays the following QSPI bus operations by :py:`duration` milliseconds. Equivalent to :py:`delay_us(duration * 1000)`."
+msgstr ""
+
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.synchronize:1
+#: of
+msgid "Synchronization barrier."
+msgstr ""
+
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.synchronize:3
+#: of
+msgid "Ensures that once this method returns, all previously submitted operations have completed."
+msgstr ""
+
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.execute_cmd:1
+#: of
+msgid "Execute a memory technology instruction without data transfer."
+msgstr ""
+
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.execute_cmd:3
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.execute_read:3
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.execute_write:3
+#: of
+msgid "This is a low-level operation; in most cases, a memory technology specific interface should be used instead."
+msgstr ""
+
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.execute_read:1
+#: of
+msgid "Execute a memory technology instruction that reads data."
+msgstr ""
+
+#: glasgow.applet.interface.qspi_controller.QSPIControllerInterface.execute_write:1
+#: of
+msgid "Execute a memory technology instruction that writes data."
+msgstr ""
+
+#: ../../src/applets/interface/qspi_controller.rst:24
+msgid "Memory command set reference"
+msgstr ""
+
+#: ../../src/applets/interface/qspi_controller.rst:26
+msgid "The building blocks below are used for implementing memory technology interfaces, such as :ref:`memory-25q <applet.memory._25q>`. They are typically not used on their own."
+msgstr ""
+
+#: glasgow.arch.qspi.Direction:1 of
+msgid "Transfer direction."
+msgstr ""
+
+#: glasgow.arch.qspi.Direction:3 of
+msgid "Specified relative to the controller."
+msgstr ""
+
+#: glasgow.arch.qspi.Direction:1 of
+msgid "Valid values are as follows:"
+msgstr ""
+
+#: glasgow.arch.qspi.CommandMode:1 of
+msgid "Command mode."
+msgstr ""
+
+#: glasgow.arch.qspi.CommandMode:3 of
+msgid "Specifies gearing for the opcode, address, and data phase."
+msgstr ""
+
+#: ../../docstring glasgow.arch.qspi.CommandMode.opcode:1
+#: glasgow.arch.qspi.Instruction.x_opcode:1 of
+msgid "Gearing of the opcode phase."
+msgstr ""
+
+#: ../../docstring glasgow.arch.qspi.CommandMode.address:1
+#: glasgow.arch.qspi.Instruction.x_address:1 of
+msgid "Gearing of the address phase."
+msgstr ""
+
+#: ../../docstring glasgow.arch.qspi.CommandMode.address:3 of
+msgid "If :py:`0`, there is no address phase."
+msgstr ""
+
+#: ../../docstring glasgow.arch.qspi.CommandMode.data:1
+#: glasgow.arch.qspi.Instruction.x_data:1 of
+msgid "Gearing of the data phase."
+msgstr ""
+
+#: ../../docstring glasgow.arch.qspi.CommandMode.data:3 of
+msgid "If :py:`0`, there is no data phase."
+msgstr ""
+
+#: glasgow.arch.qspi.CommandMode.uses_dual:1 of
+msgid "Whether any phase uses dual SPI."
+msgstr ""
+
+#: glasgow.arch.qspi.CommandMode.uses_quad:1 of
+msgid "Whether any phase uses quad SPI."
+msgstr ""
+
+#: glasgow.arch.qspi.Instruction:1 of
+msgid "Instruction format."
+msgstr ""
+
+#: glasgow.arch.qspi.Instruction:3 of
+msgid "The :py:`Instruction` describes the framing of each part (opcode, address, dummy, and data) of an abstract (Q)SPI instruction. The :py:`(x_opcode, x_address, x_data)` tuple corresponds to the SFDP ``x-y-z`` terminology (e.g. ``1-1-4`` for quad output has :py:`x_opcode, x_address, x_data = 1, 1, 4`). These \"gearing\" parameters indicate how many bits are transmitted per cycle, e.g. it takes :py:`8 // x_opcode` cycles to transmit the instruction opcode."
+msgstr ""
+
+#: ../../docstring glasgow.arch.qspi.Instruction.opcode:1 of
+msgid "Instruction opcode (one octet)."
+msgstr ""
+
+#: ../../docstring glasgow.arch.qspi.Instruction.x_address:3 of
+msgid "If :py:`0`, there is no address phase, and :data:`address_octets` must also be :py:`0`."
+msgstr ""
+
+#: ../../docstring glasgow.arch.qspi.Instruction.x_data:3 of
+msgid "If :py:`0`, there is no data phase, and :data:`data_octets` must also be :py:`0`."
+msgstr ""
+
+#: ../../docstring glasgow.arch.qspi.Instruction.address_octets:1 of
+msgid "Length of the address phase, in octets."
+msgstr ""
+
+#: ../../docstring glasgow.arch.qspi.Instruction.address_octets:3 of
+msgid "Typically, between 0 and 4 inclusive, but this is not a hard requirement."
+msgstr ""
+
+#: ../../docstring glasgow.arch.qspi.Instruction.mode_cycles:1 of
+msgid "Length of the mode phase, in cycles."
+msgstr ""
+
+#: ../../docstring glasgow.arch.qspi.Instruction.mode_cycles:3 of
+msgid "Typically, between 0 and 4 inclusive, and an integer multiple of the number of cycles needed to exchange a byte in the address phase, but this is not a hard requirement."
+msgstr ""
+
+#: ../../docstring glasgow.arch.qspi.Instruction.dummy_cycles:1 of
+msgid "Length of the dummy phase, in cycles."
+msgstr ""
+
+#: ../../docstring glasgow.arch.qspi.Instruction.dummy_cycles:3 of
+msgid "Typically, either :py:`0` or :py:`8 // x_address`, but this is not guaranteed: certain devices require dummy phase of a length that is not an integer multiple of the number of cycles needed to exchange a byte in the address or data phase."
+msgstr ""
+
+#: ../../docstring glasgow.arch.qspi.Instruction.direction:1 of
+msgid "Direction of the data phase."
+msgstr ""
+
+#: ../../docstring glasgow.arch.qspi.Instruction.direction:3 of
+msgid "Must be :py:`None` if and only if :py:`x_data == 0`."
+msgstr ""
+
+#: ../../docstring glasgow.arch.qspi.Instruction.data_octets:1 of
+msgid "Length of the data phase, in octets."
+msgstr ""
+
+#: ../../docstring glasgow.arch.qspi.Instruction.data_octets:3 of
+msgid "Typically, variable (indicated as :py:`None`), but certain commands return a fixed amount of data. See also :attr:`data_repeats`."
+msgstr ""
+
+#: ../../docstring glasgow.arch.qspi.Instruction.data_repeats:1 of
+msgid "Whether the data output repeats."
+msgstr ""
+
+#: ../../docstring glasgow.arch.qspi.Instruction.data_repeats:3 of
+msgid "If true, then the output repeats after transferring more than :attr:`data_octets`. For status registers, each repeat indicates up-to-date state at the moment of the transfer."
+msgstr ""
+
+#: ../../docstring glasgow.arch.qspi.Instruction.data_repeats:6 of
+msgid "If false, data output might return all-zeroes, all-ones, or be undriven after transferring :attr:`data_octets`, and this condition should be avoided."
+msgstr ""
+
+#: glasgow.arch.qspi.Instruction.spi_1_0_0:1 of
+msgid "SPI instruction with 1-0-0 gearing."
+msgstr ""
+
+#: glasgow.arch.qspi.Instruction.spi_1_1_0:1 of
+msgid "SPI instruction with 1-1-0 gearing."
+msgstr ""
+
+#: glasgow.arch.qspi.Instruction.spi_1_0_1:1 of
+msgid "SPI instruction with 1-0-1 gearing."
+msgstr ""
+
+#: glasgow.arch.qspi.Instruction.spi_1_1_1:1 of
+msgid "SPI instruction with 1-1-1 gearing."
+msgstr ""
+
+#: glasgow.arch.qspi.Instruction.dspi_1_1_2:1 of
+msgid "Dual SPI instruction with 1-1-2 gearing."
+msgstr ""
+
+#: glasgow.arch.qspi.Instruction.dspi_1_2_2:1 of
+msgid "Dual SPI instruction with 1-2-2 gearing."
+msgstr ""
+
+#: glasgow.arch.qspi.Instruction.qspi_1_1_4:1 of
+msgid "Quad SPI instruction with 1-1-4 gearing."
+msgstr ""
+
+#: glasgow.arch.qspi.Instruction.qspi_1_4_4:1 of
+msgid "Quad SPI instruction with 1-4-4 gearing."
+msgstr ""
+
+#: glasgow.arch.qspi.Instruction.mode:1 of
+msgid "Command mode of this instruction."
+msgstr ""
+
+#: glasgow.arch.qspi.BaseCommandSet:1 of
+msgid "Base class for command sets."
+msgstr ""
+
+#: glasgow.arch.qspi.BaseCommandSet:3 of
+msgid "A command set is a mapping from an abstract command (e.g. \"Erase 4K Sector\") to a specific concrete instruction (e.g. \"20h, 1-0-0, 3 address bytes\"). Maintaining this mapping is necessary because similar devices from different vendors, different variants of the same device from the same vendor, or the exact same device with different volatile configuration, may have the same abstract commands represented by different concrete opcodes."
+msgstr ""
+
+#: glasgow.arch.qspi.BaseCommandSet:9 of
+msgid "Technology-specific command sets should inherit from this class and include methods that parse memory architecture self-description data (if available) or assist in manually configuring the instruction set; for example, see :class:`glasgow.arch.qspi.nor.CommandSet`."
+msgstr ""
+
+#: glasgow.arch.qspi.BaseCommandSet.update:1 of
+msgid "Add multiple :py:`CommandT`-:class:`Instruction` mappings."
+msgstr ""
+
+#: glasgow.arch.qspi.BaseCommandSet.__setitem__:3
+#: glasgow.arch.qspi.BaseCommandSet.update:3 of
+msgid "Overwrites mappings that already exist."
+msgstr ""
+
+#: glasgow.arch.qspi.BaseCommandSet.__setitem__:1 of
+msgid "Add a single :py:`CommandT`-:class:`Instruction` mapping."
+msgstr ""
+
+#: glasgow.arch.qspi.BaseCommandSet.__getitem__:1 of
+msgid "Map a :py:`CommandT` to a specific :class:`Instruction`."
+msgstr ""
+
+#: glasgow.arch.qspi.BaseCommandSet.__getitem__:3 of
+msgid "If the mapping does not exist."
+msgstr ""
+
+#: glasgow.arch.qspi.BaseCommandSet.__contains__:1 of
+msgid "Check whether :py:`command` is mapped."
+msgstr ""
+
+#: glasgow.arch.qspi.BaseCommandSet.__iter__:1 of
+msgid "Iterate through every mapped :py:`CommandT`."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/interface/sbw_probe.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/interface/sbw_probe.po
@@ -1,0 +1,68 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/interface/sbw_probe.rst:2
+msgid "``sbw-probe``"
+msgstr ""
+
+#: ../../src/applets/interface/sbw_probe.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sbw-probe"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Probe Texas Instruments microcontrollers via Spy-Bi-Wire 2-wire JTAG transport layer."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'sbwtck' to PIN (default: 'A0', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'sbwtdio' to PIN (default: 'A1', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "(advanced) set clock frequency to FREQ kHz (default: 2100)"
+msgstr ""
+
+#: ../../src/applets/interface/sbw_probe.rst:14
+msgid "API reference"
+msgstr ""
+
+#: ../../src/applets/interface/sbw_probe.rst:16
+msgid "Todo"
+msgstr ""
+
+#: ../../src/applets/interface/sbw_probe.rst:18
+msgid "Add API documentation for ``sbw-probe``."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/interface/spi_analyzer.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/interface/spi_analyzer.po
@@ -1,0 +1,112 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/interface/spi_analyzer.rst:2
+msgid "``spi-analyzer``"
+msgstr ""
+
+#: ../../src/applets/interface/spi_analyzer.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run spi-analyzer"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Capture transactions on the SPI bus."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "SPI data is captured in a clock domain driven by the SCK pin and reset by the CS# pin. This approach enables capturing data at very high SCK frequencies (up to 100 MHz), but requires a small delay between the last SCK rising edge and CS# rising edge, otherwise the last byte of a transaction will not be captured correctly. Typically, SPI controllers do provide this delay."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Signal integrity is exceptionally important for this applet. When using flywires, twist every signal wire (at the very least, CS# and SCK wires) with a ground wire connected to ground at both ends, otherwise the captured data will likely be nonsense."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The capture file format is Comma Separated Values, in one of the following line formats:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "``<COPI>,<CIPO>``, where <COPI> and <CIPO> are hexadecimal byte sequences with each eight bits corresponding to samples of COPI and CIPO, respectively (from MSB to LSB); this format is used if one CS# pin is provided."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "``<CS>,<COPI>,<CIPO>``, where <CS> is a 0-based CS# pin index and <COPI> and <CIPO> are the same as above; this format is used if multiple CS# pins are provided."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "If your DUT is a 25-series SPI Flash memory, use the `tool memory-25x` to extract data from capture files. If quad-IO commands are in use, use the `qspi-analyzer` applet to capture data."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "save communications to FILE as pairs of hex sequences"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O lines 'cs' to PINS (default: 'A0', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'sck' to PIN (default: 'A1', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'copi' to PIN (default: 'A2', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'cipo' to PIN (default: 'A3', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set FPGA trace buffer size to BYTES (must be power of 2, default: 16384)"
+msgstr ""
+
+#: ../../src/applets/interface/spi_analyzer.rst:14
+msgid "API reference"
+msgstr ""
+
+#: glasgow.applet.interface.spi_analyzer.SPIAnalyzerInterface.capture:1 of
+msgid "Capture a transaction."
+msgstr ""
+
+#: glasgow.applet.interface.spi_analyzer.SPIAnalyzerInterface.capture:3 of
+msgid "Returns a 3-tuple :py:`(chip, copi, cipo)`, where :py:`chip` is the chip select index, :py:`copi` are bytes transmitted from controller to peripheral, and :py:`cipo` are bytes transmitted from peripheral to controller."
+msgstr ""
+
+#: ../../src/applets/interface/spi_analyzer.rst
+msgid "Raises"
+msgstr ""
+
+#: glasgow.applet.interface.spi_analyzer.SPIAnalyzerInterface.capture:7 of
+msgid "When the FPGA buffer overflows. The last few transactions before the overflow occurred     may be dropped as well."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/interface/spi_controller.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/interface/spi_controller.po
@@ -1,0 +1,182 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/interface/spi_controller.rst:2
+msgid "``spi-controller``"
+msgstr ""
+
+#: ../../src/applets/interface/spi_controller.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run spi-controller"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Initiate transactions on the Motorola SPI bus."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "hex bytes to exchange with the device"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'cs' to PIN (default: 'A0', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'sck' to PIN (default: 'A1', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'copi' to PIN (default: 'A2', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'cipo' to PIN (default: 'A3', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure active edge and idle state according to MODE (default: 0)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set SCK frequency to FREQ kHz (default: 100)"
+msgstr ""
+
+#: ../../src/applets/interface/spi_controller.rst:14
+msgid "API reference"
+msgstr ""
+
+#: glasgow.applet.interface.spi_controller.SPIControllerInterface.mode:1 of
+msgid "SPI mode."
+msgstr ""
+
+#: glasgow.applet.interface.spi_controller.SPIControllerInterface.mode:3 of
+msgid "Cannot be changed while a transaction is active."
+msgstr ""
+
+#: glasgow.applet.interface.spi_controller.SPIControllerInterface.clock:1 of
+msgid "SCK clock divisor."
+msgstr ""
+
+#: glasgow.applet.interface.spi_controller.SPIControllerInterface.select:1 of
+msgid "Perform a transaction."
+msgstr ""
+
+#: glasgow.applet.interface.spi_controller.SPIControllerInterface.select:3 of
+msgid "Starting a transaction asserts :py:`index`-th chip select signal and configures the mode; ending a transaction deasserts the chip select signal. Methods :meth:`write`, :meth:`read`, :meth:`exchange`, and :meth:`dummy` may be called only while a transaction is active to transfer data on the bus."
+msgstr ""
+
+#: glasgow.applet.interface.spi_controller.SPIControllerInterface.select:8 of
+msgid "For example, to read 16 bytes from an SPI NOR flash at address :py:`0x001234` using the Read (03h) command, use the following code:"
+msgstr ""
+
+#: glasgow.applet.interface.spi_controller.SPIControllerInterface.select:19 of
+msgid "An empty transaction (where the body does not call :meth:`write`, :meth:`read`, :meth:`exchange`, or :meth:`dummy`) is allowed and causes chip select activity only, in addition to any clock edges required to switch the SPI bus mode with chip select inactive."
+msgstr ""
+
+#: ../../src/applets/interface/spi_controller.rst
+msgid "Raises"
+msgstr ""
+
+#: glasgow.applet.interface.spi_controller.SPIControllerInterface.select:24 of
+msgid "If recursively called inside a transaction."
+msgstr ""
+
+#: glasgow.applet.interface.spi_controller.SPIControllerInterface.select:25 of
+msgid "If :py:`index` is greater than 7."
+msgstr ""
+
+#: glasgow.applet.interface.spi_controller.SPIControllerInterface.exchange:1 of
+msgid "Exchange data."
+msgstr ""
+
+#: glasgow.applet.interface.spi_controller.SPIControllerInterface.exchange:3 of
+msgid "Clock :py:`data` out via the COPI pin while clocking return value in via the CIPO pin."
+msgstr ""
+
+#: glasgow.applet.interface.spi_controller.SPIControllerInterface.dummy:9
+#: glasgow.applet.interface.spi_controller.SPIControllerInterface.exchange:5
+#: glasgow.applet.interface.spi_controller.SPIControllerInterface.read:5
+#: glasgow.applet.interface.spi_controller.SPIControllerInterface.write:5 of
+msgid "If called outside of a transaction."
+msgstr ""
+
+#: glasgow.applet.interface.spi_controller.SPIControllerInterface.write:1 of
+msgid "Write data."
+msgstr ""
+
+#: glasgow.applet.interface.spi_controller.SPIControllerInterface.write:3 of
+msgid "Clock :py:`data` out via the COPI pin."
+msgstr ""
+
+#: glasgow.applet.interface.spi_controller.SPIControllerInterface.read:1 of
+msgid "Read data."
+msgstr ""
+
+#: glasgow.applet.interface.spi_controller.SPIControllerInterface.read:3 of
+msgid "Clock :py:`count` bytes in via the CIPO pin."
+msgstr ""
+
+#: glasgow.applet.interface.spi_controller.SPIControllerInterface.dummy:1 of
+msgid "Clock dummy cycles."
+msgstr ""
+
+#: glasgow.applet.interface.spi_controller.SPIControllerInterface.dummy:3 of
+msgid "Clock :py:`count` dummy cycles. One octet corresponds to 8 dummy cycles."
+msgstr ""
+
+#: glasgow.applet.interface.spi_controller.SPIControllerInterface.dummy:7 of
+msgid "The state of COPI pin is undefined during this operation."
+msgstr ""
+
+#: glasgow.applet.interface.spi_controller.SPIControllerInterface.delay_ms:1
+#: glasgow.applet.interface.spi_controller.SPIControllerInterface.delay_us:1 of
+msgid "Delay operations."
+msgstr ""
+
+#: glasgow.applet.interface.spi_controller.SPIControllerInterface.delay_us:3 of
+msgid "Delays the following SPI bus operations by :py:`duration` microseconds."
+msgstr ""
+
+#: glasgow.applet.interface.spi_controller.SPIControllerInterface.delay_ms:3 of
+msgid "Delays the following SPI bus operations by :py:`duration` milliseconds. Equivalent to :py:`delay_us(duration * 1000)`."
+msgstr ""
+
+#: glasgow.applet.interface.spi_controller.SPIControllerInterface.synchronize:1
+#: of
+msgid "Synchronization barrier."
+msgstr ""
+
+#: glasgow.applet.interface.spi_controller.SPIControllerInterface.synchronize:3
+#: of
+msgid "Ensures that once this method returns, all previously submitted operations have completed."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/interface/swd_probe.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/interface/swd_probe.po
@@ -1,0 +1,189 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/interface/swd_probe.rst:2
+msgid "``swd-probe``"
+msgstr ""
+
+#: ../../src/applets/interface/swd_probe.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run swd-probe"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "At the moment, this applet does not include any high-level functionality. It only offers very low-level access to the target via the REPL or script interface."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Use the `probe-rs` applet to debug and program Arm microcontrollers."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'swclk' to PIN (default: 'A0', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'swdio' to PIN (default: 'A1', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set SWCLK frequency to FREQ kHz (default: 1000)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run swd-probe dump-memory"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "start at ADDRESS"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "dump LENGTH bytes"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "dump contents to FILENAME"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "access memory via MEM-AP #INDEX"
+msgstr ""
+
+#: ../../src/applets/interface/swd_probe.rst:14
+msgid "API reference"
+msgstr ""
+
+#: glasgow.applet.interface.swd_probe.SWDProbeException.Kind:1 of
+msgid "Valid values are as follows:"
+msgstr ""
+
+#: glasgow.applet.interface.swd_probe.SWDProbeInterface.clock:1 of
+msgid "SWCLK clock divisor."
+msgstr ""
+
+#: glasgow.applet.interface.swd_probe.SWDProbeInterface.line_reset:1 of
+msgid "Perform a line reset sequence."
+msgstr ""
+
+#: glasgow.applet.interface.swd_probe.SWDProbeInterface.jtag_to_swd_v1:1 of
+msgid "Perform a DPv1 JTAG-to-SWD switch sequence."
+msgstr ""
+
+#: glasgow.applet.interface.swd_probe.SWDProbeInterface.jtag_to_swd_v2:1 of
+msgid "Perform a DPv2 JTAG-to-SWD switch sequence."
+msgstr ""
+
+#: glasgow.applet.interface.swd_probe.SWDProbeInterface.jtag_to_swd_v2:3 of
+msgid "This sequence consists of a JTAG-to-dormant, Selection Alert, and dormant-to-SWD sub-sequences."
+msgstr ""
+
+#: glasgow.applet.interface.swd_probe.SWDProbeInterface.dp_read:1 of
+msgid "Read from DP register :py:`reg`, switching the DP bank if necessary."
+msgstr ""
+
+#: ../../src/applets/interface/swd_probe.rst
+msgid "Raises"
+msgstr ""
+
+#: glasgow.applet.interface.swd_probe.SWDProbeInterface.ap_read:3
+#: glasgow.applet.interface.swd_probe.SWDProbeInterface.ap_read_block:7
+#: glasgow.applet.interface.swd_probe.SWDProbeInterface.ap_write:4
+#: glasgow.applet.interface.swd_probe.SWDProbeInterface.dp_read:3
+#: glasgow.applet.interface.swd_probe.SWDProbeInterface.dp_write:3
+#: glasgow.applet.interface.swd_probe.SWDProbeInterface.iter_aps:6 of
+msgid "On communication error."
+msgstr ""
+
+#: glasgow.applet.interface.swd_probe.SWDProbeInterface.dp_write:1 of
+msgid "Write :py:`data` to DP register :py:`reg`, switching the DP bank if necessary."
+msgstr ""
+
+#: glasgow.applet.interface.swd_probe.SWDProbeInterface.ap_read:1 of
+msgid "Read from AP :py:`ap` register :py:`reg`, switching the AP and AP bank if necessary."
+msgstr ""
+
+#: glasgow.applet.interface.swd_probe.SWDProbeInterface.ap_read_block:1 of
+msgid "Read from AP :py:`ap` register :py:`reg` :py:`count` times, switching the AP and AP bank if necessary."
+msgstr ""
+
+#: glasgow.applet.interface.swd_probe.SWDProbeInterface.ap_read_block:4 of
+msgid "The AP reads are pipelined, making this method significantly faster than calling :meth:`ap_read` :py:`count` times."
+msgstr ""
+
+#: glasgow.applet.interface.swd_probe.SWDProbeInterface.ap_write:1 of
+msgid "Write :py:`data` to AP :py:`ap` register :py:`reg`, switching the AP and AP bank if necessary."
+msgstr ""
+
+#: glasgow.applet.interface.swd_probe.SWDProbeInterface.initialize:1 of
+msgid "Initialize the SW-DP or SWJ-DP."
+msgstr ""
+
+#: glasgow.applet.interface.swd_probe.SWDProbeInterface.initialize:3 of
+msgid "The initialization process is:"
+msgstr ""
+
+#: glasgow.applet.interface.swd_probe.SWDProbeInterface.initialize:5 of
+msgid "Perform a DPv2 JTAG-to-SWD switch sequence, as in :meth:`jtag_to_swd_v2`."
+msgstr ""
+
+#: glasgow.applet.interface.swd_probe.SWDProbeInterface.initialize:6 of
+msgid "Perform a DPv1 JTAG-to-SWD switch sequence, as in :meth:`jtag_to_swd_v1`."
+msgstr ""
+
+#: glasgow.applet.interface.swd_probe.SWDProbeInterface.initialize:7 of
+msgid "Perform a line reset and read ``DPIDR`` to start SWD communication."
+msgstr ""
+
+#: glasgow.applet.interface.swd_probe.SWDProbeInterface.initialize:8 of
+msgid "Write ``DP_ABORT`` to clear all errors."
+msgstr ""
+
+#: glasgow.applet.interface.swd_probe.SWDProbeInterface.initialize:9 of
+msgid "Write ``CTRL_STAT`` to request debug power-up."
+msgstr ""
+
+#: glasgow.applet.interface.swd_probe.SWDProbeInterface.initialize:10 of
+msgid "Read ``CTRL_STAT`` to ensure acknowledge of debug power-up."
+msgstr ""
+
+#: glasgow.applet.interface.swd_probe.SWDProbeInterface.initialize:12 of
+msgid "On communication error, or if debug power-up request isn't acknowledged."
+msgstr ""
+
+#: glasgow.applet.interface.swd_probe.SWDProbeInterface.iter_aps:1 of
+msgid "Iterate available APs."
+msgstr ""
+
+#: glasgow.applet.interface.swd_probe.SWDProbeInterface.iter_aps:3 of
+msgid "Yields 2-tuples :py:`(ap, ap_idr)` where :py:`ap` is the AP index and :py:`ap_idr` is the value of the ``IDR`` register."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/interface/uart.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/interface/uart.po
@@ -1,0 +1,136 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/interface/uart.rst:4
+msgid "``uart``"
+msgstr ""
+
+#: ../../src/applets/interface/uart.rst:7
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run uart"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Transmit and receive data via UART."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Any baud rate is supported. Only 8 data bits and from 1 to 8 integer stop bits are supported, with configurable parity."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The automatic baud rate determination algorithm works by locking onto the shortest bit time in the receive stream. It will determine the baud rate incorrectly in presence of glitches as well as insufficiently diverse data (e.g. when receiving data consisting only of the letter \"a\", the baud rate that is determined will be one half of the actual baud rate). To reduce spurious baud rate changes, the algorithm is only consulted when frame or (if enabled) parity errors are present in received data."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'rx' to PIN (default: 'A0', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tx' to PIN (default: 'A1', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "send and receive parity bit as PARITY (default: none)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "send and receive stop bits as STOP_BITS (default: 1, options: 1..8)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set baud rate to RATE bits per second (default: 115200)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "automatically estimate baud rate in response to RX errors"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run uart pty"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run uart socket"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "listen at ENDPOINT, either unix:PATH or tcp:HOST:PORT"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run uart tty"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "continue reading from I/O port even after an end-of-file condition on stdin"
+msgstr ""
+
+#: ../../src/applets/interface/uart.rst:14
+msgid "API reference"
+msgstr ""
+
+#: glasgow.applet.interface.uart.UARTInterface.get_baud:1 of
+msgid "Returns the baud rate used by the UART, whether manually or automatically configured."
+msgstr ""
+
+#: glasgow.applet.interface.uart.UARTInterface.set_baud:1 of
+msgid "Configures baud rate to ``baud`` bits per second, overriding any automatically detected baud rate."
+msgstr ""
+
+#: glasgow.applet.interface.uart.UARTInterface.use_auto_baud:1 of
+msgid "Configures UART to automatically determine baud rate from incoming bit stream."
+msgstr ""
+
+#: glasgow.applet.interface.uart.UARTInterface.read:1 of
+msgid "Reads one or more bytes from the UART. If :py:`flush` is true, transmits any buffered writes before starting to receive."
+msgstr ""
+
+#: glasgow.applet.interface.uart.UARTInterface.read_all:1 of
+msgid "Reads all buffered bytes from the UART, but no less than one byte. If :py:`flush` is true, transmits any buffered writes before starting to read."
+msgstr ""
+
+#: glasgow.applet.interface.uart.UARTInterface.read_until:1 of
+msgid "Reads bytes from the UART until :py:`trailer`, which can be a single byte sequence or a choice of multiple byte sequences, is encountered. The return value includes the trailer."
+msgstr ""
+
+#: glasgow.applet.interface.uart.UARTInterface.write:1 of
+msgid "Buffers bytes to be transmitted. Until :meth:`flush` is called, bytes are not guaranteed to be transmitted (they may or may not be)."
+msgstr ""
+
+#: glasgow.applet.interface.uart.UARTInterface.flush:1 of
+msgid "Transmits all buffered bytes from the UART."
+msgstr ""
+
+#: glasgow.applet.interface.uart.UARTInterface.monitor:1 of
+msgid "Logs receive errors and automatic baud rate changes."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/interface/uart_analyzer.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/interface/uart_analyzer.po
@@ -1,0 +1,128 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/interface/uart_analyzer.rst:2
+msgid "``uart-analyzer``"
+msgstr ""
+
+#: ../../src/applets/interface/uart_analyzer.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run uart-analyzer"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Capture data exchange on a full duplex UART link. The ``rx`` and ``tx`` pins are always inputs; they only affect the channel to which data is attributed."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The capture file format is Comma Separated Values, in the following line formats:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "``<CH>,<HEX-DATA>``, where <CH> is ``rx`` or ``tx``, and <HEX-DATA> is a sequence of 8-bit hexadecimal values. (Unless ``--ascii`` is used.)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "``<CH>,\"<ASC-DATA>\"``, where <CH> is the same as above, and <ASC-DATA> is a sequence of ASCII characters or escape sequences. Characters 0x00, 0x09, 0x0A, 0x0D, 0x22, 0x5C are escaped as ``\\0``, ``\\t``, ``\\n``, ``\\r``, ``\\x22``, ``\\\\``, and all other characters not in the range 0x20..0x7E (inclusive) are escaped as ``\\x<HEX>``, where <HEX> is two hexadecimal digits. (If ``--ascii`` is used.)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "``<CH>,#F``, where <CH> is the same as above, to indicate a frame error on this channel."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "``<CH>,#P``, where <CH> is the same as above, to indicate a parity error on this channel."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "save communications to FILE as comma separated values"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'rx' to PIN (default: 'A0', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tx' to PIN (default: 'A1', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "receive parity bit as PARITY (default: none)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set RX and TX baud rates to RATE bits per second (default: 115200)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set RX baud rate to RATE bits per second (default: same as --baud)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set TX baud rate to RATE bits per second (default: same as --baud)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "format output data as ASCII with escape sequences"
+msgstr ""
+
+#: ../../src/applets/interface/uart_analyzer.rst:14
+msgid "API reference"
+msgstr ""
+
+#: glasgow.applet.interface.uart_analyzer.UARTAnalyzerError:1 of
+msgid "Valid values are as follows:"
+msgstr ""
+
+#: glasgow.applet.interface.uart_analyzer.UARTAnalyzerInterface.baud:1 of
+msgid "Clock divisor for :py:`channel`."
+msgstr ""
+
+#: ../../src/applets/interface/uart_analyzer.rst
+msgid "Raises"
+msgstr ""
+
+#: glasgow.applet.interface.uart_analyzer.UARTAnalyzerInterface.baud:3 of
+msgid "If no such channel exists."
+msgstr ""
+
+#: glasgow.applet.interface.uart_analyzer.UARTAnalyzerInterface.capture:1 of
+msgid "Capture a sequence of messages."
+msgstr ""
+
+#: glasgow.applet.interface.uart_analyzer.UARTAnalyzerInterface.capture:3 of
+msgid "Returns a list of :py:`(channel, data)` or :py:`(channel, error)` tuples. The :py:`data` indicates a byte sequence transmitted on the :py:`channel`, while :py:`error` indicates that an error has occurred. (The :py:enum:member:`UARTAnalyzerError.Good` error code will never appear in results.)"
+msgstr ""
+
+#: glasgow.applet.interface.uart_analyzer.UARTAnalyzerInterface.capture:8 of
+msgid "This function concatenates consecutive data messages to improve readability; despite this, protocol decoders must be prepared to handle data being split across any number of messages at any boundaries."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/internal/benchmark.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/internal/benchmark.po
@@ -1,0 +1,64 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/internal/benchmark.rst:2
+msgid "``benchmark``"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run benchmark"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Evaluate performance of the host communication link."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Benchmark modes:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "source: device emits an endless stream of data via one FIFO, host validates (simulates a logic analyzer subtarget)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "sink: host emits an endless stream of data via one FIFO, device validates (simulates an I2S protocol subtarget)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "loopback: host emits an endless stream of data via one FIFOs, device mirrors it all back, host validates (simulates an SPI protocol subtarget)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "latency: host sends one packet, device sends it back, time until the packet is received back on the host is measured (simulates cases where a transaction with the DUT relies on feedback from the host; also useful for comparing different usb stacks or usb data paths like hubs or network bridges)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "run benchmark mode MODE (default: source sink loopback latency)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "transfer COUNT bytes (default: 8388608)"
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/internal/index.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/internal/index.po
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/internal/index.rst:4
+msgid "Internal test"
+msgstr ""
+
+#: glasgow.applet.internal:1 of
+msgid "The ``internal`` taxon groups applets operating on Glasgow itself."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/measure/calibrate_clock.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/measure/calibrate_clock.po
@@ -1,0 +1,116 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/measure/calibrate_clock.rst:2
+msgid "``calibrate-clock``"
+msgstr ""
+
+#: ../../src/applets/measure/calibrate_clock.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run calibrate-clock"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Measure clock accuracy against a stable external reference signal."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "By default measures the internal Glasgow system clock. With ``--ext-pin``, measures a second clock source (e.g. Si5351A output) against the reference instead."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Measure system clock vs GPS PPS reference (1 Hz) on pin B1:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The reference input expects a signal that crosses the logic threshold cleanly. A 2 V pk-pk sine centred at 1 V works well with the I/O bank set to 2 V."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Measure system clock vs Rubidium reference (2^23 Hz) on pin B1:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Measure Si5351A 10 MHz output on A0 vs same Rb reference on B1:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Apply a known rough correction to the baseline before measuring:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "stable reference clock input pin (e.g. B1 for Rb standard) (required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "optional external clock to measure (e.g. A0 for Si5351A output); if omitted the system clock is measured (optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "exact frequency of the reference clock in Hz (e.g. 8388608 for 2^23 Hz)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "nominal frequency of the external clock in Hz (required with --ext-pin)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "nominal system clock frequency in Hz (default: 48000000)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "gate window duration in seconds; longer gives more resolution (default: 10)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "initial PPM correction applied to the nominal frequency before measuring (default: 0.0)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "number of measurements to take then exit (default: 0 = run forever)"
+msgstr ""
+
+#: ../../src/applets/measure/calibrate_clock.rst:14
+msgid "API reference"
+msgstr ""
+
+#: glasgow.applet.measure.calibrate_clock.CalibrateClockInterface:1 of
+msgid "Software interface for the clock calibration applet."
+msgstr ""
+
+#: glasgow.applet.measure.calibrate_clock.CalibrateClockInterface.measure:1 of
+msgid "Wait for one gate window and return a result dict."
+msgstr ""
+
+#: glasgow.applet.measure.calibrate_clock.CalibrateClockInterface.measure:3 of
+msgid "The gateware sends cumulative counter snapshots; we subtract consecutive snapshots to get the counts for each window.  The first snapshot is used only as a baseline and is discarded."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/measure/curve_trace.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/measure/curve_trace.po
@@ -1,0 +1,152 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/measure/curve_trace.rst:2
+msgid "``curve-trace``"
+msgstr ""
+
+#: ../../src/applets/measure/curve_trace.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run curve-trace"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Sweep the I/O supply voltage on a port and record voltage and current at each step, producing a V-I curve suitable for characterising LEDs, diodes, and other two-terminal devices."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The device under test is connected between the port power rail and ground. A series resistor is recommended to keep the current within the INA233's measurement range (~546 mA max with the 0.15 ohm on-board shunt)."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Trace a red LED on port A from 1.8 V to 3.3 V in 50 mV steps (CSV):"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Same measurement, JSON output:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Stop the sweep early if current exceeds 20 mA (useful for LEDs):"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "To subtract the no-load buffer current, first run a sweep with no DUT attached and save it as a calibration file, then pass it with ``--cal``:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "In ``--diode`` mode, port A is swept while port B is held at a fixed reference voltage (default 2.5 V).  The DUT is connected between port A Vio and port B Vio.  Output voltages are relative to the reference (V_A - V_ref), so the sweep covers reverse bias (negative voltages) through forward conduction (positive voltages).  The maximum voltage across the DUT is limited by the 1.8–5.0 V Vio range: with the default 2.5 V reference, the sweep covers -0.7 V (reverse) to +2.5 V (forward)."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Trace a silicon diode with 10 mV steps, stopping at 50 mA:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Characterise a 2.7 V zener diode (raise the reference to 5.0 V so the full -3.2 V to 0 V reverse range is available):"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Use a 3.5 V reference to see both forward conduction and moderate reverse bias (-1.7 V to +1.5 V), useful for general-purpose diode characterisation:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "I/O port to sweep (A or B)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "sweep start voltage (default: 1.8)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "sweep stop voltage (default: 5.0)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "voltage step size (default: 0.050)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "settling time after each voltage change (default: 0.050)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "open-circuit calibration CSV to subtract no-load current (run a sweep with no DUT attached to generate one)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "read voltage from the Vsense pin (must be wired) instead of the commanded DAC voltage"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "stop sweep when current exceeds this value in mA"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "diode mode: sweep port A with port B as fixed reference; DUT between port A Vio and port B Vio"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "reference voltage on port B in diode mode (default: 2.5)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "output format (default: csv)"
+msgstr ""
+
+#: ../../src/applets/measure/curve_trace.rst:14
+msgid "API reference"
+msgstr ""
+
+#: glasgow.applet.measure.curve_trace.CurveTraceInterface:1 of
+msgid "Software interface for the curve tracing applet."
+msgstr ""
+
+#: glasgow.applet.measure.curve_trace.CurveTraceInterface:3 of
+msgid "Sweeps the I/O supply voltage on a single port from ``v_start`` to ``v_stop`` in steps of ``step_v``, measuring voltage and current at each point via the on-board INA233 shunt monitor."
+msgstr ""
+
+#: glasgow.applet.measure.curve_trace.CurveTraceInterface.sweep:1 of
+msgid "Generator-style sweep: yields (voltage_V, current_A) tuples."
+msgstr ""
+
+#: glasgow.applet.measure.curve_trace.DiodeTraceInterface:1 of
+msgid "Software interface for diode curve tracing using two ports."
+msgstr ""
+
+#: glasgow.applet.measure.curve_trace.DiodeTraceInterface:3 of
+msgid "Port A is swept from ``v_start`` to ``v_stop`` while port B is held at a fixed reference voltage.  The DUT is connected between port A Vio and port B Vio.  Output voltages are relative to the reference (V_A - V_ref), so forward-biased readings are positive and reverse-biased readings are negative."
+msgstr ""
+
+#: glasgow.applet.measure.curve_trace.DiodeTraceInterface.sweep:1 of
+msgid "Sweep port A relative to port B reference.  Returns (voltage_V, current_A) tuples where voltage_V is the voltage across the DUT (V_A - V_ref)."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/measure/index.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/measure/index.po
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/measure/index.rst:4
+msgid "Measure"
+msgstr ""
+
+#: glasgow.applet.measure:1 of
+msgid "The ``measure`` applets aid in the measurement of signals or the properties of devices."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/measure/prn_noise.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/measure/prn_noise.po
@@ -1,0 +1,96 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/measure/prn_noise.rst:2
+msgid "``generate-prn-noise``"
+msgstr ""
+
+#: ../../src/applets/measure/prn_noise.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run generate-prn-noise"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Generates pseudo-random binary noise at 384 Mcps effective chip rate on a single GPIO pin.  Uses a 31-bit maximal-length LFSR (x^31 + x^28 + 1, Galois form) running at 192 MHz with DDR output (2 chips per clock via SB_IO posedge/negedge)."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The on-board 33 Ohm series resistor and parasitic capacitance form a low-pass channel; calibrate source flatness by measuring the output directly before inserting the DUT."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "For audio-frequency work, the on-board series resistor can be combined with an external 240 nF film capacitor to ground to form a ~20 kHz single-pole low-pass filter.  The filtered output closely approximates Additive White Gaussian Noise (AWGN): each filter time constant integrates ~19,200 chips, giving near-Gaussian amplitude distribution via the central limit theorem."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "LFSR period: 2^31 - 1 = 2,147,483,647 chips (~5.6 s at 384 Mcps)."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "PLL: 48 MHz x16 / 4 = 192 MHz  (VCO = 768 MHz), DDR -> 384 Mcps."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Example:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'out' to PIN (default: 'A0', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run generate-prn-noise start"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run generate-prn-noise stop"
+msgstr ""
+
+#: ../../src/applets/measure/prn_noise.rst:14
+msgid "API reference"
+msgstr ""
+
+#: glasgow.applet.measure.prn_noise.PRNNoiseInterface:1 of
+msgid "Host-side interface for the PRN noise source."
+msgstr ""
+
+#: glasgow.applet.measure.prn_noise.PRNNoiseInterface.start:1 of
+msgid "Start the LFSR noise output."
+msgstr ""
+
+#: glasgow.applet.measure.prn_noise.PRNNoiseInterface.start:3 of
+msgid "Zero seeds are clamped to 1 by the gateware."
+msgstr ""
+
+#: glasgow.applet.measure.prn_noise.PRNNoiseInterface.stop:1 of
+msgid "Stop noise output (hold pin low)."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/memory/24x.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/memory/24x.po
@@ -1,0 +1,177 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/memory/24x.rst:2
+msgid "``memory-24x``"
+msgstr ""
+
+#: ../../src/applets/memory/24x.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run memory-24x"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Read and write memories compatible with 24-series EEPROM memory, such as Microchip 24C02C, Atmel 24C256, or hundreds of other memories that typically have \"24X\" (where X is some letter) in their part number."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "If the address of a read or write operation points past 255 (for one address byte memories) or 65536 (for two address byte memories), the I²C address has the extra address bits added to it. For example, running ``glasgow memory-24x -A 0x51 -W 2 read 0x10358 0x100`` reads 0x100 bytes from memory address 0x358 at I²C device address 0x52."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Page size"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The memory performs writes by first latching incoming data into a page buffer, and committing the page buffer after a stop condition. The internal address counter wraps around to the start of the page whenever the end of the page is reached. Using the correct page size is very important: while a smaller page size can always be used with a memory that has a larger actual page size, the inverse is not true. On the other hand, using the right page size significantly improves performance."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The default page size in this applet is 8, because no memories with page size less than 8 bytes have been observed so far. If the writes are too slow, look up the page size in the memory documentation. If the writes seem to be corrupted, use the ``--page-size 1`` option."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The pinout of a typical 24-series IC is as follows (the A2:0 pins may be N/C in large devices):"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'scl' to PIN (default: 'A0', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'sda' to PIN (default: 'A1', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "I²C address of the memory; typically 0b1010(A2)(A1)(A0) (default: 0b1010000)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "number of address bytes to use (one of: 1 2)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "page size; writes will be split at addresses that are multiples of PAGE-SIZE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set SCL frequency to FREQ kHz (default: 400, range: 100...4000)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run memory-24x read"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "read memory starting at address ADDRESS, with wraparound"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "read LENGTH bytes from memory"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write memory contents to FILENAME"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run memory-24x verify"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "verify memory starting at address ADDRESS"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "compare memory with DATA as hex bytes"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "compare memory with contents of FILENAME"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run memory-24x write"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write memory starting at address ADDRESS"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write memory with DATA as hex bytes"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write memory with contents of FILENAME"
+msgstr ""
+
+#: ../../src/applets/memory/24x.rst:14
+msgid "API reference"
+msgstr ""
+
+#: glasgow.applet.memory._24x.Memory24xInterface.read:1 of
+msgid "Read :py:`length` bytes at :py:`address`."
+msgstr ""
+
+#: glasgow.applet.memory._24x.Memory24xInterface.read:3 of
+msgid "If :py:`address` is larger than the maximum representable given the address width (i.e. greater than 0x100 or 0x10000 for 1 and 2 address byte memories respectively), the \"extra\" address bits are carried over into the I²C address by addition. For example, calling :py:`read(0x10358, 0x100)` when configured with :py:`i2c_address=0x51, address_width=2` reads 0x100 bytes from memory address 0x358 at I²C device address 0x52."
+msgstr ""
+
+#: glasgow.applet.memory._24x.Memory24xInterface.read:11 of
+msgid "While this behavior is suitable for most memories, there may be cases where it is not appropriate; for example, if a memory wraps over at 0x100 byte or 0x10000 byte boundaries instead of returning data that would be read from the next I²C address over."
+msgstr ""
+
+#: ../../src/applets/memory/24x.rst
+msgid "Raises"
+msgstr ""
+
+#: glasgow.applet.memory._24x.Memory24xInterface.read:15
+#: glasgow.applet.memory._24x.Memory24xInterface.write:14 of
+msgid "If communication fails; if a previous write hasn't completed yet."
+msgstr ""
+
+#: glasgow.applet.memory._24x.Memory24xInterface.write:1 of
+msgid "Write :py:`data` bytes at :py:`address`."
+msgstr ""
+
+#: glasgow.applet.memory._24x.Memory24xInterface.write:3 of
+msgid "The :py:`data` is broken up into chunks such that each chunk is aligned to, and no larger than, :py:`page_size`. This algorithm assumes that partial page writes update only the part being written, which is true for virtually every 24-series memory."
+msgstr ""
+
+#: glasgow.applet.memory._24x.Memory24xInterface.write:7 of
+msgid "The note on address bit carry-over in :meth:`read` also applies here, with the caveat that reading is done in one long request, but writing is done page-wise, and the address is sent anew for each write."
+msgstr ""
+
+#: glasgow.applet.memory._24x.Memory24xInterface.write:11 of
+msgid "This method waits for the write to complete by polling the device until it responds to its address (\"Acknowledge Polling\")."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/memory/25q.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/memory/25q.po
@@ -1,0 +1,845 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/memory/25q.rst:2
+msgid "``memory-25q``"
+msgstr ""
+
+#: ../../src/applets/memory/25q.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run memory-25q"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Identify, read, erase, or program memories compatible with 25-series SPI/dual-SPI/quad-SPI NOR Flash memory, such as Microchip 25C320, Winbond W25Q32JV, Micron MT25QU256ABA, Macronix MX25L6445E, ISSI IS25LP128, or hundreds of other memories that typically have ``25x`` (where \"x\" is a letter, usually ``C``, ``F``, or ``Q``) in their part number. Note that ``25N`` typically designates (Q)SPI NAND Flash memory, which is completely incompatible."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The pinout of a typical 25-series IC is as follows:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "This applet supports ordinary SPI mode, as well as dual-SPI and quad-SPI. When quad-SPI mode is not in use, the ``WP#`` and ``HOLD#`` pins are pulled high; these must not be left floating as the memories do not typically include internal pull-ups. These faster modes are not enabled by default because of the potential for bus contention and higher severity of crosstalk; use the options ``--dual-spi`` and ``--quad-spi`` to enable their use (when described in SFDP)."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "It is also possible to flash 25-series flash chips using the `spi-flashrom` applet, which requires a third-party tool `flashrom`. The advantage of using the `flashrom` applet is that flashrom offers compatibility with a wider variety of devices, some of which may not be supported by the `memory-25q` applet."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'cs' to PIN (default: 'A0', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'sck' to PIN (default: 'A1', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O lines 'copi', 'cipo', 'wp', 'hold' to PINS (default: 'A2,A3,A4,A5', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set SCK frequency to FREQ kHz (default: 12000)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "use dual-SPI modes if present in SFDP"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "use quad-SPI modes if present in SFDP"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "use WIDTH address bytes for data region (choices: 3, 4, default: 3)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "do not cross multiple-of-SIZE boundaries when programming"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "opcode for erasing a 4 KiB region"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "opcode for erasing a 32 KiB region"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "opcode for erasing a 64 KiB region"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run memory-25q erase"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Erase memory range. Start and end of specified range must be aligned on erase size boundaries."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "start with byte at ADDRESS"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "continue for LENGTH bytes"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run memory-25q erase-all"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Erase memory range covering the entire chip."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run memory-25q identify"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Identify memory by its JEDEC ID and (if available) Serial Flash Discoverable Parameters."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "annotate known raw SFDP DWORDs with fields"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run memory-25q protect"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Read or write Block Protection (BP) bits. The exact size and location of the protected area for a specific bit combination can only be determined from the device datasheet."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Setting all BP bits to zero may be necessary to execute the `erase-all` command or to resolve erase/program failures."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write BITMASK to BP bits (e.g. 0000 to allow all, 1111 to protect all)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run memory-25q read"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Read memory range using the fastest available read command."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write memory contents to FILENAME"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run memory-25q verify"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Read memory range using the fastest available read command, and compare with given data."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "use hex bytes DATA as memory contents"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "use data from FILENAME as memory contents"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run memory-25q write"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Write memory range using a read-modify-write sequence. Start and end of specified range do not need to be aligned on erase size boundaries."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow tool memory-25q"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Dissect captured SPI/QSPI transactions and extract data into linear memory image files."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The expected capture file format is the same as ones used by `spi-analyzer` and `qspi-analyzer` applets. Specifically, one of the following Comma-Separated Value line formats is expected:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "``<COPI>,<CIPO>``, where <COPI> and <CIPO> are hexadecimal byte sequences with each eight bits corresponding to samples of COPI and CIPO, respectively (from MSB to LSB)."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "``<DATA>``, where <DATA> is a hexadecimal nibble sequence with each four bits corresponding to samples of HOLD#, WP#, CIPO, COPI (from MSB to LSB)."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The extracted data can be saved as pairs of data files and mask files, where the mask file contains a 1 bit for every bit in the data file that has been observed in a transaction, and a 0 bit otherwise."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The list below details every command that is recognized by this tool. If your capture includes commands not currently recognized, please open an issue with a capture file attached."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "03h (Read Data)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "04h (Write Disable)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "05h (Read Status Register)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "06h (Write Enable)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "0Bh (Fast Read)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "4Bh (Read Unique ID)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "5Ah (Read SFDP)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "9Fh (Read JEDEC ID)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "B7h (Enter 4-Byte Address Mode)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "E9h (Exit 4-Byte Address Mode)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "3Bh (Dual Output Fast Read)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "6Bh (Quad Output Fast Read)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "BBh (Dual I/O Fast Read)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "EBh (Quad I/O Fast Read)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "read captured SPI transactions from CAPTURE-FILE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write extracted data to DATA-FILE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write data presence mask to MASK-FILE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write extracted SFDP data to DATA-FILE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write SFDP data presence mask to MASK-FILE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write extracted UID data to DATA-FILE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write UID data presence mask to MASK-FILE"
+msgstr ""
+
+#: ../../src/applets/memory/25q.rst:19
+msgid "API reference"
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface:1 of
+msgid "Make sure to call :meth:`initialize` first."
+msgstr ""
+
+#: ../../docstring glasgow.applet.memory._25q.Memory25QInterface.qspi:1 of
+msgid "Underlying QSPI interface."
+msgstr ""
+
+#: ../../docstring glasgow.applet.memory._25q.Memory25QInterface.cmds:1 of
+msgid "Active NOR command set."
+msgstr ""
+
+#: ../../docstring glasgow.applet.memory._25q.Memory25QInterface.cmds:3 of
+msgid "The command set may be modified or extended after the interface is created to better represent actual capabilities of the memory device."
+msgstr ""
+
+#: ../../docstring glasgow.applet.memory._25q.Memory25QInterface.sfdp:1 of
+msgid "SFDP table collection."
+msgstr ""
+
+#: ../../docstring glasgow.applet.memory._25q.Memory25QInterface.sfdp:3 of
+msgid "Populated only if the tables were parsed successfully."
+msgstr ""
+
+#: ../../docstring glasgow.applet.memory._25q.Memory25QInterface.sfdp_used:1 of
+msgid "Whether SFDP tables are usable."
+msgstr ""
+
+#: ../../docstring glasgow.applet.memory._25q.Memory25QInterface.sfdp_used:3 of
+msgid "Will be :py:`True` if SFDP information was used to successfully configure data transfer parameters, :py:`False` otherwise."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.memory_size:1 of
+msgid "Memory size."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.memory_size:3 of
+msgid "Size of the data region in bytes, or :py:`None` if SFDP data is not populated."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.power_up:1 of
+msgid "Power up the device."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.power_up:3 of
+msgid "Implemented using :data:`Opcode.ReleasePowerDown <glasgow.arch.qspi.nor.Opcode.ReleasePowerDown>`."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.power_up:8 of
+msgid "A memory may not accept any commands besides this one if it is in a deep power-down state."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.power_down:1 of
+msgid "Power down the device."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.power_down:3 of
+msgid "Implemented using :data:`Opcode.PowerDown <glasgow.arch.qspi.nor.Opcode.PowerDown>`."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.power_down:5 of
+msgid "See :meth:`power_up`."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.jedec_id:1 of
+msgid "Read JEDEC IDs."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.jedec_id:3 of
+msgid "Implemented using :data:`Opcode.ReadJEDEC <glasgow.arch.qspi.nor.Opcode.ReadJEDEC>`."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.jedec_id:5 of
+msgid "Returns :py:`(jedec_mfg_id, device_id)`."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.read_sfdp:1 of
+msgid "Read SFDP information."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.read_sfdp:3 of
+msgid "Implemented using :data:`Opcode.ReadSFDP <glasgow.arch.qspi.nor.Opcode.ReadSFDP>`."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.read_sfdp:5 of
+msgid "Returns :py:`length` SFDP bytes starting at :py:`address`, wrapping when reading past the end of the SFDP region."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.initialize:1 of
+msgid "Prepare device for data transfer."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.initialize:3 of
+msgid "Powers up the device and populates :data:`sfdp` (if possible)."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.read_data:1 of
+msgid "Read data."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.read_data:3 of
+msgid "Implemented using the :data:`Command.ReadData <glasgow.arch.qspi.nor.Command.ReadData>`, which is typically but not necessarily mapped to one of:"
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.read_data:6 of
+msgid ":data:`Opcode.Read <glasgow.arch.qspi.nor.Opcode.Read>`"
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.read_data:7 of
+msgid ":data:`Opcode.FastRead <glasgow.arch.qspi.nor.Opcode.FastRead>`"
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.read_data:8 of
+msgid ":data:`Opcode.FastReadDualOutput <glasgow.arch.qspi.nor.Opcode.FastReadDualOutput>`"
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.read_data:9 of
+msgid ":data:`Opcode.FastReadQuadOutput <glasgow.arch.qspi.nor.Opcode.FastReadQuadOutput>`"
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.read_data:10 of
+msgid ":data:`Opcode.FastReadDualInOut <glasgow.arch.qspi.nor.Opcode.FastReadDualInOut>`"
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.read_data:11 of
+msgid ":data:`Opcode.FastReadQuadInOut <glasgow.arch.qspi.nor.Opcode.FastReadQuadInOut>`"
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.read_data:13 of
+msgid "Returns :py:`length` data bytes starting at :py:`address`, wrapping when reading past the end of the data region."
+msgstr ""
+
+#: ../../src/applets/memory/25q.rst
+msgid "Raises"
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.read_data:16 of
+msgid "If no read commands are configured."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.read_status_reg_1:1 of
+msgid "Read Status Register 1."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.read_status_reg_1:3 of
+msgid "Implemented using :data:`Opcode.ReadStatusReg1 <glasgow.arch.qspi.nor.Opcode.ReadStatusReg1>`."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.write_status_reg_1:1 of
+msgid "Write Status Register 1."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.write_status_reg_1:3 of
+msgid "Implemented using :data:`Opcode.WriteStatusReg1 <glasgow.arch.qspi.nor.Opcode.WriteStatusReg1>`."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.write_enable:1 of
+msgid "Prefix for write operations."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.write_enable:3 of
+msgid "All methods of this interface that perform write operations internally enable writes; only call this method explicitly when implementing new operations."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.write_enable:6 of
+msgid "If the :data:`BUSY <glasgow.arch.qspi.nor.StatusReg1.BUSY>` bit is set     in Status Register 1."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.write_enable:7 of
+msgid "If the operation fails to set the :data:`WREN <glasgow.arch.qspi.nor.StatusReg1.WREN>`     bit in Status Register 1."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.poll_busy:1 of
+msgid "Wait until operation is done."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.poll_busy:3 of
+msgid "Polls Status Register 1 until the :data:`BUSY <glasgow.arch.qspi.nor.StatusReg1.BUSY>` bit is clear."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.poll_busy:6 of
+msgid "All methods of this interfaces that perform write operations internally wait for completion; only call this method explicitly when implementing new operations."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.poll_busy:9 of
+msgid "If the :data:`WREN <glasgow.arch.qspi.nor.StatusReg1.WREN>` bit in Status Register 1     is still set after the :data:`BUSY <glasgow.arch.qspi.nor.StatusReg1.BUSY>` bit clears.     This usually means that the preceding operation failed."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.set_quad_enabled:1 of
+msgid "Enable or disable quad-SPI instructions."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.set_quad_enabled:3 of
+msgid "Most devices power on and/or arrive from the factory configured with IO2/IO3 pins having the WP#/HOLD# function. Using quad-SPI instructions requires switching them to data I/O first. Since this can cause bus contention and disables hardware write protection (if any), this action must be taken explicitly."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.set_quad_enabled:8 of
+msgid "If SFDP tables are not available."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.set_quad_enabled:9 of
+msgid "If the device-specific enablement algorithm has not been implemented."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.erase_data_all:1 of
+msgid "Erase all data."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.erase_data_all:3 of
+msgid "Implemented using :data:`Opcode.EraseChip <glasgow.arch.qspi.nor.Opcode.EraseChip>`."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.erase_data_all:7 of
+msgid "This command can take a very long time (on the order of minutes) and does not read back data to verify success."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.erase_data_all:12 of
+msgid "If the memory size is known (see :data:`memory_size`), prefer using :meth:`erase_data` with a range that covers the entire data region, which will report progress and verify that the data was successfully erased."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.erase_data:1 of
+msgid "Erase data and verify success."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.erase_data:3 of
+msgid "Implemented using one of:"
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.erase_data:5 of
+msgid ":data:`Command.EraseData4K <glasgow.arch.qspi.nor.Command.EraseData4K>`"
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.erase_data:6 of
+msgid ":data:`Command.EraseData32K <glasgow.arch.qspi.nor.Command.EraseData32K>`"
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.erase_data:7 of
+msgid ":data:`Command.EraseData64K <glasgow.arch.qspi.nor.Command.EraseData64K>`"
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.erase_data:9 of
+msgid "Erases memory range specified by :py:`address` and :py:`length`."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.erase_data:11 of
+msgid "If either :py:`address` or :py:`length` is not divisible by the erase size of one of     the available erase commands."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.erase_data:12 of
+msgid "If no erase commands are configured."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.erase_data:13 of
+msgid "If readback of erased data fails verification."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.program_data:1 of
+msgid "Program data and verify success."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.program_data:3 of
+msgid "Implemented using :data:`Command.ProgramData <glasgow.arch.qspi.nor.Command.ProgramData>`."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.program_data:5 of
+msgid "Programs :py:`data` to memory range starting at :py:`address`. The memory range must have been erased (using :meth:`erase_data` or otherwise), otherwise the resulting contents will become a logical AND of existing data and written data, and will fail verification."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.program_data:9 of
+msgid "If no program commands are available, or page size is not configured."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.program_data:10 of
+msgid "If readback of programmed data fails verification."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.write_data:1 of
+msgid "Write data and verify success."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.write_data:3 of
+msgid "Implemented using :meth:`erase_data` and :meth:`program_data`."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.write_data:5 of
+msgid "Writes :py:`data` at :py:`address` without any alignment constraints. If the written region is not already appropriately aligned, performs a read-modify-write cycle; in any case, data is first erased and then programmed."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.write_data:9 of
+msgid "If no erase or program commands are configured, or page size is not configured."
+msgstr ""
+
+#: glasgow.applet.memory._25q.Memory25QInterface.write_data:10 of
+msgid "If readback of erased or programmed data fails verification."
+msgstr ""
+
+#: ../../src/applets/memory/25q.rst:29
+msgid "NOR command set reference"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.Opcode:1 of
+msgid "Common (Q)SPI NOR Flash memory opcodes."
+msgstr ""
+
+#: glasgow.arch.qspi.nor.Opcode glasgow.arch.qspi.nor.StatusReg1 of
+msgid "Member Type"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.Opcode:1 glasgow.arch.qspi.nor.StatusReg1:1 of
+msgid ":py:class:`int`"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.Command:1 glasgow.arch.qspi.nor.Opcode:1
+#: glasgow.arch.qspi.nor.StatusReg1:1 of
+msgid "Valid values are as follows:"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.StatusReg1:1 of
+msgid "Status Register 1 flags."
+msgstr ""
+
+#: glasgow.arch.qspi.nor.StatusReg1:3 of
+msgid "Only includes six universally agreed upon LSBs. The two remaining MSBs have wildly varying function."
+msgstr ""
+
+#: glasgow.arch.qspi.nor.StatusReg1.BUSY:1 of
+msgid "Operation in Progress bit"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.StatusReg1.WREN:1 of
+msgid "Write Enable Latch bit"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.StatusReg1.BP0:1 of
+msgid "Block Protection bit 0"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.StatusReg1.BP1:1 of
+msgid "Block Protection bit 1"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.StatusReg1.BP2:1 of
+msgid "Block Protection bit 2"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.StatusReg1.BP3:1 of
+msgid "Block Protection bit 3 or Top/Bottom Block Protection bit"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.Command:1 of
+msgid "Abstract (Q)SPI NOR Flash memory commands."
+msgstr ""
+
+#: glasgow.arch.qspi.nor.Command:3 of
+msgid "While some commands directly correspond to a specific :enum:`Opcode`, other commands have multiple functionally equivalent opcodes with different throughput, or in some cases there is no globally uniform opcode assignment at all."
+msgstr ""
+
+#: glasgow.arch.qspi.nor.Command:7 of
+msgid "The mapping of :class:`Command`\\ s to :class:`Instruction <glasgow.arch.qspi.Instruction>`\\ s (and therefore :class:`Opcode`\\ s) is maintained within a :class:`CommandSet`."
+msgstr ""
+
+#: glasgow.arch.qspi.nor.Command:1 of
+msgid "The :class:`~enum.Enum` and its members also have the following methods:"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.Command.all_erase_sizes:1 of
+msgid "Every known erase size."
+msgstr ""
+
+#: glasgow.arch.qspi.nor.Command.erase_for_size:1 of
+msgid "Select erase command for an :py:`erase_size`-long region."
+msgstr ""
+
+#: glasgow.arch.qspi.nor.Command.erase_for_size:3 of
+msgid "If :py:`erase_size` is not in :meth:`erase_erase_sizes`."
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet:1 of
+msgid "Bases: :py:class:`~glasgow.arch.qspi.BaseCommandSet`\\ [:py:class:`~glasgow.arch.qspi.nor.Command`]"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet:1 of
+msgid "SPI NOR Flash command set."
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet:3 of
+msgid "When created, the command set only contains the opcodes that are implemented by every JESD216 compliant device. This makes identification and configuration possible, but data transfer cannot occur until the corresponding command set is configured via :meth:`use_explicit` or :meth:`use_jesd216`."
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet:8 of
+msgid "Created with the following mappings:"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet:10 of
+msgid ":data:`Command.PowerUp`: :data:`Opcode.ReleasePowerDown`, (1-0-0) mode"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet:11 of
+msgid ":data:`Command.PowerDown`: :data:`Opcode.PowerDown`, (1-0-0) mode"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet:12 of
+msgid ":data:`Command.ReadSFDP`: :data:`Opcode.ReadSFDP`, (1-1-1) mode"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet:13 of
+msgid ":data:`Command.ReadJEDEC`: :data:`Opcode.ReadJEDEC`, (1-0-1) mode"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet:14 of
+msgid ":data:`Command.ReadStatusReg1`: :data:`Opcode.ReadStatusReg1`, (1-0-1) mode"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet:15 of
+msgid ":data:`Command.ReadStatusReg2`: :data:`Opcode.ReadStatusReg2`, (1-0-1) mode"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet:16 of
+msgid ":data:`Command.ReadStatusReg3`: :data:`Opcode.ReadStatusReg3`, (1-0-1) mode"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet:17 of
+msgid ":data:`Command.WriteStatusRegs`: :data:`Opcode.WriteStatusReg1`, (1-0-1) mode"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet:18 of
+msgid ":data:`Command.WriteEnable`: :data:`Opcode.WriteEnable`, (1-0-0) mode"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet:19 of
+msgid ":data:`Command.WriteDisable`: :data:`Opcode.WriteDisable`, (1-0-0) mode"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet:20 of
+msgid ":data:`Command.EraseDataAll`: :data:`Opcode.EraseChip`, (1-0-0) mode"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet.use_explicit:1 of
+msgid "Use explicitly specified instructions."
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet.use_explicit:3 of
+msgid "Adds up to five mappings:"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet.use_explicit:5 of
+msgid ":data:`Command.ReadData`: :data:`Opcode.Read`, (1-1-1) mode"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet.use_explicit:6 of
+msgid ":data:`Command.EraseData4K`: :py:`opcode_erase_4k`, (1-1-0) mode (if specified)"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet.use_explicit:7 of
+msgid ":data:`Command.EraseData32K`: :py:`opcode_erase_32k`, (1-1-0) mode (if specified)"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet.use_explicit:8 of
+msgid ":data:`Command.EraseData64K`: :py:`opcode_erase_64k`, (1-1-0) mode (if specified)"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet.use_explicit:9 of
+msgid ":data:`Command.ProgramData`: :data:`Opcode.PageProgram`, (1-1-1) mode (if :py:`page_size` is specified)"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet.use_explicit:12 of
+msgid "Configures the :meth:`data_operation_prologue` method to execute :py:`data_operation_prologue`."
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet.use_explicit:15 of
+msgid "This function is intended for \"lowest common denominator\" configuration in absence of SFDP data. If you need to configure a different or more complex command set, you should add the necessary mappings directly."
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet.use_jesd216:1 of
+msgid "Use instructions specified by :py:`sfdp`."
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet.use_jesd216:3 of
+msgid "To determine the highest throughput instruction, all the possible (1-`x`-`y`) modes are ordered first by `y` and then `x`."
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet.use_jesd216:6 of
+msgid "Adds the following mappings:"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet.use_jesd216:8 of
+msgid ":data:`Command.ReadData` (fastest available, considering :py:`enable_dual` and :py:`enable_quad`)"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet.use_jesd216:10 of
+msgid ":data:`Command.EraseData4K` (if available)"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet.use_jesd216:11 of
+msgid ":data:`Command.EraseData32K` (if available)"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet.use_jesd216:12 of
+msgid ":data:`Command.EraseData64K` (if available)"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet.use_jesd216:13 of
+msgid ":data:`Command.ProgramData`: :data:`Opcode.PageProgram`, (1-1-1) mode"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet.use_jesd216:14 of
+msgid ":data:`Command.Enter4ByteMode`: :data:`Opcode.Enter4ByteMode` (if relevant)"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet.use_jesd216:15 of
+msgid ":data:`Command.Leave4ByteMode`: :data:`Opcode.Leave4ByteMode` (if relevant)"
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet.use_jesd216:17 of
+msgid "Configures the :meth:`data_operation_prologue` method to execute any appropriate mode switch or register access sequence for 4-byte addressing."
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet.use_jesd216:20 of
+msgid "If JEDEC flash parameters table is not present."
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet.use_jesd216:21 of
+msgid "If JEDEC flash parameters table contains unsupported parameters for required features."
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet.min_erase_size:1 of
+msgid "Smallest supported erase size."
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet.data_operation_prologue:1 of
+msgid "Compute prologue sequence for a data operation starting at :py:`address`."
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet.data_operation_prologue:3 of
+msgid "Returns an (address-specific) sequence of commands or write instructions that must be executed to prepare for any operation (reading, erasing, or programming) addressing the data region. A preceding call to :meth:`use_explicit` or :meth:`use_jesd216` may affect the specific sequence returned by this method."
+msgstr ""
+
+#: glasgow.arch.qspi.nor.CommandSet.data_operation_prologue:10 of
+msgid "If the steps above are not followed exactly, the outcome of any read, erase, or program operations may be completely unpredictable."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/memory/25x.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/memory/25x.po
@@ -1,0 +1,288 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/memory/25x.rst:2
+msgid "``memory-25x``"
+msgstr ""
+
+#: ../../src/applets/memory/25x.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run memory-25x"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Identify, read, erase, or program memories compatible with 25-series Flash memory, such as Microchip 25C320, Winbond 25Q64, Macronix MX25L1605, or hundreds of other memories that typically have \"25X\" where X is a letter in their part number."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "When using this applet for erasing or programming, it is necessary to look up the page and sector sizes. These values are displayed by the `identify` command when the memory is self-describing, and can be found in the memory datasheet otherwise."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The pinout of a typical 25-series IC is as follows:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The default pin assignment follows the pinouts above in the clockwise direction, making it easy to connect the memory with probes or, alternatively, crimp an IDC cable wired to a SOIC clip."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "It is also possible to flash 25-series flash chips using the `spi-flashrom` applet, which requires a third-party tool `flashrom`. The advantage of using the `flashrom` applet is that flashrom offers compatibility with a wider variety of devices, some of which may not be supported by the `memory-25x` applet."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'cs' to PIN (default: 'A5', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O lines 'copi', 'cipo', 'wp', 'hold' to PINS (default: 'A2,A4,A3,A0', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'sck' to PIN (default: 'A1', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set SCK frequency to FREQ kHz (default: 12000)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run memory-25x erase-block"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "erase block(s) starting at address ADDRESS"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run memory-25x erase-chip"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run memory-25x erase-program"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "program memory starting at address ADDRESS"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "erase memory in SIZE byte sectors"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "program memory region using SIZE byte pages"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "program memory with DATA as hex bytes"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "program memory with contents of FILENAME"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run memory-25x erase-sector"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "erase sector(s) starting at address ADDRESS"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run memory-25x fast-read"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "read memory starting at address ADDRESS, with wraparound"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "read LENGTH bytes from memory"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write memory contents to FILENAME"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run memory-25x identify"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run memory-25x program"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run memory-25x program-page"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run memory-25x protect"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set SR.BP[3:0] to BITS"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run memory-25x read"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run memory-25x verify"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow tool memory-25x"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Dissect captured SPI/QSPI transactions and extract data into linear memory image files."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The expected capture file format is the same as ones used by `spi-analyzer` and `qspi-analyzer` applets. Specifically, one of the following Comma-Separated Value line formats is expected:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "``<COPI>,<CIPO>``, where <COPI> and <CIPO> are hexadecimal byte sequences with each eight bits corresponding to samples of COPI and CIPO, respectively (from MSB to LSB)."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "``<DATA>``, where <DATA> is a hexadecimal nibble sequence with each four bits corresponding to samples of HOLD#, WP#, CIPO, COPI (from MSB to LSB)."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The extracted data can be saved as pairs of data files and mask files, where the mask file contains a 1 bit for every bit in the data file that has been observed in a transaction, and a 0 bit otherwise."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The list below details every command that is recognized by this tool. If your capture includes commands not currently recognized, please open an issue with a capture file attached."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "03h (Read Data)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "04h (Write Disable)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "05h (Read Status Register)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "06h (Write Enable)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "0Bh (Fast Read)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "4Bh (Read Unique ID)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "5Ah (Read SFDP)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "9Fh (Read JEDEC ID)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "B7h (Enter 4-Byte Address Mode)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "E9h (Exit 4-Byte Address Mode)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "3Bh (Dual Output Fast Read)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "6Bh (Quad Output Fast Read)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "BBh (Dual I/O Fast Read)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "EBh (Quad I/O Fast Read)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "read captured SPI transactions from CAPTURE-FILE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write extracted data to DATA-FILE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write data presence mask to MASK-FILE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write extracted SFDP data to DATA-FILE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write SFDP data presence mask to MASK-FILE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write extracted UID data to DATA-FILE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write UID data presence mask to MASK-FILE"
+msgstr ""
+
+#: ../../src/applets/memory/25x.rst:19
+msgid "API reference"
+msgstr ""
+
+#: ../../src/applets/memory/25x.rst:21
+msgid "Todo"
+msgstr ""
+
+#: ../../src/applets/memory/25x.rst:23
+msgid "Add API documentation for ``memory-25x``."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/memory/index.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/memory/index.po
@@ -1,0 +1,32 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/memory/index.rst:4
+msgid "Memory manipulation"
+msgstr ""
+
+#: glasgow.applet.memory:1 of
+msgid "The ``memory`` taxon groups applets implementing interfaces to memory technology devices (volatile and non-volatile) that include no functionality beyond manipulating data."
+msgstr ""
+
+#: glasgow.applet.memory:4 of
+msgid "Examples: SPI flash, I²C EEPROM. Counterexamples: SPI flash on an FPGA board that requires coordinated reset (use taxon ``program``), flash macroblock embedded in a microcontroller (use taxon ``program``)."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/program/avr_spi.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/program/avr_spi.po
@@ -1,0 +1,148 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/program/avr_spi.rst:2
+msgid "``program-avr-spi``"
+msgstr ""
+
+#: ../../src/applets/program/avr_spi.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-avr-spi"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Identify, program, and verify Microchip AVR microcontrollers using low-voltage serial (SPI) programming."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "While programming is disabled, the programming interface is tristated, so the applet can be used for in-circuit programming even if the device uses SPI itself."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The standard AVR ICSP connector layout is as follows:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Commands that read or write memory contents derive the file format from the filename as follows:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'reset' to PIN (default: 'A0', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'sck' to PIN (default: 'A1', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'cipo' to PIN (default: 'A2', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'copi' to PIN (default: 'A3', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set SCK frequency to FREQ kHz (default: 100)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-avr-spi erase"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-avr-spi identify"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-avr-spi read"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "display fuse bytes"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "display lock bits"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "display calibration bytes"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write program memory contents to FILE (must be '-' or end with: .bin, .hex, .ihx, .ihex)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write EEPROM contents to FILE (must be '-' or end with: .bin, .hex, .ihx, .ihex)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-avr-spi write-eeprom"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "read EEPROM contents from FILE (must be '-' or end with: .bin, .hex, .ihx, .ihex)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-avr-spi write-fuses"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set low fuse to binary BITS"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set high fuse to binary BITS"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set extra fuse to binary BITS"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-avr-spi write-lock"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write lock bits BITS"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-avr-spi write-program"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "read program memory contents from FILE (must be '-' or end with: .bin, .hex, .ihx, .ihex)"
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/program/ice40_flash.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/program/ice40_flash.po
@@ -1,0 +1,188 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/program/ice40_flash.rst:2
+msgid "``program-ice40-flash``"
+msgstr ""
+
+#: ../../src/applets/program/ice40_flash.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-ice40-flash"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Program the 25-series SPI NOR Flash memories found on many boards with iCE40 FPGAs. This applet is based on the `memory-25q` applet; in addition, it asserts the FPGA reset while programming the memory, and checks the CDONE pin to determine whether the FPGA has successfully read the configuration after the applet finishes."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "See the description of the `memory-25q` applet for details."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'cs' to PIN (default: 'A0', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'sck' to PIN (default: 'A1', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O lines 'copi', 'cipo', 'wp', 'hold' to PINS (default: 'A2,A3,A4,A5', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'reset' to PIN (default: 'A6', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'done' to PIN (default: 'A7', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set SCK frequency to FREQ kHz (default: 12000)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "use dual-SPI modes if present in SFDP"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "use quad-SPI modes if present in SFDP"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "use WIDTH address bytes for data region (choices: 3, 4, default: 3)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "do not cross multiple-of-SIZE boundaries when programming"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "opcode for erasing a 4 KiB region"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "opcode for erasing a 32 KiB region"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "opcode for erasing a 64 KiB region"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-ice40-flash erase"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Erase memory range. Start and end of specified range must be aligned on erase size boundaries."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "start with byte at ADDRESS"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "continue for LENGTH bytes"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-ice40-flash erase-all"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Erase memory range covering the entire chip."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-ice40-flash identify"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Identify memory by its JEDEC ID and (if available) Serial Flash Discoverable Parameters."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "annotate known raw SFDP DWORDs with fields"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-ice40-flash protect"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Read or write Block Protection (BP) bits. The exact size and location of the protected area for a specific bit combination can only be determined from the device datasheet."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Setting all BP bits to zero may be necessary to execute the `erase-all` command or to resolve erase/program failures."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write BITMASK to BP bits (e.g. 0000 to allow all, 1111 to protect all)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-ice40-flash read"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Read memory range using the fastest available read command."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write memory contents to FILENAME"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-ice40-flash verify"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Read memory range using the fastest available read command, and compare with given data."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "use hex bytes DATA as memory contents"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "use data from FILENAME as memory contents"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-ice40-flash write"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Write memory range using a read-modify-write sequence. Start and end of specified range do not need to be aligned on erase size boundaries."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/program/ice40_sram.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/program/ice40_sram.po
@@ -1,0 +1,92 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/program/ice40_sram.rst:2
+msgid "``program-ice40-sram``"
+msgstr ""
+
+#: ../../src/applets/program/ice40_sram.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-ice40-sram"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Program the volatile bitstream memory of iCE40 FPGAs."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bitstream file"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'cs' to PIN (default: 'A0', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'sck' to PIN (default: 'A1', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'copi' to PIN (default: 'A2', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'reset' to PIN (default: 'A3', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'done' to PIN (default: 'A4', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set SCK frequency to FREQ kHz (default: 12000)"
+msgstr ""
+
+#: ../../src/applets/program/ice40_sram.rst:14
+msgid "API reference"
+msgstr ""
+
+#: glasgow.applet.program.ice40_sram.ICE40SRAMInterface.clock:1 of
+msgid "SCK clock divisor."
+msgstr ""
+
+#: glasgow.applet.program.ice40_sram.ICE40SRAMInterface.load:1 of
+msgid "Load :py:`bitstream` into configuration SRAM."
+msgstr ""
+
+#: ../../src/applets/program/ice40_sram.rst
+msgid "Raises"
+msgstr ""
+
+#: glasgow.applet.program.ice40_sram.ICE40SRAMInterface.load:3 of
+msgid "If the CDONE pin is present and was not asserted within 100 ms after the bitstream     has been shifted in."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/program/index.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/program/index.po
@@ -1,0 +1,36 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/program/index.rst:4
+msgid "MCU/FPGA programming"
+msgstr ""
+
+#: glasgow.applet.program:1 of
+msgid "The ``program`` taxon groups applets implementing interfaces to memory technology devices (volatile and non-volatile) that are directly connected to programmable logic, such as a microcontroller or a gate array."
+msgstr ""
+
+#: glasgow.applet.program:5 of
+msgid "Such memories may be included on the same die, in the same package, on the same  board, or in the same assembly as the programmable logic; what is important is that the applet has both memory functionality (i.e. read/write functions) and logic functionality (e.g. as simple as holding the logic in reset while updating the memory, or as complex as encapsulating memory operations in JTAG transactions)."
+msgstr ""
+
+#: glasgow.applet.program:11 of
+msgid "Examples: flash macroblock embedded in an AVR microcontroller, SPI flash on an FPGA board that requires coordinated reset. Counterexamples: JTAG interface for an ARM microcontroller that may be used with an external tool to update its flash (use taxon ``debug``)."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/program/mec16xx.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/program/mec16xx.po
@@ -1,0 +1,208 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/program/mec16xx.rst:2
+msgid "``program-mec16xx``"
+msgstr ""
+
+#: ../../src/applets/program/mec16xx.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-mec16xx"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Read and write Microchip MEC16xx/MEC16xxi embedded controller integrated Flash via the JTAG interface."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "This applet has been tested and works correctly on Lenovo Thinkshield-branded MEC1663 (2024 january). This applet was originally developed to support MEC1618/MEC1618i, however the latest changes and fixes have not yet been tested on this device."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Per the MEC16xx datasheets, the minimum JTAG frequency should be 1 MHz."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "There are two types of erase operations that can be performed:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Emergency erase: It erases both the flash and eeprom (if the device has an eeprom), using a special JTAG sequence, which may work even in the case of boot code corruption"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Non-emergency erase: (see commands erase-flash and erase-eeprom). This uses normal flash or eeprom controller commands to perform the erase, but if the target is protected, then it might fail."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Typical flash sizes:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "192KiB: MEC1609(i), MEC1618(i), MEC1632, MEC1633"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "256KiB: MEC1663"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "To avoid data loss when the flash size is not known for certain, we recommend attempting to read 256KiB flash image, and analyzing the content."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tck' to PIN (default: 'A0', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tms' to PIN (default: 'A1', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tdi' to PIN (default: 'A2', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tdo' to PIN (default: 'A3', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'trst' to PIN (optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set TCK frequency to FREQ kHz (default: 100)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "give up scanning IRs longer than LENGTH bits (default: 128)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "give up scanning DRs longer than LENGTH bits (default: 1024)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set IR lengths of each TAP to corresponding IR-LENGTH (default: autodetect)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "select TAP #INDEX for communication (default: select only TAP)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-mec16xx emergency-erase"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-mec16xx erase-eeprom"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-mec16xx erase-flash"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "force erasing the flash even if parts of it can't be erased due to security settings"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "size of the embedded flash memory in bytes (typically 192K or 256K; a K suffix means multiply by 1024)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-mec16xx read-eeprom"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write eeprom binary image to FILE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-mec16xx read-flash"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write flash binary image to FILE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "force reading the flash even if it would result in an incomplete image due to security settings"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "use burst read for speed. this may be unreliable on some MEC16xx variants"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-mec16xx reset-quick-halt"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-mec16xx security-status"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-mec16xx test-lock-boot-block"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-mec16xx test-lock-data-block"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-mec16xx unlock-eeprom"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "password to try to unlock with"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-mec16xx write-eeprom"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "read eeprom binary image from FILE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-mec16xx write-flash"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "read flash binary image from FILE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "force erasing and writing the flash even if parts of it can't be written due to security settings"
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/program/nrf24lx1.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/program/nrf24lx1.po
@@ -1,0 +1,108 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/program/nrf24lx1.rst:2
+msgid "``program-nrf24lx1``"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-nrf24lx1"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Program the non-volatile memory of nRF24LE1 and nRF24LU1+ microcontrollers."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'prog' to PIN (default: 'A0', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'sck' to PIN (default: 'A1', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'copi' to PIN (default: 'A2', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'cipo' to PIN (default: 'A3', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'cs' to PIN (default: 'A4', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'reset' to PIN (default: 'A5', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set SPI frequency to FREQ kHz (default: 1000)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "type of device to program (one of: LE1, LU1p32k, LU1p16k)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-nrf24lx1 enable-debug"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-nrf24lx1 erase"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "back up, erase, and restore info page, removing read protection (DANGEROUS)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-nrf24lx1 program"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "firmware file to read (in Intel HEX format)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "erase and program info page, if present in firmware file (DANGEROUS)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-nrf24lx1 protect-read"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-nrf24lx1 read"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "firmware file to write (in Intel HEX format)"
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/program/xc6s.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/program/xc6s.po
@@ -1,0 +1,88 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/program/xc6s.rst:2
+msgid "``program-xc6s``"
+msgstr ""
+
+#: ../../src/applets/program/xc6s.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-xc6s"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Program Xilinx Spartan-6 FPGAs via the JTAG interface."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "load bitstream from .bin file BIT-FILE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tck' to PIN (default: 'A0', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tms' to PIN (default: 'A1', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tdi' to PIN (default: 'A2', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tdo' to PIN (default: 'A3', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'trst' to PIN (optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set TCK frequency to FREQ kHz (default: 100)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "give up scanning IRs longer than LENGTH bits (default: 128)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "give up scanning DRs longer than LENGTH bits (default: 1024)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set IR lengths of each TAP to corresponding IR-LENGTH (default: autodetect)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "select TAP #INDEX for communication (default: select only TAP)"
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/program/xc9500.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/program/xc9500.po
@@ -1,0 +1,172 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/program/xc9500.rst:2
+msgid "``program-xc9500``"
+msgstr ""
+
+#: ../../src/applets/program/xc9500.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-xc9500"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Program, verify, and read out Xilinx XC9500 series CPLD bitstreams via the JTAG interface."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "It is recommended to use TCK frequency between 100 and 250 kHz for programming."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Some CPLDs in the wild have been observed to return failures during programming, possibly because they are taken from the rejects bin or recycled, see [1]. The \"program word failed\" messages during programming do not necessarily mean a failed device; if the bitstream verifies afterwards, it is likely to operate correctly."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "[1]: http://tech.mattmillman.com/making-use-of-recycled-xilinx-xc9500-cplds/"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Supported devices are:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "XC9536"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "XC9572"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "XC95108"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "XC95144"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "XC95216"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "XC95288"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tck' to PIN (default: 'A0', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tms' to PIN (default: 'A1', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tdi' to PIN (default: 'A2', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tdo' to PIN (default: 'A3', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'trst' to PIN (optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set TCK frequency to FREQ kHz (default: 100)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "give up scanning IRs longer than LENGTH bits (default: 128)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "give up scanning DRs longer than LENGTH bits (default: 1024)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set IR lengths of each TAP to corresponding IR-LENGTH (default: autodetect)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "select TAP #INDEX for communication (default: select only TAP)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "use slower but potentially more robust algorithms, where applicable"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-xc9500 erase"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "override write-protection"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-xc9500 program"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "JED file to read"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "erase before programming, if necessary"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "verify after programming"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "enable write protection"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "enable read protection"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-xc9500 read"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "JED file to write"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-xc9500 verify"
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/program/xc9500xl.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/program/xc9500xl.po
@@ -1,0 +1,180 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/program/xc9500xl.rst:2
+msgid "``program-xc9500xl``"
+msgstr ""
+
+#: ../../src/applets/program/xc9500xl.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-xc9500xl"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Program, verify, and read out Xilinx XC9500XL and XC9500XV series CPLD bitstreams via the JTAG interface."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "It is recommended to use TCK frequency between 100 and 250 kHz for programming."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Some CPLDs in the wild have been observed to return failures during programming, possibly because they are taken from the rejects bin or recycled, see [1]. The \"program word failed\" messages during programming do not necessarily mean a failed device; if the bitstream verifies afterwards, it is likely to operate correctly."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "[1]: http://tech.mattmillman.com/making-use-of-recycled-xilinx-xc9500-cplds/"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Supported devices are:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "XC9536XL"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "XC9572XL"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "XC95144XL"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "XC95288XL"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "XC9536XV"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "XC9572XV"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "XC95144XV"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "XC95288XV"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tck' to PIN (default: 'A0', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tms' to PIN (default: 'A1', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tdi' to PIN (default: 'A2', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tdo' to PIN (default: 'A3', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'trst' to PIN (optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set TCK frequency to FREQ kHz (default: 100)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "give up scanning IRs longer than LENGTH bits (default: 128)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "give up scanning DRs longer than LENGTH bits (default: 1024)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set IR lengths of each TAP to corresponding IR-LENGTH (default: autodetect)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "select TAP #INDEX for communication (default: select only TAP)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "use slower but potentially more robust algorithms, where applicable"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-xc9500xl erase"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "override write-protection"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-xc9500xl program"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "JED file to read"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "erase before programming, if necessary"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "verify after programming"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "enable write protection"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "enable read protection"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-xc9500xl read"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "JED file to write"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-xc9500xl verify"
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/program/xpla3.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/program/xpla3.po
@@ -1,0 +1,172 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/program/xpla3.rst:2
+msgid "``program-xpla3``"
+msgstr ""
+
+#: ../../src/applets/program/xpla3.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-xpla3"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Program, verify, and read out Xilinx XPLA3 series CPLD bitstreams via the JTAG interface."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Supported devices are:"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "xcr3032xl"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "xcr3064xl"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "xcr3128xl"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "xcr3256xl"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "xcr3384xl"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "xcr3512xl"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Warning: programming SRAM directly will not set the initial register values correctly. Use this option at your own risk."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tck' to PIN (default: 'A0', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tms' to PIN (default: 'A1', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tdi' to PIN (default: 'A2', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'tdo' to PIN (default: 'A3', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'trst' to PIN (optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set TCK frequency to FREQ kHz (default: 100)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "give up scanning IRs longer than LENGTH bits (default: 128)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "give up scanning DRs longer than LENGTH bits (default: 1024)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set IR lengths of each TAP to corresponding IR-LENGTH (default: autodetect)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "select TAP #INDEX for communication (default: select only TAP)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-xpla3 erase"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-xpla3 program"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "JED file to read"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "use on-the-fly programming (keep device running)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "erase before programming, if necessary"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "verify after programming"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "enable read protection"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "user electronic signature (ASCII)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "user electronic signature (hex)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-xpla3 program-sram"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-xpla3 read"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "JED file to write"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-xpla3 read-sram"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run program-xpla3 verify"
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/radio/index.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/radio/index.po
@@ -1,0 +1,32 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/radio/index.rst:4
+msgid "Radio frequency"
+msgstr ""
+
+#: glasgow.applet.radio:1 of
+msgid "The ``radio`` taxon groups applets implementing radio interfaces, that is, interfaces for intentional transmitters and receivers in radio-frequency spectrum."
+msgstr ""
+
+#: glasgow.applet.radio:4 of
+msgid "Examples: DAC with a radio frontend, GFSK PHY. Counterexamples: VGA output (use taxon ``video``)."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/radio/nrf24l01.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/radio/nrf24l01.po
@@ -1,0 +1,255 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/radio/nrf24l01.rst:2
+msgid "``radio-nrf24l01``"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run radio-nrf24l01"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Transmit and receive packets using the nRF24L01/nRF24L01+ RF PHY."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "This applet allows configuring all channel and packet parameters, and provides basic transmit and receive workflow, as well as monitor mode. It supports Enhanced ShockBurst (new packet framing with automatic transaction handling) with one pipe, as well as ShockBurst (old packet framing). It does not support multiple pipes or acknowledgement payloads."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Note that in the CLI, the addresses are most significant byte first (the same as on-air order, and reversed with regards to register access order.)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The `monitor` subcommand is functionally identical to the `receive` subcommand, except that it will never attempt to acknowledge packets; this way, it is possible to watch a transaction started by a node with a known address without disturbing either party. It is not natively supported by nRF24L01(+), and is emulated in an imperfect way."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "The pinout of a common 8-pin nRF24L01+ module is as follows (live bug view):"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'ce' to PIN (default: 'A0', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'cs' to PIN (default: 'A1', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'sck' to PIN (default: 'A2', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'copi' to PIN (default: 'A3', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'cipo' to PIN (default: 'A4', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'irq' to PIN (default: 'A5', optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set SCK frequency to FREQ kHz (default: 8000)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set channel number to RF-CHANNEL (range: 0..125, corresponds to 2400..2525 MHz)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set air data rate to RF-BANDWIDTH kbps (one of: 250 1000 2000)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set output power to RF-POWER dBm (one of: 0 -6 -12 -18, default: 0)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set address width to WIDTH bytes (one of: 2 3 4 5)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set CRC width to WIDTH bytes (one of: 0 1 2)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "disable automatic transaction handling, for pre-L01 compatibility"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "enable dynamic payload length (L01+ only)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run radio-nrf24l01 monitor"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "receive packet with hex address ADDRESS"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "receive packet with length LENGTH (mutually exclusive with --dynamic-length)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "keep receiving packets until interrupted"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run radio-nrf24l01 receive"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run radio-nrf24l01 transmit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "transmit packet with hex address ADDRESS"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "transmit DATA as packet payload"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "if not acknowledged within DELAY µs, consider packet lost (default: 1500 us)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "if unacknowledged, retransmit up to COUNT times (default: 3)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "do not request acknowledgement (L01+ only)"
+msgstr ""
+
+#: ../../src/applets/radio/nrf24l01.rst:11
+msgid "API reference"
+msgstr ""
+
+#: glasgow.applet.radio.nrf24l01.RadioNRF24L01Interface.clock:1 of
+msgid "SCK clock divisor."
+msgstr ""
+
+#: glasgow.applet.radio.nrf24l01.RadioNRF24L01Interface.read_register:1 of
+msgid "Read a single register at :py:`address`."
+msgstr ""
+
+#: glasgow.applet.radio.nrf24l01.RadioNRF24L01Interface.write_register:1 of
+msgid "Write :py:`value` to a single register at :py:`address`."
+msgstr ""
+
+#: glasgow.applet.radio.nrf24l01.RadioNRF24L01Interface.read_register_wide:1 of
+msgid "Read :py:`length` consecutive registers starting at :py:`address`."
+msgstr ""
+
+#: glasgow.applet.radio.nrf24l01.RadioNRF24L01Interface.write_register_wide:1
+#: of
+msgid "Write :py:`value` to consecutive registers starting at :py:`address`."
+msgstr ""
+
+#: glasgow.applet.radio.nrf24l01.RadioNRF24L01Interface.enable:1 of
+msgid "Transition to TX mode, RX mode, or Standby-II state by asserting CE."
+msgstr ""
+
+#: glasgow.applet.radio.nrf24l01.RadioNRF24L01Interface.disable:1 of
+msgid "Transition to Standby-I state by deasserting CE."
+msgstr ""
+
+#: glasgow.applet.radio.nrf24l01.RadioNRF24L01Interface.poll_rx_status:1 of
+msgid "Poll for, and clear, the ``RX_DR`` IRQ."
+msgstr ""
+
+#: glasgow.applet.radio.nrf24l01.RadioNRF24L01Interface.poll_rx_status:3
+#: glasgow.applet.radio.nrf24l01.RadioNRF24L01Interface.poll_tx_status:3 of
+msgid "The :py:`delay` parameter sets the busy loop delay, in seconds."
+msgstr ""
+
+#: glasgow.applet.radio.nrf24l01.RadioNRF24L01Interface.poll_rx_status:5 of
+msgid "Returns the status register before any bits have been cleared."
+msgstr ""
+
+#: glasgow.applet.radio.nrf24l01.RadioNRF24L01Interface.read_rx_payload_length:1
+#: of
+msgid "Retrieve payload length of the first packet in the RX FIFO."
+msgstr ""
+
+#: glasgow.applet.radio.nrf24l01.RadioNRF24L01Interface.read_rx_payload:1 of
+msgid "Remove packet from the RX FIFO and return its payload."
+msgstr ""
+
+#: glasgow.applet.radio.nrf24l01.RadioNRF24L01Interface.read_rx_payload:3 of
+msgid "The :py:`length` parameter sets the payload length, and must be retrieved using :meth:`read_rx_payload_length`. If the packet length is greater than 32, it was corrupted and must be discarded using :meth:`flush_rx` instead."
+msgstr ""
+
+#: glasgow.applet.radio.nrf24l01.RadioNRF24L01Interface.flush_rx:1 of
+msgid "Remove packet from the RX FIFO."
+msgstr ""
+
+#: glasgow.applet.radio.nrf24l01.RadioNRF24L01Interface.flush_rx_all:1 of
+msgid "Remove all packets from the RX FIFO."
+msgstr ""
+
+#: glasgow.applet.radio.nrf24l01.RadioNRF24L01Interface.poll_tx_status:1 of
+msgid "Poll for the ``TX_DS`` or ``MAX_RT`` IRQs, and clear the ``TX_DS`` IRQ."
+msgstr ""
+
+#: glasgow.applet.radio.nrf24l01.RadioNRF24L01Interface.poll_tx_status:5 of
+msgid "Returns the status register before any bits have been cleared. To find out whether the last transmitted packet has been removed from the TX FIFO, check the :py:`MAX_RT` field of the returned value. If :py:`MAX_RT` is set, payload has not been removed."
+msgstr ""
+
+#: glasgow.applet.radio.nrf24l01.RadioNRF24L01Interface.write_tx_payload:1 of
+msgid "Insert packet with given :py:`payload` into the TX FIFO, and request acknowledgement if :py:`ack` is true."
+msgstr ""
+
+#: glasgow.applet.radio.nrf24l01.RadioNRF24L01Interface.reuse_tx_payload:1 of
+msgid "Reuse last transmitted payload."
+msgstr ""
+
+#: glasgow.applet.radio.nrf24l01.RadioNRF24L01Interface.reuse_tx_payload:3 of
+msgid "Payload may be reused after a packet was transmitted and until a subsequent :meth:`write_tx_payload` or :meth:`flush_tx` call."
+msgstr ""
+
+#: glasgow.applet.radio.nrf24l01.RadioNRF24L01Interface.flush_tx:1 of
+msgid "Remove packet from the TX FIFO."
+msgstr ""
+
+#: glasgow.applet.radio.nrf24l01.RadioNRF24L01Interface.flush_tx:3 of
+msgid "Use this method to clear a packet that has exceeded the maximum retransmission count."
+msgstr ""
+
+#: glasgow.applet.radio.nrf24l01.RadioNRF24L01Interface.flush_tx_all:1 of
+msgid "Remove all packets from the TX FIFO."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/sensor/bmx280.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/sensor/bmx280.po
@@ -1,0 +1,192 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/sensor/bmx280.rst:2
+msgid "``sensor-bmx280``"
+msgstr ""
+
+#: ../../src/applets/sensor/bmx280.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-bmx280"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Measure temperature and pressure using Bosch BMP280 sensors, or temperature, pressure, and humidity using Bosch BME280 sensors."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Only the I²C communication interface is supported."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'scl' to PIN (default: 'A0', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'sda' to PIN (default: 'A1', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "I2C address of the sensor (one of: 0x76 0x77, default: 0x76)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "oversample temperature measurements by FACTOR (default: 1)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "oversample pressure measurements by FACTOR (default: 1)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "oversample humidity measurements by FACTOR (default: 1)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "use IIR filter with coefficient COEFF (default: 0)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "use PRESSURE Pa as sea level pressure (default: 101325.000000)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "calculate altitude"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-bmx280 log"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "sample each TIME seconds"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-bmx280 log csv"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Log data to a comma-separated value (CSV) file."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write data to CSV-FILE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "format CSV file according to DIALECT"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-bmx280 log influxdb"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Log data to an InfluxDB 1.x endpoint over HTTP(S)."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to endpoint URL //ENDPOINT/write"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to database DATABASE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to measurement SERIES"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to retention policy POLICY"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "attach TAG=VALUE to all data points"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set timestamp precision to PRECISION"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "submit data in groups of BATCH-SIZE points"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-bmx280 log influxdb2"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Log data to an InfluxDB 2.x endpoint over HTTP(S)."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to endpoint URL //ENDPOINT/api/v2/write"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to Organization ORGANIZATION (can be either the name or the id)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to bucket BUCKET"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set the Token to use for Authentication"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-bmx280 log stdout"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Log data to standard output in a human-readable format."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-bmx280 measure"
+msgstr ""
+
+#: ../../src/applets/sensor/bmx280.rst:14
+msgid "API reference"
+msgstr ""
+
+#: ../../src/applets/sensor/bmx280.rst:16
+msgid "Todo"
+msgstr ""
+
+#: ../../src/applets/sensor/bmx280.rst:18
+msgid "Add API documentation for ``sensor-bmx280``."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/sensor/hcsr04.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/sensor/hcsr04.po
@@ -1,0 +1,181 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/sensor/hcsr04.rst:2
+msgid "``sensor-hcsr04``"
+msgstr ""
+
+#: ../../src/applets/sensor/hcsr04.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-hcsr04"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Measure distance using HC-SR04 compatible ultrasound sensors."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'trig' to PIN (default: 'A0', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'echo' to PIN (default: 'A1', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "number of samples to take for supersampling, as a power of two; use 0 to disable, 4 to average 16 samples (default: 2)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "timeout for each measurement, in seconds (default: 1.040)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "speed of sound for conversion to distance (default: 343.2)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-hcsr04 log"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "interval between measurements, in seconds"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-hcsr04 log csv"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Log data to a comma-separated value (CSV) file."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write data to CSV-FILE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "format CSV file according to DIALECT"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-hcsr04 log influxdb"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Log data to an InfluxDB 1.x endpoint over HTTP(S)."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to endpoint URL //ENDPOINT/write"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to database DATABASE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to measurement SERIES"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to retention policy POLICY"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "attach TAG=VALUE to all data points"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set timestamp precision to PRECISION"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "submit data in groups of BATCH-SIZE points"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-hcsr04 log influxdb2"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Log data to an InfluxDB 2.x endpoint over HTTP(S)."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to endpoint URL //ENDPOINT/api/v2/write"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to Organization ORGANIZATION (can be either the name or the id)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to bucket BUCKET"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set the Token to use for Authentication"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-hcsr04 log stdout"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Log data to standard output in a human-readable format."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-hcsr04 measure"
+msgstr ""
+
+#: ../../src/applets/sensor/hcsr04.rst:14
+msgid "API reference"
+msgstr ""
+
+#: glasgow.applet.sensor.hcsr04.SensorHCSR04Interface.measure_time:1 of
+msgid "Measures the time it takes for sound to travel to the object, in seconds."
+msgstr ""
+
+#: glasgow.applet.sensor.hcsr04.SensorHCSR04Interface.measure_distance:3
+#: glasgow.applet.sensor.hcsr04.SensorHCSR04Interface.measure_time:3 of
+msgid ":py:`supersample` represents the number of samples to take for supersampling, as 2^samples. For example, if you want to take 8 samples, set this parameter to 3. A value of 0 means no supersampling. Maximum value is 7."
+msgstr ""
+
+#: glasgow.applet.sensor.hcsr04.SensorHCSR04Interface.measure_distance:1 of
+msgid "Measures the distance to the object by using the speed of sound."
+msgstr ""
+
+#: glasgow.applet.sensor.hcsr04.SensorHCSR04Interface.measure_distance:7 of
+msgid ":py:`speed_of_sound` is the speed of sound in the current environment."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/sensor/hx711.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/sensor/hx711.po
@@ -1,0 +1,189 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/sensor/hx711.rst:2
+msgid "``sensor-hx711``"
+msgstr ""
+
+#: ../../src/applets/sensor/hx711.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-hx711"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Measure voltage with AVIA Semiconductor HX711 wheatstone bridge analog-to-digital converter."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "This applet can optionally provide a frequency source that can be connected to the XI pin. The provided frequency source is much more accurate than the internal oscillator of the HX711, and, depending on the state of the RATE pin, allows for a much wider sample rate range from approx. 1 Hz to approx. 144 Hz."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'sck' to PIN (default: 'A0', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'din' to PIN (default: 'A1', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'osc' to PIN (optional)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set reference oscillator frequency to FREQ MHz"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "measure channel CHAN"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "amplify GAIN times (64 or 128 for channel A, 32 for channel B)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-hx711 log"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-hx711 log csv"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Log data to a comma-separated value (CSV) file."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write data to CSV-FILE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "format CSV file according to DIALECT"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-hx711 log influxdb"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Log data to an InfluxDB 1.x endpoint over HTTP(S)."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to endpoint URL //ENDPOINT/write"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to database DATABASE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to measurement SERIES"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to retention policy POLICY"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "attach TAG=VALUE to all data points"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set timestamp precision to PRECISION"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "submit data in groups of BATCH-SIZE points"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-hx711 log influxdb2"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Log data to an InfluxDB 2.x endpoint over HTTP(S)."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to endpoint URL //ENDPOINT/api/v2/write"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to Organization ORGANIZATION (can be either the name or the id)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to bucket BUCKET"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set the Token to use for Authentication"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-hx711 log stdout"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Log data to standard output in a human-readable format."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-hx711 measure"
+msgstr ""
+
+#: ../../src/applets/sensor/hx711.rst:14
+msgid "API reference"
+msgstr ""
+
+#: glasgow.applet.sensor.hx711.SensorHX711Interface.sck_clock:1 of
+msgid "Serial Clock (sck) clock divisor."
+msgstr ""
+
+#: glasgow.applet.sensor.hx711.SensorHX711Interface.sck_clock:3 of
+msgid "The recommended frequency is 1MHz, otherwise the valid range is 20kHz to 5MHz."
+msgstr ""
+
+#: glasgow.applet.sensor.hx711.SensorHX711Interface.sample:1 of
+msgid "Read the current sample, and initiate the conversion of the next sample."
+msgstr ""
+
+#: glasgow.applet.sensor.hx711.SensorHX711Interface.sample:3 of
+msgid ":py:`next_setting` determines the channel and gain of the next sample."
+msgstr ""
+
+#: glasgow.applet.sensor.hx711.SensorHX711Interface.sample:5 of
+#, python-brace-format
+msgid "Returns the sample as a signed 24 bit integer, which can be converted into the measured differential voltage with the formula: :math:`v = (sample/2^{23}) * (0.5AVDD/GAIN)`"
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/sensor/index.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/sensor/index.po
@@ -1,0 +1,32 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/sensor/index.rst:4
+msgid "Environment sensing"
+msgstr ""
+
+#: glasgow.applet.sensor:1 of
+msgid "The ``sensor`` taxon groups applets implementing interfaces to measurement devices. The  differentiating characteristic for this taxon is explicit display of measured data in terms of physical quantities."
+msgstr ""
+
+#: glasgow.applet.sensor:5 of
+msgid "Examples: I²C thermometer, Xilinx XADC. Counterexamples: SPI ADC with bitstream output (use taxon ``stream``), integrated thermometer on a e-ink display (use taxon ``display``)."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/sensor/qmc5883p.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/sensor/qmc5883p.po
@@ -1,0 +1,382 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/sensor/qmc5883p.rst:2
+msgid "``sensor-qmc5883p``"
+msgstr ""
+
+#: ../../src/applets/sensor/qmc5883p.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-qmc5883p"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Measure magnetic field using the QMC5883P triple-axis magnetometer sensor."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "This applet only supports sensors connected via the I²C interface."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'scl' to PIN (default: 'A0', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'sda' to PIN (default: 'A1', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "I2C address of the sensor (default: 0x2c)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "operating mode (default: normal)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "output data rate in Hz (default: 50)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "oversample ratio (default: 4)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "downsample ratio (default: 2)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "field range in Gauss (default: 8)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-qmc5883p log"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "sample each TIME seconds"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-qmc5883p log csv"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Log data to a comma-separated value (CSV) file."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write data to CSV-FILE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "format CSV file according to DIALECT"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-qmc5883p log influxdb"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Log data to an InfluxDB 1.x endpoint over HTTP(S)."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to endpoint URL //ENDPOINT/write"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to database DATABASE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to measurement SERIES"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to retention policy POLICY"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "attach TAG=VALUE to all data points"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set timestamp precision to PRECISION"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "submit data in groups of BATCH-SIZE points"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-qmc5883p log influxdb2"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Log data to an InfluxDB 2.x endpoint over HTTP(S)."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to endpoint URL //ENDPOINT/api/v2/write"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to Organization ORGANIZATION (can be either the name or the id)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to bucket BUCKET"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set the Token to use for Authentication"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-qmc5883p log stdout"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Log data to standard output in a human-readable format."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-qmc5883p measure"
+msgstr ""
+
+#: ../../src/applets/sensor/qmc5883p.rst:14
+msgid "API reference"
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.OperatingMode:1 of
+msgid "Operating modes for QMC5883P."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.DownsampleRatio:1
+#: glasgow.applet.sensor.qmc5883p.FieldRange:1
+#: glasgow.applet.sensor.qmc5883p.OperatingMode:1
+#: glasgow.applet.sensor.qmc5883p.OutputDataRate:1
+#: glasgow.applet.sensor.qmc5883p.OversampleRatio:1
+#: glasgow.applet.sensor.qmc5883p.SetResetMode:1 of
+msgid "Valid values are as follows:"
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.OutputDataRate:1 of
+msgid "Output data rates (Hz)."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.OversampleRatio:1 of
+msgid "Oversample ratios."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.DownsampleRatio:1 of
+msgid "Downsample ratios."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.FieldRange:1 of
+msgid "Field ranges (Gauss)."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.SetResetMode:1 of
+msgid "Set/Reset modes."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface:1 of
+msgid "Interface to QMC5883P magnetometer sensor."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.identify:1 of
+msgid "Read and verify chip ID."
+msgstr ""
+
+#: ../../src/applets/sensor/qmc5883p.rst
+msgid "Returns"
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.identify:3 of
+msgid "Chip ID (should be 0x80)."
+msgstr ""
+
+#: ../../src/applets/sensor/qmc5883p.rst
+msgid "Return type"
+msgstr ""
+
+#: ../../src/applets/sensor/qmc5883p.rst
+msgid "Raises"
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.identify:6 of
+msgid "If chip ID does not match expected value 0x80."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.soft_reset:1 of
+msgid "Perform soft reset via CONTROL2 register."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.soft_reset:3 of
+msgid "Waits 50ms for reset to complete and verifies chip ID."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.soft_reset:5 of
+msgid "If chip ID is invalid after reset."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.set_mode:1 of
+msgid "Set operating mode."
+msgstr ""
+
+#: ../../src/applets/sensor/qmc5883p.rst
+msgid "Parameters"
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.set_mode:3 of
+msgid "Operating mode."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.set_mode:6 of
+msgid "If mode is invalid."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.set_data_rate:1 of
+msgid "Set output data rate."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.set_data_rate:3 of
+msgid "Output data rate."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.set_data_rate:6 of
+msgid "If data rate is invalid."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.set_oversample_ratio:1 of
+msgid "Set oversample ratio."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.set_oversample_ratio:3 of
+msgid "Oversample ratio."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.set_oversample_ratio:6 of
+msgid "If oversample ratio is invalid."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.set_downsample_ratio:1 of
+msgid "Set downsample ratio."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.set_downsample_ratio:3 of
+msgid "Downsample ratio."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.set_downsample_ratio:6 of
+msgid "If downsample ratio is invalid."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.set_range:1 of
+msgid "Set field range."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.set_range:3 of
+msgid "Field range."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.set_range:6 of
+msgid "If field range is invalid."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.get_range:1 of
+msgid "Get current field range setting."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.get_range:3 of
+msgid "Current field range."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.set_setreset_mode:1 of
+msgid "Set set/reset mode for eliminating sensor offset."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.set_setreset_mode:3 of
+msgid "Set/reset mode: :py:`SetResetMode.ON`, :py:`SetResetMode.SETONLY`, or :py:`SetResetMode.OFF`."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.set_setreset_mode:7 of
+msgid "If set/reset mode is invalid."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.data_ready:1 of
+msgid "Check if new measurement data is available."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.data_ready:3 of
+msgid "True if data is ready to be read."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.overflow:1 of
+msgid "Check if sensor measurement has overflowed."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.overflow:3 of
+msgid "True if overflow occurred."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.get_magnetic_raw:1 of
+msgid "Read raw magnetic field values."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.get_magnetic_raw:3 of
+msgid "Waits for data ready, then reads all three axes."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.get_magnetic_raw:5 of
+msgid "Raw 16-bit signed values (x, y, z)."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.get_magnetic:8
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.get_magnetic_raw:8 of
+msgid "If timeout waiting for data ready."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.get_magnetic:1 of
+msgid "Read magnetic field in Gauss."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.get_magnetic:3 of
+msgid "Reads raw values and converts to Gauss based on current range setting."
+msgstr ""
+
+#: glasgow.applet.sensor.qmc5883p.QMC5883PInterface.get_magnetic:5 of
+msgid "Magnetic field values in Gauss (x, y, z)."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/sensor/scd30.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/sensor/scd30.po
@@ -1,0 +1,200 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/sensor/scd30.rst:2
+msgid "``sensor-scd30``"
+msgstr ""
+
+#: ../../src/applets/sensor/scd30.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-scd30"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Measure CO₂ concentration, humidity, and temperature using Sensirion SCD30 sensors connected over the I²C interface."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "NOTE: The SCD30 takes some time to start up. Run `glasgow voltage AB 3.3` or similar before attempting to interact with it."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'scl' to PIN (default: 'A0', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'sda' to PIN (default: 'A1', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-scd30 calibrate"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "enable automatic self-calibration"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "disable automatic self-calibration"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "force calibration at CAL ppm of CO₂ (range: 400..2000)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set temperature offset to OFF °C"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set altitude compensation to ALT m above sea level (range: 0..10000)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set measurement interval to INTV s (range: 2..1800)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-scd30 log"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-scd30 log csv"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Log data to a comma-separated value (CSV) file."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write data to CSV-FILE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "format CSV file according to DIALECT"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-scd30 log influxdb"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Log data to an InfluxDB 1.x endpoint over HTTP(S)."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to endpoint URL //ENDPOINT/write"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to database DATABASE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to measurement SERIES"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to retention policy POLICY"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "attach TAG=VALUE to all data points"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set timestamp precision to PRECISION"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "submit data in groups of BATCH-SIZE points"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-scd30 log influxdb2"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Log data to an InfluxDB 2.x endpoint over HTTP(S)."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to endpoint URL //ENDPOINT/api/v2/write"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to Organization ORGANIZATION (can be either the name or the id)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to bucket BUCKET"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set the Token to use for Authentication"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-scd30 log stdout"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Log data to standard output in a human-readable format."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-scd30 measure"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-scd30 start"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "compensate for ambient pressure of PRESSURE mbar"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-scd30 stop"
+msgstr ""
+
+#: ../../src/applets/sensor/scd30.rst:14
+msgid "API reference"
+msgstr ""
+
+#: ../../src/applets/sensor/scd30.rst:16
+msgid "Todo"
+msgstr ""
+
+#: ../../src/applets/sensor/scd30.rst:18
+msgid "Add API documentation for ``sensor-scd30``."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/applets/sensor/sen5x.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/applets/sensor/sen5x.po
@@ -1,0 +1,168 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/applets/sensor/sen5x.rst:2
+msgid "``sensor-sen5x``"
+msgstr ""
+
+#: ../../src/applets/sensor/sen5x.rst:5
+msgid "CLI reference"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-sen5x"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Measure PM, NOx, VOC, humidity, and temperature using Sensirion SEN5x sensors connected over the I²C interface."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "NOTE: The SEL pin must be connected to ground before startup for the SEN5x to enable the I2C interface."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "show this help message and exit"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "configure I/O port voltage to SPEC (e.g.: '3.3', 'A=5.0,B=3.3', 'A=SA')"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'scl' to PIN (default: 'A0', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "bind the applet I/O line 'sda' to PIN (default: 'A1', required)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-sen5x log"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-sen5x log csv"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Log data to a comma-separated value (CSV) file."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write data to CSV-FILE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "format CSV file according to DIALECT"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-sen5x log influxdb"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Log data to an InfluxDB 1.x endpoint over HTTP(S)."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to endpoint URL //ENDPOINT/write"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to database DATABASE"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to measurement SERIES"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to retention policy POLICY"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "attach TAG=VALUE to all data points"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set timestamp precision to PRECISION"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "submit data in groups of BATCH-SIZE points"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-sen5x log influxdb2"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Log data to an InfluxDB 2.x endpoint over HTTP(S)."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to endpoint URL //ENDPOINT/api/v2/write"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to Organization ORGANIZATION (can be either the name or the id)"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "write to bucket BUCKET"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "set the Token to use for Authentication"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-sen5x log stdout"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "Log data to standard output in a human-readable format."
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-sen5x measure"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-sen5x start"
+msgstr ""
+
+#: ../../<autoprogram>:1
+msgid "glasgow run sensor-sen5x stop"
+msgstr ""
+
+#: ../../src/applets/sensor/sen5x.rst:14
+msgid "API reference"
+msgstr ""
+
+#: ../../src/applets/sensor/sen5x.rst:16
+msgid "Todo"
+msgstr ""
+
+#: ../../src/applets/sensor/sen5x.rst:18
+msgid "Add API documentation for ``sensor-sen5x``."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/build.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/build.po
@@ -1,0 +1,104 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/build.rst:4
+msgid "Building hardware"
+msgstr ""
+
+#: ../../src/build.rst:6
+msgid "Pre-assembled Glasgow devices and cases are :ref:`available for purchase <purchasing>`. Since Glasgow is open hardware, you also have the option of building a device yourself."
+msgstr ""
+
+#: ../../src/build.rst:10
+msgid "If you manufacture your own devices from the design files in this repository, you must clearly distinguish the PCBs by modifying the silkscreen artwork such that the placeholder manufacturer name and/or logo are replaced with your own contact information."
+msgstr ""
+
+#: ../../src/build.rst:12
+msgid "If you use the PCBA design files and the BOM that are included in this repository without modifications (other than the modifications required above), the Glasgow project will provide the same degree of support for your device as it does for the CrowdSupply orders (except for repairs under warranty)."
+msgstr ""
+
+#: ../../src/build.rst:14
+msgid "If you modify the design files (which the license allows you to do without restrictions), the Glasgow project will not in general provide support for such devices, and you must not call your modified devices \"Glasgow\". You must remove the name \"Glasgow\" from the PCB silkscreen artwork to ensure that the device is clearly identifiable as being modified from the original source files. You must run ``glasgow factory`` with the ``--using-modified-design-files=yes`` argument when preparing the device, which will appropriately mark the device and change the product name USB descriptor to not include \"Glasgow\"."
+msgstr ""
+
+#: ../../src/build.rst:16
+msgid "If you are modifying the BOM to replace passive components with equivalent parts from a different vendor (such as in response to shortages), you may call your modified device \"Glasgow\". In addition, exceptions to the rule above can be made after discussing your case with Catherine \"whitequark\" or Piotr Esden-Tempski."
+msgstr ""
+
+#: ../../src/build.rst:22
+msgid "Assembling a device"
+msgstr ""
+
+#: ../../src/build.rst:24 ../../src/build.rst:64
+msgid "Todo"
+msgstr ""
+
+#: ../../src/build.rst:26
+msgid "This section is not written yet."
+msgstr ""
+
+#: ../../src/build.rst:32
+msgid "Factory flashing"
+msgstr ""
+
+#: ../../src/build.rst:34
+msgid "\"Factory flashing\" refers to the process of assigning a brand new Glasgow board (that you probably just assembled) a serial number, as well as writing a few critical configuration options that will let the ``glasgow`` command use this device. Barring severe and unusual EEPROM corruption, this process is performed only once in the lifetime of a device."
+msgstr ""
+
+#: ../../src/build.rst:36
+msgid "To prepare for factory flashing, follow the :ref:`installation steps <initial-setup>`."
+msgstr ""
+
+#: ../../src/build.rst:38
+msgid "Any board that is being factory flashed must have a blank ``FX2_MEM`` EEPROM. If the ``FX2_MEM`` EEPROM is not completely erased (all bytes set to ``FF``), the factory flashing process may fail."
+msgstr ""
+
+#: ../../src/build.rst:42
+msgid "Configure your system to allow unprivileged access for anyone logged in to the physical terminal to any hardware that enumerates as the Cypress FX2 ROM bootloader:"
+msgstr ""
+
+#: ../../src/build.rst:50
+msgid "Note that this rule will allow unprivileged access to any device based on the Cypress FX2 that has a blank EEPROM, and not just the Glasgow hardware specifically."
+msgstr ""
+
+#: ../../src/build.rst:52
+msgid "Plug in the newly assembled device. At this point, ``lsusb -d 04b4:8613`` should list one entry. Note the revision of the board you are factory flashing. If the board has revision ``C3``, run:"
+msgstr ""
+
+#: ../../src/build.rst:58
+msgid "That's it! After running this command, the device will disconnect from USB and reconnect, and ``lsusb -d 20b7:9db1`` will list one entry."
+msgstr ""
+
+#: ../../src/build.rst:62
+msgid "The steps are similar to the steps for Linux, but you will need to use Zadig to bind the WinUSB driver to the device, since this will not happen automatically with a device that hasn't been flashed yet."
+msgstr ""
+
+#: ../../src/build.rst:66
+msgid "Write a full explanation here."
+msgstr ""
+
+#: ../../src/build.rst:70
+msgid "Plug in the newly assembled device. At this point, ``System Information.app`` should list the FX2 device with Vid ``04b4`` and Pid ``8613``. Note the revision of the board you are factory flashing. If the board has revision ``C3``, run:"
+msgstr ""
+
+#: ../../src/build.rst:76
+msgid "That's it! After running this command, the device will disconnect from USB and reconnect, and after refreshing (⌘R) the information in ``System Information.app`` you should see a new entry with Vid ``20b7`` and Pid ``9db1``."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/community.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/community.po
@@ -1,0 +1,120 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/community.rst:4
+msgid "Community"
+msgstr ""
+
+#: ../../src/community.rst:6
+msgid "Glasgow Interface Explorer is a community-driven project that coordinates via `GitHub issues <issues_>`__ and real-time chat channels on multiple platforms:"
+msgstr ""
+
+#: ../../src/community.rst:8
+msgid "IRC channel `#glasgow at irc.libera.chat <irc_>`__ with `logs available <irclogs_>`__."
+msgstr ""
+
+#: ../../src/community.rst:9
+msgid "Matrix channel `#glasgow-interface-explorer:matrix.org <matrix_>`__."
+msgstr ""
+
+#: ../../src/community.rst:10
+msgid "Discord channel `#glasgow at 1BitSquared's Discord server <discord_>`__."
+msgstr ""
+
+#: ../../src/community.rst:12
+msgid "All of our chat channels are bridged together; regardless of which one you choose, your messages reach everyone on all of the platforms. Note that what you say will be logged in a public archive indexed by search engines."
+msgstr ""
+
+#: ../../src/community.rst:24
+msgid "Code of Conduct"
+msgstr ""
+
+#: ../../src/community.rst:26
+msgid "All community interactions are covered by our :doc:`Code of Conduct <conduct>`."
+msgstr ""
+
+#: ../../src/community.rst:32
+msgid "Fediverse"
+msgstr ""
+
+#: ../../src/community.rst:34
+msgid "Many of the community members involved with the project have Fediverse pages; `@esden@chaos.social <https://chaos.social/@esden>`_ has been writing a lot about the process of mass manufacturing the hardware."
+msgstr ""
+
+#: ../../src/community.rst:36
+msgid "You, too, can join the conversation via the `#GlasgowInterfaceExplorer` hashtag. Please avoid using `#Glasgow`; we are not talking about the city. (Unless you live there, in which case both are appropriate!)"
+msgstr ""
+
+#: ../../src/community.rst:42
+msgid "Weekly meetings"
+msgstr ""
+
+#: ../../src/community.rst:44
+msgid "Every week we conduct an informal developer meeting on our chat channels, discussing the progress over the last week, outstanding issues, and any other matters that need attention. At the moment the meeting is scheduled **every Saturday at 22:00 UTC**, and the typical duration is one hour. Anyone is free to attend, and we publish our past `meeting minutes <minutes_>`__."
+msgstr ""
+
+#: ../../src/community.rst:46
+msgid "When conducting a meeting, we first discuss `nominated`_ issues, and then anything else that is brought up. Once discussed, the ``nominated`` tag is removed."
+msgstr ""
+
+#: ../../src/community.rst:55
+msgid "Acknowledgements"
+msgstr ""
+
+#: ../../src/community.rst:57
+msgid "The Glasgow project has been built by its many `contributors <https://github.com/GlasgowEmbedded/Glasgow/graphs/contributors>`_, including some without whom the project would not have been possible:"
+msgstr ""
+
+#: ../../src/community.rst:59
+msgid "`@whitequark <https://github.com/whitequark>`_ originated the overall design, coordinates the project and implements most of gateware and software"
+msgstr ""
+
+#: ../../src/community.rst:60
+msgid "`@awygle <https://github.com/awygle>`_ designed the power/analog port circuitry and helped with layout of revB"
+msgstr ""
+
+#: ../../src/community.rst:61
+msgid "`@marcan <https://github.com/marcan>`_ improved almost every aspect of hardware for revC"
+msgstr ""
+
+#: ../../src/community.rst:62
+msgid "`@esden <https://github.com/esden>`_ is handling batch manufacturing"
+msgstr ""
+
+#: ../../src/community.rst:63
+msgid "`@smunaut <https://github.com/smunaut>`_ provided advice crucial for stability and performance of USB communication"
+msgstr ""
+
+#: ../../src/community.rst:64
+msgid "`@electroniceel <https://github.com/electroniceel>`_ improved the hardware for revC2, designed the test jig and is working on advanced protection circuitry"
+msgstr ""
+
+#: ../../src/community.rst:65
+msgid "`@Attie <https://github.com/attie>`_ improved and refactored many applets, hardware photos"
+msgstr ""
+
+#: ../../src/community.rst:66
+msgid "`@wanda-phi <https://github.com/wanda-phi>`_ does important maintenance work to keep the codebase in good shape"
+msgstr ""
+
+#: ../../src/community.rst:67
+msgid "`@isabelburgos <https://github.com/isabelburgos>`_ brought many applets up to date"
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/conduct.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/conduct.po
@@ -1,0 +1,84 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/conduct.md:1
+msgid "Code of Conduct"
+msgstr ""
+
+#: ../../src/conduct.md:4
+msgid "Preface"
+msgstr ""
+
+#: ../../src/conduct.md:7
+msgid "The Glasgow Interface Explorer project is a long-term collaborative project that aims to unify the efforts of many individual contributors, whether they are contributing glue work, documentation, process, code, or other kinds of labor not explicitly included, into a coherent *instrument* that is accessible to the public and experts alike and remains such for as long as it is feasible. The continued existence of such an instrument is indelibly tied to the existence of a community caring for and maintaining it; this community achieving it by the individuals accepting shared values and goals to become more than the sum of the parts."
+msgstr ""
+
+#: ../../src/conduct.md:10
+msgid "Argument"
+msgstr ""
+
+#: ../../src/conduct.md:13
+msgid "The Glasgow Interface Explorer project was started and to a large degree is built by those who are queer, trans, and plural, existing perpetually on the fringes of what is acceptable. This is _our space_. If you are neither, please be our guest; we build it in the open for your benefit, no matter who you are, and share our knowledge, expertise, and skill freely. Do treat us like the agents we are; we will tell you in private if you seem not to, and we will ask you to leave if that fails."
+msgstr ""
+
+#: ../../src/conduct.md:15
+msgid "The project is built in the open and distributed under the most permissive licenses because we want society as a whole to benefit from our work, and we do not find that calling cops on the cops is effective. This does not mean, however, that we wilfully turn a blind eye to the outcomes of our work. You will always have what the law says you do, but you may end up with not much more than that. For example, both ordinary contributors and project leaders may give you no quarter if you work to spill the blood of the innocent. We will explain our reasoning."
+msgstr ""
+
+#: ../../src/conduct.md:17
+msgid "The spaces of the project exist foremost to advance its goals, which are both technical and social in nature. That does not mean that all discussion must be free of raw emotion and sensitive topics. However, if your approach to communication ends up persistently disruptive or creates a hostile environment, we will privately ask you to reconsider, and we will ask you to leave if that fails."
+msgstr ""
+
+#: ../../src/conduct.md:19
+msgid "For the avoidance of doubt, we have virtually no tolerance for: sexism, misogyny, racism, xenophobia, homophobia, transphobia, queerphobia, pluralphobia, stalking, harassment, unwelcome sexual advances of any kind, doxing, direct violation of non-consent, general bigotry. (This includes egregious off-space behavior if it appears relevant.) Do not post anything that can be reasonably anticipated to cause legal issues for the project. Avoid sexualized language and imagery to keep our spaces suitable for minors and survivors. In severe cases, these actions may result in an immediate ban."
+msgstr ""
+
+#: ../../src/conduct.md:21
+msgid "Project leaders have a noticeable degree of influence on the behavior of community members and as such are partially responsible for the community as a whole."
+msgstr ""
+
+#: ../../src/conduct.md:24
+msgid "Resolution"
+msgstr ""
+
+#: ../../src/conduct.md:27
+msgid "Where feasible, we encourage resolution of interpersonal conflict through private communication. Where that fails or is inapplicable due to the nature of the issue, instances of unacceptable behavior may be reported to any of the project leaders, who are currently:"
+msgstr ""
+
+#: ../../src/conduct.md:29
+msgid "Catherine [@whitequark]"
+msgstr ""
+
+#: ../../src/conduct.md:30
+msgid "Piotr [@esden]"
+msgstr ""
+
+#: ../../src/conduct.md:32
+msgid "Project leaders are obliged to respect the privacy and security of the reporter and promptly investigate all reports. To the best of our ability, we will address them fairly and proportionally."
+msgstr ""
+
+#: ../../src/conduct.md:38
+msgid "Afterwords"
+msgstr ""
+
+#: ../../src/conduct.md:41
+msgid "[Reach heaven by violence.](https://en.uesp.net/wiki/Morrowind:The_36_Lessons_of_Vivec)"
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/contribute.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/contribute.po
@@ -1,0 +1,144 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/contribute.rst:2
+msgid "Contributing"
+msgstr ""
+
+#: ../../src/contribute.rst:4
+msgid "The Glasgow project relies on many community members to contribute to the extensive scope covered by its hardware and software. The project has a strong commitment to stability: most importantly, every unit of hardware for which design files have been published in the ``main`` branch will be supported forever. This scope and support commitment is challenging and requires us to be careful in evaluating any contributions."
+msgstr ""
+
+#: ../../src/contribute.rst:6
+msgid "We expect every contributor to work with the maintainers to ensure longevity of their contribution. If your contribution is substantial, please discuss it via our :ref:`community channels <community>` before working on it to ensure that it fits the project goals and to coordinate a long-term support commitment, especially in the cases where exotic or expensive hardware is required to test the changes."
+msgstr ""
+
+#: ../../src/contribute.rst:12
+msgid "Contributing bug reports"
+msgstr ""
+
+#: ../../src/contribute.rst:14
+msgid "Bug reports are always welcome! If you are experiencing an issue with your device and you are not sure what kind of issue it is, :ref:`ask the community for assistance <community>`."
+msgstr ""
+
+#: ../../src/contribute.rst:16
+msgid "For a timely resolution of your issues involving the Glasgow software, include the following information when `reporting a bug on GitHub <issues_>`__:"
+msgstr ""
+
+#: ../../src/contribute.rst:18
+msgid "The version of the Glasgow software stack and environment components (as printed by ``glasgow --version``);"
+msgstr ""
+
+#: ../../src/contribute.rst:20
+msgid "The complete debug information produced by the command you are running (as printed by ``glasgow -vvv [command...]``)."
+msgstr ""
+
+#: ../../src/contribute.rst:22
+msgid "If you believe there is an issue with the design of the Glasgow hardware or firmware, `open an issue on GitHub <issues_>`__. The Glasgow hardware and firmware have been extensively reviewed, evaluated, and tested, and it is relatively unlikely for you to experience a design issue."
+msgstr ""
+
+#: ../../src/contribute.rst:24
+msgid "If you believe that your device may be damaged or malfunctioning, and the device is unmodified from the design files published in this repository (bearing the \"Glasgow\" name on it), you may :ref:`ask the community for assistance <community>` before referring to the manufacturer of your device. If your device has been :ref:`modified from the original design files <build>` or does not bear the \"Glasgow\" name on it, you must request assistance from the manufacturer of your device. You may ask the community for assistance if you make it clear in your request that your device has been modified from the original design files, but the effort required to evaluate such modifications is scarcely available."
+msgstr ""
+
+#: ../../src/contribute.rst:33
+msgid "Contributing code or documentation"
+msgstr ""
+
+#: ../../src/contribute.rst:35
+msgid "Code contributions are expected to be in the form of a `pull request <pulls_>`__ containing a small number of self-contained commits with :ref:`descriptive messages <commit-messages>`, each of which individually captures a functional state of the working tree. If your pull request does not fit this description it will not be merged until it is cleaned up, but it is okay to have a draft pull request containing a large number of temporary commits while it is undergoing review or ongoing work."
+msgstr ""
+
+#: ../../src/contribute.rst:37
+msgid "As Git is a notoriously difficult version control system to use effectively, feel free to :ref:`ask the community for assistance <community>`. Often, your pull request will be edited by maintainers to ensure it fits the codebase well. In those cases the maintainer will usually rearrange the commits to fit our requirements."
+msgstr ""
+
+#: ../../src/contribute.rst:39
+msgid "The Glasgow project does not strictly adhere to any specific Python or C coding standards. If your code is structured and formatted similarly to existing code, it is good enough. We use `pre-commit.ci <pre-commit-ci_>`__, a system that automatically remediates code style issues where possible, and highlights them otherwise. Code review is a dialogue focused on function, not form."
+msgstr ""
+
+#: ../../src/contribute.rst:41
+msgid "We do not accept contributions where code was generated partly or in whole using LLMs. These tools are designed to be extractive and place an unreasonable burden on OSS maintainers, both on the level of individual pull requests and for the ecosystem as a whole. If you didn't bother writing it, we won't bother reading."
+msgstr ""
+
+#: ../../src/contribute.rst:49
+msgid "Writing commit messages"
+msgstr ""
+
+#: ../../src/contribute.rst:51
+msgid "When modifying Python code, the first line of a commit message should, if possible, start with the name of the module (not including the leading ``glasgow.``) that is being modified, such that ``git log --grep`` can be used to filter changes by scope:"
+msgstr ""
+
+#: ../../src/contribute.rst:57
+msgid "The format is the same for Python code implementing applets:"
+msgstr ""
+
+#: ../../src/contribute.rst:63
+msgid "When modifying documentation, the first line of a commit message should start with ``manual:``, followed by the base name of the ``.rst`` file that is being modified:"
+msgstr ""
+
+#: ../../src/contribute.rst:69
+msgid "When modifying firmware, the first line of a commit message should start with ``firmware:``:"
+msgstr ""
+
+#: ../../src/contribute.rst:75
+msgid "If none of the cases above are a good fit, any descriptive message is sufficient."
+msgstr ""
+
+#: ../../src/contribute.rst:81
+msgid "Working with `pre-commit.ci <https://pre-commit.ci>`_"
+msgstr ""
+
+#: ../../src/contribute.rst:83
+msgid "Whenever our continuous integration system notices issues with your code that it can automatically fix, it will push a commit to your branch (provided you have allowed edits from maintainers for your pull request, which you should). You are encouraged to examine this commit and integrate the changes it suggests into your code, but it is not a requirement to do so. Such issues will not clutter the \"Files changed\" view of your pull request, and the \"lint\" check will ignore them."
+msgstr ""
+
+#: ../../src/contribute.rst:85
+msgid "Less commonly, our continuous integration system will encounter an issue it cannot resolve on its own. Such issues will appear as an annotation in the \"Files changed\" view of your PR (as well as in the commit diffs), and the \"lint\" check will reject your code. You will have to resolve the issue before the pull request can be merged, but you can ignore it until then, and all other checks will still run."
+msgstr ""
+
+#: ../../src/contribute.rst:87
+msgid "Whenever your branch is edited by our automated system, you will not be able to update it using ``git push`` right away because your local system and the Git server disagree on the state of the branch. You can either retrieve the suggested changes using ``git pull``, or discard them using ``git push --force``, at your discretion; you do not have to keep the ``[pre-commit.ci]`` commit in your branch."
+msgstr ""
+
+#: ../../src/contribute.rst:89
+msgid "To expedite the workflow, you may run the ``pre-commit`` tool locally on your system such that it can tidy up your commits while you create them. To do so, `install the pre-commit tool <https://pre-commit.com/#install>`_ and run ``pre-commit install`` in the Glasgow repository. From that point on, running ``git commit`` will invoke ``pre-commit run`` first, and your branch will not be edited by the continuous integration system."
+msgstr ""
+
+#: ../../src/contribute.rst:95
+msgid "Vendor documentation"
+msgstr ""
+
+#: ../../src/contribute.rst:97
+msgid "If you have used vendor documentation while writing the code you're contributing, you are required to:"
+msgstr ""
+
+#: ../../src/contribute.rst:99
+msgid "upload the documentation to the `Glasgow archive repository <archive_>`__; and"
+msgstr ""
+
+#: ../../src/contribute.rst:101
+msgid "reference the documentation at the top of the file in the following format:"
+msgstr ""
+
+#: ../../src/contribute.rst:109
+msgid "If you cannot upload the documentation to the archive because it is under NDA and/or watermarked, :ref:`ask the community for assistance <community>`. Often, it is possible to collate enough information by using existing leaked documents or through parallel construction."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/develop/applet.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/develop/applet.po
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/develop/applet.rst:4
+msgid "Applets"
+msgstr ""
+
+#: ../../src/develop/applet.rst:8
+msgid "We do not yet have documentation for developing applets or a stable API, so for now every applet must be loaded from within the main ``glasgow`` package."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/develop/docs.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/develop/docs.po
@@ -1,0 +1,84 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/develop/docs.rst:4
+msgid "Documentation"
+msgstr ""
+
+#: ../../src/develop/docs.rst:6
+msgid "The source files for this documentation manual is contained in the `GlasgowEmbedded/glasgow`_ repository under ``docs/manual/``. It is written in `reStructuredText`_ and published with `Sphinx`_, using `PDM`_ for package management."
+msgstr ""
+
+#: ../../src/develop/docs.rst:8
+msgid "To build the documentation locally, first `install PDM`_. Then, navigate to the working directory you have :ref:`installed <initial-setup>` the Glasgow software in, and run:"
+msgstr ""
+
+#: ../../src/develop/docs.rst:15
+msgid "Once this step completes (which should always happen without errors), you are ready to edit the documentation. In a terminal, run:"
+msgstr ""
+
+#: ../../src/develop/docs.rst:37
+msgid "This command starts a web server running on your local PC that allows you to quickly see any changes to the documentation you are making. Navigate to `the URL it prints <http://127.0.0.1:8000>`_, and open the page you would like to change. Whenever you edit the ``.rst`` file corresponding to the page, you should see the page automatically reload in the web browser, reflecting the new contents."
+msgstr ""
+
+#: ../../src/develop/docs.rst:39
+msgid "In some cases (primarily when you are updating the documentation index in the sidebar) the changes aren't picked up by the web server. In that case, remove the output directory to trigger a full rebuild."
+msgstr ""
+
+#: ../../src/develop/docs.rst:41
+msgid "The markup language we are using, reStructuredText, has an awkward syntax, and it is easy for new editors to introduce syntax changes. If this happens, the web server prints a warning message whenever the ``.rst`` file is saved. Watch out for these warnings---they can save a lot of time trying to understand why the markup does not render correctly."
+msgstr ""
+
+#: ../../src/develop/docs.rst:43
+msgid "To check that all of the external links in the documentation are valid, run the following command:"
+msgstr ""
+
+#: ../../src/develop/docs.rst:58
+msgid "Our continuous integration system checks external links on every build, ensuring they stay valid."
+msgstr ""
+
+#: ../../src/develop/docs.rst:68
+msgid "Style guide"
+msgstr ""
+
+#: ../../src/develop/docs.rst:70
+msgid "When writing documentation, please follow our style:"
+msgstr ""
+
+#: ../../src/develop/docs.rst:72
+msgid "Only capitalise the first word of headings."
+msgstr ""
+
+#: ../../src/develop/docs.rst:73
+msgid "Insert two blank lines before headings."
+msgstr ""
+
+#: ../../src/develop/docs.rst:74
+msgid "Use ``.. note::`` and ``.. warning::`` sparingly, where important details may otherwise be missed."
+msgstr ""
+
+#: ../../src/develop/docs.rst:75
+msgid "Use an em-dash (---), which can be written as ``---`` in reStructuredText."
+msgstr ""
+
+#: ../../src/develop/docs.rst:76
+msgid "Link to our `official repositories <https://github.com/GlasgowEmbedded>`_ where appropriate."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/develop/firmware.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/develop/firmware.po
@@ -1,0 +1,148 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/develop/firmware.rst:4
+msgid "Firmware"
+msgstr ""
+
+#: ../../src/develop/firmware.rst:8
+msgid "Introduction"
+msgstr ""
+
+#: ../../src/develop/firmware.rst:10
+msgid "All revisions of the Glasgow hardware include a single ASIC with a CPU that runs firmware: the `Infineon/Cypress CY7C68013A <FX2LP_>`__ chip, also known as \"FX2LP\" or just \"FX2\" (which is how it is called in this documentation). It is the de-facto standard ASIC for adding a relatively high-performance (~300 Mbps) USB interface to an FPGA-based system at low cost and without much increase in complexity. This ASIC implements a configurable USB to parallel bus bridge that functions autonomously once configured, and includes an `Intel MCS8051`_ compatible CPU core for configuration and ancillary functions that executes a firmware residing in the internal RAM. The firmware can be loaded from an external I²C EEPROM after power-on reset, or be reloaded by the host PC using a vendor-specific USB request at any time."
+msgstr ""
+
+#: ../../src/develop/firmware.rst:12
+msgid "The Glasgow hardware relies on this CPU core to perform all of the board management functions, such as loading the FPGA bitstream, configuring the port I/O standard, sensing port voltage and current, configuring pull resistors, and so on. The FPGA solely concerns itself with data processing. Because of its central (and safety-critical) function in the device, the FX2 firmware is of paramount importance, and the way it is managed reflects this fact."
+msgstr ""
+
+#: ../../src/develop/firmware.rst:19
+msgid "Firmware management"
+msgstr ""
+
+#: ../../src/develop/firmware.rst:21
+msgid "The FX2 firmware is considered an integral component of the Glasgow software/hardware stack: it is not end user modifiable or replaceable, does not have an interface that is stable or suitable for use in third-party tools, and is reloaded by the host software without prior consent whenever necessary."
+msgstr ""
+
+#: ../../src/develop/firmware.rst:25
+msgid "Being open software and open hardware, nothing prevents an end user from modifying, replacing, or interfacing with the firmware. However, the Glasgow project will not in general provide support for running modified firmware, and interfacing third party tools with the firmware directly (by means other than the Python-based software stack) is strongly discouraged at the moment."
+msgstr ""
+
+#: ../../src/develop/firmware.rst:27
+msgid "The Glasgow hardware includes an EEPROM labelled \"FX2_MEM\" that stores the factory provisioning information (revision, serial number, etc) as well as the FX2 firmware. In most cases, this EEPROM would have a firmware stored in it at all times (as done by the ``glasgow flash`` command, unless requested otherwise), but this is only an optimization: if the software stack discovers a device plugged in without firmware it will automatically load the firwmare, and if it discovers that the firmware is too old (or too new) to be compatible, it will reload a compatible version of the firmware to RAM (without affecting the stored version)."
+msgstr ""
+
+#: ../../src/develop/firmware.rst:29
+msgid "To ensure that a compatible version of the firmware is available at all times, a built artifact (an Intel HEX file) is checked into the repository as ``software/glasgow/hardware/firmware.ihex`` and included in the built artifacts (Python wheels) of the Glasgow software. Whenever necessary, this data file is requested via :mod:`importlib.resources` and loaded or flashed. At the moment, whenever the firmware source code is changed, this file is manually built on a developer's machine and committed to the repository."
+msgstr ""
+
+#: ../../src/develop/firmware.rst:31
+msgid "Currently, the firmware is written to be compatible with every version of the Glasgow hardware ever designed. This simplifies firmware management and to some extent development, eliminating the need for conditional compilation. It is possible that, as functionality is added, this approach will become infeasible and several versions of the firmware will be concurrently built."
+msgstr ""
+
+#: ../../src/develop/firmware.rst:35
+msgid "Firmware interface"
+msgstr ""
+
+#: ../../src/develop/firmware.rst:37
+msgid "The interface of the FX2 firmware that is exposed over USB is a critical implementation detail, and it is necessary to ensure that the firmware and the software agree on the exact interface used at all times. This is a common situation, and many FX2-based devices opt to ensure this by (re)loading the firmware each time the driver opens the device. (This also allows them to use the smallest, and cheapest, I²C EEPROM available, only large enough to store the unique USB VID/PID pair.) However, this is not an option for the Glasgow firmware, for two core reasons:"
+msgstr ""
+
+#: ../../src/develop/firmware.rst:39
+msgid "It is not possible for a USB device to indicate that its descriptors have changed, so reloading the firmware, in general, requires the device to logically disconnect itself from the USB bus and reconnect back. This adds a delay that can be as high as several seconds, and can interact poorly with virtualization (where manual action may be required to pass a USB device to the VM) or security features (where user consent may be required each time the device is opened)."
+msgstr ""
+
+#: ../../src/develop/firmware.rst:40
+msgid "Reloading the firmware, in general, requires the device to be reinitialized, since there is no way to be sure that the previously loaded firmware has left the device in a well-defined state. This will clear the FPGA configuration, disable Vio supply, and otherwise clear volatile state."
+msgstr ""
+
+#: ../../src/develop/firmware.rst:42
+msgid "The Glasgow software encourages a granular workflow where the ``glasgow`` CLI tool is often invoked many times in quick succession; reloading the firmware on each invocation would be extremely disruptive. Because of this as well as the delivery optimization of having the firmware initially load from the FX2_MEM EEPROM, the firmware interface is versioned, enabling the software stack to reload the firmware only on version mismatch."
+msgstr ""
+
+#: ../../src/develop/firmware.rst:44
+msgid "The version of the firmware interface is called an \"API level\", which is an integer (in range of 1 to 255 inclusive) with semantics roughly equivalent to the \"major\" version in `Semantic Versioning`_ terminology. That is, whenever an incompatible change is made to the firmware interface, the API level is increased by 1; if a backwards-compatible change (that could be as significant as support for a new hardware revision) is made, the API level does not change."
+msgstr ""
+
+#: ../../src/develop/firmware.rst:48
+msgid "What counts as an \"incompatible change\" is left to the discretion of maintainers. The usable range of API levels is limited, making it infeasible to increment it every time the firmware is changed at all."
+msgstr ""
+
+#: ../../src/develop/firmware.rst:50
+msgid "The API level is exposed to the software stack by being placed in the high byte of the ``bcdDevice`` field of the standard USB device descriptor. Since this descriptor is read by the OS during enumeration, it is possible for the software stack to discover the API level of any connected device without accessing it."
+msgstr ""
+
+#: ../../src/develop/firmware.rst:56
+msgid "Building firmware"
+msgstr ""
+
+#: ../../src/develop/firmware.rst:58
+msgid "The firmware can only be built on a Unix-like system; to develop the firmware on Windows, use `WSL`_. You will need `GNU Make`_ and `sdcc`_ (version 4.0 or newer). To install these, run:"
+msgstr ""
+
+#: ../../src/develop/firmware.rst:80
+msgid "On Fedora, the `sdcc` package installs the tools into a different location, which must be added to the search path:"
+msgstr ""
+
+#: ../../src/develop/firmware.rst:86
+msgid "The source code of the chip support library `libfx2`_ used by the firmware is included in the Glasgow repository as a `git submodule`_. Make sure it is checked out at the appropriate revision and compiled:"
+msgstr ""
+
+#: ../../src/develop/firmware.rst:93
+msgid "Now, build the firmware itself:"
+msgstr ""
+
+#: ../../src/develop/firmware.rst:99
+msgid "The freshly built firmware can be unconditionally loaded to a connected device as follows:"
+msgstr ""
+
+#: ../../src/develop/firmware.rst:105
+msgid "Provided the API level matches, the Glasgow software stack will use the device where the firmware was loaded in such a way as-is and not reload the firmware. In the unlikely case of an API level mismatch, the ``glasgow`` tool will print a diagnostic message at the ``WARN`` log level."
+msgstr ""
+
+#: ../../src/develop/firmware.rst:115
+msgid "Deploying firmware"
+msgstr ""
+
+#: ../../src/develop/firmware.rst:117
+msgid "Building the firmware within the ``firmware/`` subtree does not affect the built firmware artifact used by the software stack, which resides within the ``software/`` subtree. Firmware development can be done in the same repository checkout that is being used for applet development or other everyday use of the device."
+msgstr ""
+
+#: ../../src/develop/firmware.rst:119
+msgid "Whenever the modified firmware is ready for general use, it must be rebuilt in a reproducible environment (guaranteeing that every developer, as well as our continuous integration system, would produce a bit-for-bit identical binary artifact) and copied to its final location within the ``software/`` subtree. This process is called \"deployment\"."
+msgstr ""
+
+#: ../../src/develop/firmware.rst:121
+msgid "Deploying the firmware requires `Docker`_ and an internet connection. To deploy the firmware, run:"
+msgstr ""
+
+#: ../../src/develop/firmware.rst:127
+msgid "Once a modified firmware is deployed, the Glasgow software stack will load this firmware whenever the usual conditions for doing so are met, and loading it manually (with ``make -C firmware load``) is no longer necessary."
+msgstr ""
+
+#: ../../src/develop/firmware.rst:131
+msgid "When submitting a pull request that changes the firmware source code, be sure to update the built binary artifact, ``software/glasgow/hardware/firmware.ihex``, in a separate commit that is the very last one in your pull request. (The built binary artifact includes the git revision of the latest modification of the source code in the ``firmware/`` subtree, and it cannot be self-referential.)"
+msgstr ""
+
+#: ../../src/develop/firmware.rst:133
+msgid "Our continuous integration system will rebuild the firmware from source code and prevent the pull request from being merged unless the freshly built firmware is bit-for-bit identical to the firmware checked into the repository. This automated process ensures that the checked-in binary artifact is trustworthy and reproducible."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/develop/hardware.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/develop/hardware.po
@@ -1,0 +1,32 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/develop/hardware.rst:4
+msgid "Hardware"
+msgstr ""
+
+#: ../../src/develop/hardware.rst:6
+msgid "Todo"
+msgstr ""
+
+#: ../../src/develop/hardware.rst:8
+msgid "This section needs to be written."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/develop/index.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/develop/index.po
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/develop/index.rst:2
+msgid "Development process"
+msgstr ""
+
+#: ../../src/develop/index.rst:4
+msgid "As an end user, you will most likely work only on :ref:`applets <applet>` and :ref:`documentation <docs>`. Development of :ref:`software <software>`, :ref:`firmware <firmware>`, and :ref:`hardware <hardware>` are advanced topics, and these pages are only used for sharing knowledge among already experienced developers rather than teaching the required skills."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/develop/software.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/develop/software.po
@@ -1,0 +1,32 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/develop/software.rst:4
+msgid "Software"
+msgstr ""
+
+#: ../../src/develop/software.rst:6
+msgid "Todo"
+msgstr ""
+
+#: ../../src/develop/software.rst:8
+msgid "This section needs to be written."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/index.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/index.po
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/index.rst:4
+msgid "Run in browser"
+msgstr ""
+
+#: ../../src/index.rst:2
+msgid "Glasgow Interface Explorer manual"
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/install.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/install.po
@@ -1,0 +1,125 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/install.rst:2
+msgid "Installing & updating"
+msgstr ""
+
+#: ../../src/install.rst:6
+msgid "If you are using a Chromium-based browser (including Chrome, Edge, Vivaldi, Opera, Brave), you can `run the Glasgow software within the browser <webusb_>`__. This functionality is experimental and has limitations and bugs that are not present when running natively on a desktop."
+msgstr ""
+
+#: ../../src/install.rst:13
+msgid "Initial setup"
+msgstr ""
+
+#: ../../src/install.rst:15
+msgid "A lot of care and effort has been put into making the use of the software stack as seamless as possible. In particular, every dependency where it is possible is shipped via the `Python package index <pypi_>`__ (including the USB driver and the FPGA toolchains) to make installation and upgrades as seamless as they can be."
+msgstr ""
+
+#: ../../src/install.rst:17
+msgid "If these instructions don't work for you, please `file a bug <file-a-bug_>`__ so that the experience can be improved for everyone."
+msgstr ""
+
+#: ../../src/install.rst:23
+msgid "You will need to have `git <git-lin_>`__, `Python <python-lin_>`__, and `pipx`_ installed. To install these, run:"
+msgstr ""
+
+#: ../../src/install.rst:32 ../../src/install.rst:41 ../../src/install.rst:50
+#: ../../src/install.rst:160 ../../src/install.rst:204
+msgid "The ``pipx ensurepath`` command may prompt you to reopen the terminal window; do so."
+msgstr ""
+
+#: ../../src/install.rst:60
+msgid "These instructions assume that `Eudev <https://wiki.alpinelinux.org/wiki/Eudev>`_ is used as the device manager. To install Eudev, run:"
+msgstr ""
+
+#: ../../src/install.rst:66 ../../src/install.rst:162 ../../src/install.rst:206
+msgid "Navigate to a convenient working directory and download the source code:"
+msgstr ""
+
+#: ../../src/install.rst:72
+msgid "Configure your system to allow access to the Glasgow hardware for anyone logged in to the physical terminal, and apply the rules to any devices that are already plugged in:"
+msgstr ""
+
+#: ../../src/install.rst:80 ../../src/install.rst:124 ../../src/install.rst:168
+#: ../../src/install.rst:212
+msgid "Install the Glasgow software for the current user:"
+msgstr ""
+
+#: ../../src/install.rst:86 ../../src/install.rst:130 ../../src/install.rst:174
+#: ../../src/install.rst:218
+msgid "To update the software to its newest revision, navigate to your working directory and run:"
+msgstr ""
+
+#: ../../src/install.rst:93 ../../src/install.rst:137 ../../src/install.rst:181
+#: ../../src/install.rst:225
+msgid "After setup, confirm that the Glasgow utility is operational by running:"
+msgstr ""
+
+#: ../../src/install.rst:100 ../../src/install.rst:144
+#: ../../src/install.rst:188 ../../src/install.rst:232
+msgid "Plug in your device and confirm that it is discovered by running:"
+msgstr ""
+
+#: ../../src/install.rst:109
+msgid "You will need to have `git <git-win_>`__, `Python <python-win_>`__, and `pipx`_ installed.  To install git and Python, follow the instructions from their respective pages. To install pipx, run:"
+msgstr ""
+
+#: ../../src/install.rst:116
+msgid "The ``py -3 -m pipx ensurepath`` command may prompt you to reopen the terminal window; do so."
+msgstr ""
+
+#: ../../src/install.rst:118
+msgid "Navigate to a convenient working directory (it is highly recommended to use a local directory, e.g. ``%LOCALAPPDATA%``, since running Glasgow software from a network drive or a roaming profile causes significant slowdown) and download the source code:"
+msgstr ""
+
+#: ../../src/install.rst:153
+msgid "You will need to have `libusb`_ and `pipx`_ installed. If you haven't already, install `Homebrew <https://brew.sh/>`_. To install those packages, run:"
+msgstr ""
+
+#: ../../src/install.rst:197
+msgid "You will need to have `pipx`_, `Yosys`_, `nextpnr`_, `icestorm`_, and `prjtrellis`_ installed. To install these packages, run:"
+msgstr ""
+
+#: ../../src/install.rst:253
+msgid "Using a system FPGA toolchain"
+msgstr ""
+
+#: ../../src/install.rst:255
+msgid "The steps above install the `YoWASP`_ FPGA toolchain, which is a good low-friction option, especially for people whose primary competence is not in software, since it does not require any additional installation steps. However, the YoWASP toolchain is noticeably slower compared to a native code code toolchain (usually by a factor of less than 2×). The YoWASP toolchain is also not available for all platforms and architectures; notably, 32-bit Raspberry Pi is not covered."
+msgstr ""
+
+#: ../../src/install.rst:257
+msgid "If you already have the required tools (``yosys``, ``nextpnr-ice40``, ``nextpnr-ecp5``, ``icepack``, ``ecppack``) installed or are willing to `install <oss-cad-suite_>`__ them, you can update your profile to set the environment variable ``GLASGOW_TOOLCHAIN`` to ``system,builtin``, which prioritizes using the system tools over the YoWASP tools. The default value is ``builtin,system``, which causes the system tools to be used only if the YoWASP tools are not present or not runnable."
+msgstr ""
+
+#: ../../src/install.rst:264
+msgid "Developing the Glasgow software"
+msgstr ""
+
+#: ../../src/install.rst:266
+msgid "The steps above install the Glasgow software using ``pipx install -e``, which performs an *editable install*: changes to the downloaded source code modify the behavior of the next invocation of the ``glasgow`` tool. Changes to ``pyproject.toml``, most importantly to the dependencies or list of applet entrypoints, are not picked up until ``pipx reinstall`` is manually run."
+msgstr ""
+
+#: ../../src/install.rst:268
+msgid "If you want to have your global Glasgow installation be independent from the source code check-out, you can omit the ``-e`` argument in the instructions above. You can use any way of managing virtual environments for your development workflow, but we use and recommend `PDM`_."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/intro.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/intro.po
@@ -1,0 +1,276 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/intro.rst:-1
+msgid "Glasgow Interface Explorer"
+msgstr ""
+
+#: ../../src/intro.rst:-1
+msgid "website"
+msgstr ""
+
+#: ../../src/intro.rst:-1
+msgid "https://glasgow-embedded.org/"
+msgstr ""
+
+#: ../../src/intro.rst:-1
+msgid "A highly capable and extremely flexible open source multitool for digital electronics"
+msgstr ""
+
+#: ../../src/intro.rst:-1
+msgid "https://www.crowdsupply.com/img/f9a9/glasgow-revc2_jpg_open-graph.jpg"
+msgstr ""
+
+#: ../../src/intro.rst:-1
+msgid "A Glasgow Interface Explorer PCB, without a case "
+msgstr ""
+
+#: ../../src/intro.rst:-1
+msgid "summary_large_image"
+msgstr ""
+
+#: ../../src/intro.rst:-1
+msgid "https://www.crowdsupply.com/img/f9a9/glasgow-revc2_jpg_project-main.jpg"
+msgstr ""
+
+#: ../../src/intro.rst:-1
+msgid "A Glasgow Interface Explorer PCB, without a case"
+msgstr ""
+
+#: ../../src/intro.rst:23
+msgid "Introduction"
+msgstr ""
+
+#: ../../src/intro.rst
+msgid "Glasgow Interface Explorer, in a black anodized aluminum case"
+msgstr ""
+
+#: ../../src/intro.rst
+msgid "Open Source Hardware Association mark, project UK000081"
+msgstr ""
+
+#: ../../src/intro.rst:37
+msgid "What is Glasgow?"
+msgstr ""
+
+#: ../../src/intro.rst:39
+msgid "Glasgow Interface Explorer is an `open hardware <oshwa-cert_>`__ tool for exploring digital interfaces, aimed at embedded developers, reverse engineers, digital archivists, electronics hobbyists, and everyone else who wants to communicate with a wide range of digital devices with high reliability and minimum hassle. It can be connected to most digital interfaces without additional active or passive components, and includes extensive protection from unexpected conditions and operator error."
+msgstr ""
+
+#: ../../src/intro.rst:41
+msgid "The Glasgow hardware can support many digital interfaces because it uses reconfigurable logic. Instead of only offering a small selection of standard hardware supported interfaces, it uses an FPGA to adapt on the fly to the task at hand without compromising on performance or reliability, even for unusual, custom, or obsolete interfaces."
+msgstr ""
+
+#: ../../src/intro.rst:43
+msgid "The Glasgow software is a set of building blocks designed to eliminate incidental complexity. Each interface is packaged into a self-contained applet that can be used directly from the command line, or reused as a part of a more complex system. Using Glasgow does not require any programming knowledge, although it becomes much more powerful if you know a bit of Python."
+msgstr ""
+
+#: ../../src/intro.rst:-1
+msgid "Bare Glasgow Interface Explorer PCB assembly"
+msgstr ""
+
+#: ../../src/intro.rst:52
+msgid "What can I do with Glasgow?"
+msgstr ""
+
+#: ../../src/intro.rst:54
+msgid "control pins as :ref:`GPIO <applet.control.gpio>`"
+msgstr ""
+
+#: ../../src/intro.rst:56
+msgid "communicate via :ref:`UART <applet.interface.uart>`"
+msgstr ""
+
+#: ../../src/intro.rst:58
+msgid "automatically measure and adjust baud rate"
+msgstr ""
+
+#: ../../src/intro.rst:60
+msgid "analyze :ref:`UART <applet.interface.uart_analyzer>` transactions"
+msgstr ""
+
+#: ../../src/intro.rst:62
+msgid "initiate :ref:`SPI <applet.interface.spi_controller>`, :ref:`QSPI <applet.interface.qspi_controller>`, or :ref:`I²C <applet.interface.i2c_controller>` transactions"
+msgstr ""
+
+#: ../../src/intro.rst:64
+msgid "analyze :ref:`SPI <applet.interface.spi_analyzer>` and :ref:`QSPI <applet.interface.qspi_analyzer>` transactions at up to ~100 MHz"
+msgstr ""
+
+#: ../../src/intro.rst:66
+msgid "read and write :ref:`24-series I²C EEPROMs <applet.memory._24x>`"
+msgstr ""
+
+#: ../../src/intro.rst:68
+msgid "read and write :ref:`25-series SPI Flash memories <applet.memory._25q>`"
+msgstr ""
+
+#: ../../src/intro.rst:70
+msgid "determine memory parameters via SFDP"
+msgstr ""
+
+#: ../../src/intro.rst:72
+msgid ":ref:`extract data and SFDP information <applet.memory._25q.tool>` from SPI transaction captures"
+msgstr ""
+
+#: ../../src/intro.rst:74
+msgid "read and write ONFI-compatible Flash memories"
+msgstr ""
+
+#: ../../src/intro.rst:76
+msgid "determine memory parameters via ONFI parameter page"
+msgstr ""
+
+#: ../../src/intro.rst:78
+msgid "read and write parallel 27/28/29-series EPROMs, EEPROMs and Flash memories"
+msgstr ""
+
+#: ../../src/intro.rst:80
+msgid "determine the extent of floating gate charge decay and rescue data"
+msgstr ""
+
+#: ../../src/intro.rst:82
+msgid ":ref:`program and verify AVR microcontrollers <applet.program.avr.spi>` via SPI"
+msgstr ""
+
+#: ../../src/intro.rst:84
+msgid "automatically :ref:`determine JTAG pinout <applet.interface.jtag_pinout>`"
+msgstr ""
+
+#: ../../src/intro.rst:86
+msgid "probe `IEEE 1149.1`_ compatible devices via :ref:`JTAG <applet.interface.jtag_probe>`"
+msgstr ""
+
+#: ../../src/intro.rst:88
+msgid "play back JTAG :ref:`SVF files <applet.interface.jtag_svf>`"
+msgstr ""
+
+#: ../../src/intro.rst:90
+msgid ":ref:`debug ARM7TDMI processors <applet.debug.arm.arm7>` via JTAG"
+msgstr ""
+
+#: ../../src/intro.rst:92
+msgid ":ref:`debug ARC processors <applet.debug.arc>` via JTAG"
+msgstr ""
+
+#: ../../src/intro.rst:94
+msgid ":ref:`debug MIPS processors <applet.debug.mips>` via EJTAG"
+msgstr ""
+
+#: ../../src/intro.rst:96
+msgid "program and verify :ref:`XC9500 <applet.program.xc9500>` and :ref:`XC9500XL <applet.program.xc9500xl>` CPLDs via JTAG"
+msgstr ""
+
+#: ../../src/intro.rst:98
+msgid ":ref:`expose JTAG to Vivado <applet.bridge.jtag_xvc>`"
+msgstr ""
+
+#: ../../src/intro.rst:100
+msgid "probe Arm Cortex processors via :ref:`SWD <applet.interface.swd_probe>`"
+msgstr ""
+
+#: ../../src/intro.rst:102
+msgid ":ref:`debug Arm Cortex processors <applet.bridge.probe_rs>` via `probe-rs <https://probe.rs>`_"
+msgstr ""
+
+#: ../../src/intro.rst:104
+msgid "program :ref:`internal SRAM <applet.program.ice40_sram>` and :ref:`external Flash <applet.program.ice40_flash>` memories of iCE40 FPGAs"
+msgstr ""
+
+#: ../../src/intro.rst:106
+msgid ":ref:`configure Ethernet PHYs  <applet.control.mdio>` via MDIO"
+msgstr ""
+
+#: ../../src/intro.rst:108
+msgid ":ref:`communicate using nRF24L01(+) radios <applet.radio.nrf24l01>`"
+msgstr ""
+
+#: ../../src/intro.rst:110
+msgid ":ref:`program nRF24LE1 and nRF24LU1(+) microcontrollers <applet.program.nrf24lx1>`"
+msgstr ""
+
+#: ../../src/intro.rst:112
+msgid "sense environmental data"
+msgstr ""
+
+#: ../../src/intro.rst:114
+msgid "temperature, pressure, and humidity via :ref:`Bosch BMP280/BME280 <applet.sensor.bmx280>` sensors"
+msgstr ""
+
+#: ../../src/intro.rst:116
+msgid "CO₂ concentration via Sensirion :ref:`SCD30 <applet.sensor.scd30>` and NOx concentration via :ref:`SEN5x <applet.sensor.sen5x>` sensors"
+msgstr ""
+
+#: ../../src/intro.rst:118
+msgid "distance by ultrasonic echo via :ref:`HC-SR04 <applet.sensor.hcsr04>` sensors"
+msgstr ""
+
+#: ../../src/intro.rst:120
+msgid "weight by Whetstone bridge via :ref:`HX-711 <applet.sensor.hx711>` amplifier"
+msgstr ""
+
+#: ../../src/intro.rst:122
+msgid "synthesize sound using a Yamaha OPLx/OPM chip and play it in real time on a webpage"
+msgstr ""
+
+#: ../../src/intro.rst:124
+msgid "read raw modulated data from 5.25\"/3.5\" floppy drives"
+msgstr ""
+
+#: ../../src/intro.rst:126
+msgid "... and more!"
+msgstr ""
+
+#: ../../src/intro.rst:128
+msgid "Everything above can be done with only a Glasgow revC board, some wires, and depending on the device under test, external power."
+msgstr ""
+
+#: ../../src/intro.rst:134
+msgid "What does using Glasgow look like?"
+msgstr ""
+
+#: ../../src/intro.rst:136
+msgid "This screencast shows a typical command-line workflow:"
+msgstr ""
+
+#: ../../src/intro.rst:143
+msgid "What software does Glasgow use?"
+msgstr ""
+
+#: ../../src/intro.rst:145
+msgid "Glasgow is written entirely in `Python 3`_. The interface logic that runs on the FPGA is described using `Amaranth`_, which is a Python-based domain specific language. The supporting code that runs on the host PC is written in Python with `asyncio`_. This way, the logic on the FPGA can be assembled on demand for any requested configuration, keeping it as fast and compact as possible, and code can be shared between gateware and software, removing the need to add error-prone \"glue\" boilerplate."
+msgstr ""
+
+#: ../../src/intro.rst:147
+msgid "Glasgow would not be possible without the `open-source iCE40 FPGA toolchain <icestorm_>`__, which is not only very reliable but also extremely fast. It is so fast that it usually only takes a few seconds to build a bitstream from scratch for something like a UART. When developing a new applet it is rarely necessary to wait for the toolchain to finish."
+msgstr ""
+
+#: ../../src/intro.rst:149
+msgid "Implementing reliable, high-performance USB communication is not trivial—packetization, buffering, and USB quirks add up. Glasgow abstracts away USB: on the FPGA, the applet gateware writes to or reads from a FIFO, and on the host, applet software writes to or reads from a socket-like interface. Idiomatic Python code can communicate at maximum USB 2 bulk bandwidth on a modern PC without additional effort. Moreover, when a future Glasgow revision adds Ethernet next to USB, no changes to applet code will be necessary."
+msgstr ""
+
+#: ../../src/intro.rst:151
+msgid "Debugging applets can be hard, especially if bidirectional communication over the same wires is involved. Glasgow provides a built-in cycle-accurate logic analyzer that can relate the I/O pin level and direction changes to commands and responses received and sent by the applet. The logic analyzer compresses waveforms and can pause the applet if its buffer is about to overflow."
+msgstr ""
+
+#: ../../src/intro.rst:155
+msgid "The built-in logic analyzer has been removed from the codebase pending internal architecture improvements. It will be reinstated once a high-quality implementation becomes feasible."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/library/index.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/library/index.po
@@ -1,0 +1,36 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/library/index.rst:2
+msgid "Reusable library"
+msgstr ""
+
+#: ../../src/library/index.rst:4
+msgid "The Glasgow reusable library provides implementations of protocols, algorithms, and other useful tools that are necessary for an applet and are common enough in embedded development to document and share."
+msgstr ""
+
+#: ../../src/library/index.rst:8
+msgid "**No API stability guarantees whatsoever are provided.** This reusable library is designed to be easy to copy and paste piecemeal into other projects; you should do so if you need stability. We *can* and *will* make cross-cutting changes to interfaces here, synchronized with the in-tree applets."
+msgstr ""
+
+#: ../../src/library/index.rst:12
+msgid "Note that not every library module is documented here yet."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/library/support/progress.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/library/support/progress.po
@@ -1,0 +1,141 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/library/support/progress.rst:2
+msgid "``support.progress``"
+msgstr ""
+
+#: glasgow.support.progress.Progress:1 of
+msgid "Progress tracker."
+msgstr ""
+
+#: glasgow.support.progress.Progress:3 of
+msgid "This context manager is used to indicate progress of a slow process within applet code in a generic way, decoupling it from a specific type of user interface. For example, if an applet is used with a CLI frontend, terminal escape sequences could be used to repeatedly display a text description on the last used line, whereas with a GUI frontend, a progress bar widget would be used."
+msgstr ""
+
+#: glasgow.support.progress.Progress:9 of
+msgid "To use it, modify applet code that processes multiple items by wrapping it in :py:`with Progress(...):`. For example, let's consider a method that uploads a bitstream via :class:`SPIControllerInterface<glasgow.applet.interface.spi_controller.SPIControllerInterface>`:"
+msgstr ""
+
+#: glasgow.support.progress.Progress:19 of
+msgid "To add progress indication here, the bitstream will need to be explicitly chunked (while avoiding copies using :class:`memoryview`) and individual chunks iterated through:"
+msgstr ""
+
+#: glasgow.support.progress.Progress:37 of
+msgid "The :py:`synchronize()` call is added because the :py:`write()` method does not wait for the operation to complete; without it, the :py:`load()` method would quickly finish, with the command buffer draining slowly after. In most cases (e.g. Flash programming) there is a requirement to wait for feedback, making explicit synchronization unnecessary."
+msgstr ""
+
+#: glasgow.support.progress.Progress:42 of
+msgid "The particluar case of chunking a sequence (of bytes, or otherwise) is common enough that this class provides a helper method for it, :meth:`chunks`. Using this helper the :py:`load()` function becomes:"
+msgstr ""
+
+#: glasgow.support.progress.Progress:55 of
+msgid "With this change to the applet code, a CLI frontend can now indicate the progress of the operation, for example, by printing:"
+msgstr ""
+
+#: glasgow.support.progress.Progress.chunks:1 of
+msgid "Chunked progress tracker."
+msgstr ""
+
+#: glasgow.support.progress.Progress.chunks:3 of
+msgid "This helper method exists to handle the case where a sequence must be brought into chunks for processing, but progress must be tracked per-item, not per-chunk. For example, when manipulating large byte sequences, it would be too inefficient to process bytes one by one just to report progress, but processing 64 KiB chunks is usually fine."
+msgstr ""
+
+#: glasgow.support.progress.Progress.chunks:8 of
+msgid "All keyword arguments not explicitly declared are passed to the class constructor. Returns a :term:`python:generator` yielding the result of indexing slices of :py:`items` up to :py:`chunk_size` in length, and advancing progress whenever control is returned. If :py:`len(items) <= chunk_size`, progress indication is omitted entirely."
+msgstr ""
+
+#: glasgow.support.progress.Progress.chunks:13 of
+msgid "To split a byte array into chunks of up to :py:`chunk_size`, such as for a write operation, use:"
+msgstr ""
+
+#: glasgow.support.progress.Progress.chunks:22 of
+msgid "To split an address range into chunks of up to :py:`chunk_size`, such as for a read operation, use:"
+msgstr ""
+
+#: glasgow.support.progress.Progress.chunks:33 of
+msgid "Avoid passing :class:`bytes` or :class:`bytearray` values as :py:`items`; wrap them in :class:`memoryview` so that chunks reference the original bytes instead of copying."
+msgstr ""
+
+#: glasgow.support.progress.Progress.action:1 of
+msgid "Action taking progress."
+msgstr ""
+
+#: glasgow.support.progress.Progress.action:3 of
+msgid "Should have a `present participle` with no punctuation at the end, e.g. :py:`\"writing\"` or :py:`\"programming flash\"`."
+msgstr ""
+
+#: glasgow.support.progress.Progress.item:1 of
+msgid "Item being operated on."
+msgstr ""
+
+#: glasgow.support.progress.Progress.item:3 of
+msgid "Should be a singular noun, e.g. :py:`\"byte\"` or :py:`\"B\"`. If :py:`None`, then the unit of processing is unspecified: either clear from context, or not feasible to specify exactly."
+msgstr ""
+
+#: glasgow.support.progress.Progress.scale:1 of
+msgid "Scale of item count."
+msgstr ""
+
+#: glasgow.support.progress.Progress.scale:3 of
+msgid "May be one of 1, 1000, or 1024. If not 1, an appropriate SI prefix (K, M, G... or Ki, Mi, Gi...) will be used when counting items."
+msgstr ""
+
+#: glasgow.support.progress.Progress.total:1 of
+msgid "Total number of items."
+msgstr ""
+
+#: glasgow.support.progress.Progress.total:3 of
+msgid "If :py:`None`, impossible to know until the operation finishes."
+msgstr ""
+
+#: glasgow.support.progress.Progress.done:1 of
+msgid "Number of completed items."
+msgstr ""
+
+#: glasgow.support.progress.Progress.advance:1 of
+msgid "Indicate completion of :py:`count` items."
+msgstr ""
+
+#: glasgow.support.progress.Progress.advance:3 of
+msgid "Advancing progress beyond :py:`self.total` completed items may result in confusing UI behavior, but will not raise errors. However, :py:`count` must not be negative."
+msgstr ""
+
+#: glasgow.support.progress.Progress.__enter__:1 of
+msgid "Register the progress indicator."
+msgstr ""
+
+#: glasgow.support.progress.Progress.__enter__:3 of
+msgid "Adds :py:`self` to the stack of displayed progress indicators."
+msgstr ""
+
+#: glasgow.support.progress.Progress.__enter__:5
+#: glasgow.support.progress.Progress.__exit__:5 of
+msgid "This :term:`python:dunder` method is called implicitly by the :py:`with Progress(...):` block."
+msgstr ""
+
+#: glasgow.support.progress.Progress.__exit__:1 of
+msgid "Unregister the progress indicator."
+msgstr ""
+
+#: glasgow.support.progress.Progress.__exit__:3 of
+msgid "Removes :py:`self` from the stack of displayed progress indicators."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/license.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/license.po
@@ -1,0 +1,40 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/license.rst:2
+msgid "License"
+msgstr ""
+
+#: ../../src/license.rst:4
+msgid "The Glasgow Interface Explorer source code, documentation, and design files are distributed under a choice of two licenses: 0-clause BSD and Apache 2.0."
+msgstr ""
+
+#: ../../src/license.rst:6
+msgid "Catherine \"whitequark\", who has started the project, opposes copyright on moral and philosophical grounds, and the choice of the 0-clause BSD license reflects that. In addition, the Apache 2.0 license includes a patent grant, which protects manufacturers of open hardware from litigation."
+msgstr ""
+
+#: ../../src/license.rst:10
+msgid "0-clause BSD"
+msgstr ""
+
+#: ../../src/license.rst:17
+msgid "Apache 2"
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/purchase.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/purchase.po
@@ -1,0 +1,48 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/purchase.rst:4
+msgid "Purchasing hardware"
+msgstr ""
+
+#: ../../src/purchase.rst:6
+msgid "Pre-assembled Glasgow devices and cases are available for purchase from the stores listed below."
+msgstr ""
+
+#: ../../src/purchase.rst:8
+msgid "`CrowdSupply`_"
+msgstr ""
+
+#: ../../src/purchase.rst:9
+msgid "`1BitSquared USA`_"
+msgstr ""
+
+#: ../../src/purchase.rst:10
+msgid "`1BitSquared Germany`_"
+msgstr ""
+
+#: ../../src/purchase.rst:11
+msgid "`Mouser`_"
+msgstr ""
+
+#: ../../src/purchase.rst:18
+msgid "As Glasgow is open hardware, you also have the option of :ref:`building a device yourself <build>`!"
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/revisions/index.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/revisions/index.po
@@ -1,0 +1,112 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/revisions/index.rst:2
+msgid "Hardware revisions"
+msgstr ""
+
+#: ../../src/revisions/index.rst:6
+msgid "The devices manufactured by 1BitSquared and :ref:`sold by CrowdSupply and Mouser <purchasing>` use the hardware revision `revC3`_."
+msgstr ""
+
+#: ../../src/revisions/index.rst:8
+msgid "The Glasgow hardware evolves over time, with each major milestone called a \"revision\". Although all revisions are, and will always be supported with the latest software stack, they vary significantly in their capabilities, and the revision that is being used will determine which tasks can be achieved using the hardware."
+msgstr ""
+
+#: ../../src/revisions/index.rst:10
+msgid "Glasgow hardware revisions use the ``revXN`` format, where ``X`` is a revision letter (advanced alphabetically when major design changes are made) and ``N`` is a stepping number (incremented on any layout or component changes). For example, ``revC0`` is the first stepping of revision C."
+msgstr ""
+
+#: ../../src/revisions/index.rst:14
+msgid "Technical descriptions"
+msgstr ""
+
+#: ../../src/revisions/index.rst:16
+msgid "In-depth technical descriptions are available for certain hardware revisions:"
+msgstr ""
+
+#: ../../src/revisions/index.rst:27
+msgid "revD"
+msgstr ""
+
+#: ../../src/revisions/index.rst:29
+msgid "Revision D is the latest revision, currently in `pre-launch stage on CrowdSupply <https://www.crowdsupply.com/fully-automated/glasgow-interface-explorer-revd>`_. It provides 32 I/O pins with a data rate up to approx. 100 Mbps/pin (50 MHz) [#]_, independent direction control and independently programmable pull-up/pull-down resistors. The I/O pins are grouped into four I/O ports, each of which can use any I/O standard from 1.2 V to 5 V, sense and monitor I/O voltage of the device under test, provide up to 300 mA of power, and measure analog voltages on two dedicated pins (single-ended or differential; 24 bit @ 500 kSPS across all enabled channels). The board uses USB 2 for power, configuration, and communication, achieving up to 336 Mbps (42 MB/s) of sustained combined throughput. Except for USB connectivity, every aspect of the device has been significantly improved compared to revC."
+msgstr ""
+
+#: ../../src/revisions/index.rst:31 ../../src/revisions/index.rst:77
+msgid "Data rate achievable in practice depends on many factors and will vary greatly with specific interface and applet design. 12 Mbps/pin (6 MHz) can be achieved with minimal development effort; reaching higher data rates requires careful HDL coding and a good understanding of timing analysis."
+msgstr ""
+
+#: ../../src/revisions/index.rst:41
+msgid "revC"
+msgstr ""
+
+#: ../../src/revisions/index.rst:43
+msgid "Revision C was first mass produced by `1bitSquared`_ at stepping ``revC3``. It provides 16 I/O pins with a data rate up to approx. 100 Mbps/pin (50 MHz) [#]_, independent direction control and independently programmable pull-up/pull-down resistors. The I/O pins are grouped into two I/O ports, each of which can use any I/O standard from 1.8 V to 5 V, sense and monitor I/O voltage of the device under test, as well as provide up to 150 mA of power. The board uses USB 2 for power, configuration, and communication, achieving up to 336 Mbps (42 MB/s) of sustained combined throughput."
+msgstr ""
+
+#: ../../src/revisions/index.rst
+msgid "Overview of the Glasgow PCB (front)"
+msgstr ""
+
+#: ../../src/revisions/index.rst
+msgid "Overview of the Glasgow PCB (back)"
+msgstr ""
+
+#: ../../src/revisions/index.rst
+msgid "Description of functional blocks on the Glasgow PCB"
+msgstr ""
+
+#: ../../src/revisions/index.rst:62 ../../src/revisions/index.rst:88
+msgid "Design and fabrication files are located in the Git repository:"
+msgstr ""
+
+#: ../../src/revisions/index.rst:64
+msgid "`revC0 (design) <https://github.com/GlasgowEmbedded/glasgow/tree/revC0/hardware/boards/glasgow>`_, `revC0 (schematics) <https://github.com/GlasgowEmbedded/glasgow/blob/main/hardware/boards/glasgow/revC0/schematics.pdf>`_, `revC0 (fabrication) <https://github.com/GlasgowEmbedded/glasgow/tree/main/hardware/boards/glasgow/revC0>`_."
+msgstr ""
+
+#: ../../src/revisions/index.rst:67
+msgid "`revC1 (design) <https://github.com/GlasgowEmbedded/glasgow/tree/revC1/hardware/boards/glasgow>`_, `revC1 (schematics) <https://github.com/GlasgowEmbedded/glasgow/blob/main/hardware/boards/glasgow/revC1/schematics.pdf>`_, `revC1 (fabrication) <https://github.com/GlasgowEmbedded/glasgow/tree/main/hardware/boards/glasgow/revC1>`_."
+msgstr ""
+
+#: ../../src/revisions/index.rst:70
+msgid "`revC2 (design) <https://github.com/GlasgowEmbedded/glasgow/tree/revC2/hardware/boards/glasgow>`_, `revC2 (schematics) <https://github.com/GlasgowEmbedded/glasgow/blob/main/hardware/boards/glasgow/revC2/schematics.pdf>`_, `revC2 (fabrication) <https://github.com/GlasgowEmbedded/glasgow/tree/main/hardware/boards/glasgow/revC2>`_."
+msgstr ""
+
+#: ../../src/revisions/index.rst:73
+msgid "`revC3 (design) <https://github.com/GlasgowEmbedded/glasgow/tree/revC3/hardware/boards/glasgow>`_, `revC3 (schematics) <https://github.com/GlasgowEmbedded/glasgow/blob/main/hardware/boards/glasgow/revC3/schematics.pdf>`_, `revC3 (fabrication) <https://github.com/GlasgowEmbedded/glasgow/tree/main/hardware/boards/glasgow/revC3>`_."
+msgstr ""
+
+#: ../../src/revisions/index.rst:84
+msgid "revA, revB"
+msgstr ""
+
+#: ../../src/revisions/index.rst:86
+msgid "Revisions A and B have not been produced in significant numbers, have major design issues, and are therefore mostly of historical interest. Nevertheless, anyone who has one of the revA/revB boards can keep using them—forever."
+msgstr ""
+
+#: ../../src/revisions/index.rst:90
+msgid "`revA (design) <https://github.com/GlasgowEmbedded/glasgow/tree/revA/hardware/boards/glasgow>`_, `revA (schematics) <https://github.com/GlasgowEmbedded/glasgow/blob/main/hardware/boards/glasgow/revA/schematics.pdf>`_, `revA (fabrication) <https://github.com/GlasgowEmbedded/glasgow/tree/main/hardware/boards/glasgow/revA>`_."
+msgstr ""
+
+#: ../../src/revisions/index.rst:93
+msgid "`revB (design) <https://github.com/GlasgowEmbedded/glasgow/tree/revB/hardware/boards/glasgow>`_, `revB (schematics) <https://github.com/GlasgowEmbedded/glasgow/blob/main/hardware/boards/glasgow/revB/schematics.pdf>`_, `revB (fabrication) <https://github.com/GlasgowEmbedded/glasgow/tree/main/hardware/boards/glasgow/revB>`_."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/revisions/revC3.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/revisions/revC3.po
@@ -1,0 +1,1479 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/revisions/revC3.rst:2
+msgid "Technical description (revC3)"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:4
+msgid "This document provides a technical description of the Glasgow revC3 hardware."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:10
+msgid "Power"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:12
+msgid "Glasgow is powered by its USB-C connection. The input voltage is 5.0 V and the typical operating current is 500 mA or less. For reliable and safe operation we recommend that you power Glasgow from a standard USB port capable of providing at least 1.0 A at 5.0 V."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:14
+msgid "Some non-standards-compliant USB ports, such as those found on certain powered USB hubs, may provide more than 3.0 A of current at 5.0 V on their ports without active negotiation. While powering Glasgow from these ports is absolutely fine under all but the rarest circumstances, such non-compliant high-current USB power sources may not implement proper overcurrent protection. Such supplies carry a greater risk of damage to the board and its components in the rare event that the USB-C connector on Glasgow becomes damaged and a short develops between VBUS and GND. Shorts anywhere elsewhere on the board should be protected by overcurrent detection and protection features built into Glasgow's design. These protection features are discussed elsewhere in this document."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:16
+msgid "Since Glasgow draws less than 1.0 A of current at all times, it does not benefit from non-standards-compliant high-current USB ports."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:18
+msgid "The USB-C connector shield is connected to ground via a 100 nF capacitor and 100 kΩ resistor in parallel. The plated mounting holes in the four corners of the board are grounded."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:24
+msgid "+5V rail"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:26
+msgid "The +5V rail is the input power rail for Glasgow. You can measure this rail using the 5V test points on the front and rear of the board."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:28
+msgid "The +5V rail is derived from VUSB without additional regulation - as such, you should expect some variance in the +5V rail voltage depending on the power source and USB cable that you are using."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:30
+msgid "A BLM15PX601SZ1 ferrite bead (FB1) is inserted in series with VUSB with the intention of reducing conducted emissions onto the USB cable. Its maximum DC series resistance is 230 mΩ and its impedance at 100 MHz is 600 Ω. This ferrite bead also acts as a makeshift fuse in the event that either U15 or C8 fail short and the upstream USB supply does not implement proper overcurrent protection."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:32
+msgid "A TPD3S014 current limit switch IC (U15) is inserted between VUSB and the +5V rail, and enforces a maximum current of 850 mA. There is a 150 uF aluminium electrolytic capacitor on the +5V rail for bulk decoupling and brownout protection. As such, you should expect up to 850 mA of inrush current for a brief period when you plug Glasgow in. Continuous operating current should not exceed 500 mA under normal circumstances."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:34
+msgid "The +5V rail is monitored by an APX811-40UG-7 supervisor IC. The supervisor has a nominal undervoltage threshold of 4.0 V. If the +5V rail drops below this threshold, the +3.3V regulator is disabled and ``CY_RESET`` is asserted to hold the Cypress FX2 USB controller IC (U1) in a reset state."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:36
+msgid "The +5V rail is used to power the following devices:"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:39 ../../src/revisions/revC3.rst:65
+#: ../../src/revisions/revC3.rst:150 ../../src/revisions/revC3.rst:161
+#: ../../src/revisions/revC3.rst:411 ../../src/revisions/revC3.rst:457
+msgid "Designator"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:39 ../../src/revisions/revC3.rst:65
+#: ../../src/revisions/revC3.rst:150 ../../src/revisions/revC3.rst:161
+#: ../../src/revisions/revC3.rst:411 ../../src/revisions/revC3.rst:457
+msgid "Part"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:39 ../../src/revisions/revC3.rst:65
+#: ../../src/revisions/revC3.rst:150 ../../src/revisions/revC3.rst:161
+msgid "Function / Notes"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:41
+msgid "U7"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:41
+msgid "APX811-40UG-7"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:41
+msgid "+5V rail supervisor and reset (triggered by reset button)"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:43
+msgid "U8"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:43
+msgid "TLV75533PDRVR"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:43
+msgid "3.3 V, 500 mA linear regulator for generating +3.3V rail"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:45
+msgid "U36"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:45
+msgid "TLV73312PQDRVR"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:45
+msgid "1.2 V, 300 mA linear regulator for generating +1.2V rail"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:47
+msgid "U31"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:47 ../../src/revisions/revC3.rst:49
+msgid "TPS73101DBV"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:47
+msgid "Adjustable linear regulator for generating VIO on port A"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:49
+msgid "U14"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:49
+msgid "Adjustable linear regulator for generating VIO on port B"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:56
+msgid "+3.3V rail"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:58
+msgid "The +3.3V rail is used to power most ICs on the board. You can measure this rail using the 3V3 test points on the front and rear of the board. The green PWR LED on the front of the board is powered by the +3.3V rail."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:60
+msgid "The +3.3V rail is derived from the +5V rail using a TLV75533PDRVR linear voltage regulator (U8). The regulator has a maximum output current of 500 mA. The regulator's EN pin is driven by an APX811-40UG-7 supervisor IC (U7) which monitors the +5V rail for stability; in the event that the +5V rail does not meet the required threshold, U7's reset signal will disable the +3.3V regulator."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:62
+msgid "The +3.3V rail is used to power the following devices:"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:67 ../../src/revisions/revC3.rst:413
+msgid "D1"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:67 ../../src/revisions/revC3.rst:413
+#: ../../src/revisions/revC3.rst:433 ../../src/revisions/revC3.rst:435
+msgid "NCD0603G1"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:67
+msgid "Green \"PWR\" LED on front of board"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:69 ../../src/revisions/revC3.rst:423
+msgid "U1"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:69
+msgid "CY7C68013A-56LTX"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:69
+msgid "Cypress FX2 HS USB controller. +3.3V rail powers VCC, AVCC"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:71 ../../src/revisions/revC3.rst:425
+#: ../../src/revisions/revC3.rst:459
+msgid "U2"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:71 ../../src/revisions/revC3.rst:459
+msgid "CAT24M01X"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:71
+msgid "I2C 1Mbit serial EEPROM for iCE40"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:73 ../../src/revisions/revC3.rst:427
+#: ../../src/revisions/revC3.rst:461
+msgid "U3"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:73 ../../src/revisions/revC3.rst:461
+msgid "BL24C256A-SFRC"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:73
+msgid "I2C 256Kbit serial EEPROM for FX2"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:75 ../../src/revisions/revC3.rst:165
+#: ../../src/revisions/revC3.rst:431 ../../src/revisions/revC3.rst:473
+msgid "U5"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:75 ../../src/revisions/revC3.rst:83
+#: ../../src/revisions/revC3.rst:154 ../../src/revisions/revC3.rst:165
+#: ../../src/revisions/revC3.rst:467 ../../src/revisions/revC3.rst:473
+msgid "PCA6408APW"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:75
+msgid "I2C I/O expander for programmable pullup/pulldown resistors on port B. +3.3V powers I2C supply"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:77 ../../src/revisions/revC3.rst:152
+msgid "U4, U6, U9, U10, U11, U16, U17, U18"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:77 ../../src/revisions/revC3.rst:89
+#: ../../src/revisions/revC3.rst:93 ../../src/revisions/revC3.rst:152
+#: ../../src/revisions/revC3.rst:163
+msgid "SN74LVC1T45DCKR"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:77
+msgid "Logic level translators for port A. +3.3V powers internal side (VCCA)"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:79 ../../src/revisions/revC3.rst:471
+msgid "U12"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:79 ../../src/revisions/revC3.rst:87
+#: ../../src/revisions/revC3.rst:465 ../../src/revisions/revC3.rst:471
+msgid "INA233"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:79
+msgid "Voltage/current measurement IC for port B."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:81 ../../src/revisions/revC3.rst:469
+msgid "U13"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:81 ../../src/revisions/revC3.rst:85
+#: ../../src/revisions/revC3.rst:463 ../../src/revisions/revC3.rst:469
+msgid "DAC081C081CIMK"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:81
+msgid "I2C DAC for programming VIO voltage on port B."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:83 ../../src/revisions/revC3.rst:154
+#: ../../src/revisions/revC3.rst:467
+msgid "U19"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:83
+msgid "I2C I/O expander for programmable pullup/pulldown resistors on port A. +3.3V powers I2C supply"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:85 ../../src/revisions/revC3.rst:463
+msgid "U20"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:85
+msgid "I2C DAC for programming VIO voltage on port A"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:87 ../../src/revisions/revC3.rst:465
+msgid "U21"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:87
+msgid "Voltage/current measurement IC for port A."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:89 ../../src/revisions/revC3.rst:163
+msgid "U22, U23, U24, U25, U26, U27, U28, U29"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:89
+msgid "Logic level translators for port B. +3.3V powers internal side (VCCA)"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:91
+msgid "U30"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:91
+msgid "ICE40HX8K-BG121"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:91
+msgid "iCE40 FPGA. +3.3V rail powers VCCIO_x, VPP_2V5, VCC_SPI"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:93
+msgid "U32"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:93
+msgid "Logic level translator for SYNC input/output connector. +3.3V powers internal side (VCCA)"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:100
+msgid "+1.2V rail"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:102
+msgid "The +1.2V rail is used to power the iCE40 FPGA (VCC and VCCPLL0/1). You can measure this rail using the 1V2 test points on the front and back of the board."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:104
+msgid "The +1.2V rail is derived from the +5V rail using a TLV73312PQDRVR linear voltage regulator (U36). The regulator has a maximum output current of 300 mA. The regulator's EN pin is tied directly to the +5V rail. The regulator enters dropout mode when the +5V rail reaches approximately 1.3 V, and enters normal operation once the +5V rail reaches approximately 1.65 V."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:106
+msgid "The VCCPLL0 and VCCPLL1 supplies are low-pass filtered using a 100 Ω resistor and 4.7 uF capacitor, resulting in a -3 dB cutoff frequency of approximately 340 Hz."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:112
+msgid "VIO rails"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:114
+msgid "There are two main independent VIO rails - one for port A, and one for port B. These rails are adjustable and set the IO voltage levels for the ports. Each VIO rail voltage can be independently configured, which allows you to work with different logic levels on ports A and B simultaneously. The VIOA and VIOB rails are exposed as pins on the port A and port B connectors."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:116
+msgid "Each VIO rail is derived from the +5V rail using a TPS73101DBV linear regulator (U31, U14). These regulators have an ultra-low dropout voltage of just 30 mV, which allows the VIO voltages to be programmed anywhere between 1.8 V and the +5V rail voltage (which is essentially equal to VUSB) minus 30 mV."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:118
+msgid "The TPS73101DBV regulators feature reverse current blocking which prevents current from being sunk into the regulator instead of sourced from it. They also have a unique foldback current limit characteristic which provides excellent protection against short circuits on the VIO rails - see the \"Internal Current Limit\" section and Figure 12 in the datasheet."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:120
+msgid "Each VIO regulator has a feedback network which incorporates the output of a DAC081C081CIMK DAC IC. These DACs (U20, U13) are programmed over I2C to adjust the feedback voltage by injecting current into the feedback resistor network, which in turn adjusts the VIO voltage, thus providing runtime VIO voltage adjustment. The DAC output voltages can be measured using the VDAC A and B test points on the rear of the board. The FX2 firmware `calculates the correct DAC voltage <https://github.com/GlasgowEmbedded/glasgow/blob/1f5691a4b516f4ac083e7fa4fc32abcc659e608d/firmware/dac_ldo.c#L76-L83>`__ for the target output voltage. Some examples are:"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:123
+msgid "VIO Voltage"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:123
+msgid "DAC Output"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:125 ../../src/revisions/revC3.rst:190
+#: ../../src/revisions/revC3.rst:206
+msgid "5.0 V"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:125
+msgid "0.45 V"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:127 ../../src/revisions/revC3.rst:192
+#: ../../src/revisions/revC3.rst:208
+msgid "3.3 V"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:127
+msgid "1.88 V"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:129
+msgid "2.8 V"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:129
+msgid "2.31 V"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:131 ../../src/revisions/revC3.rst:194
+#: ../../src/revisions/revC3.rst:210
+msgid "2.5 V"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:131
+msgid "2.56 V"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:133 ../../src/revisions/revC3.rst:196
+#: ../../src/revisions/revC3.rst:212
+msgid "1.8 V"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:133
+msgid "3.15 V"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:136
+msgid "On power-on or reset, both VIO regulators are disabled and the voltage adjustment DACs are reset to 0.0 V. The DAC voltages are programmed over I2C, after which the regulators may be enabled by the FX2 asserting the ``ENVA`` and ``ENVB`` signals (pins 45 and 51 on the FX2 respectively). The VIO A and VIO B LEDs on the front of the board light up when the regulators are enabled."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:138
+msgid "The VIO rail currents are measured by INA233 voltage and current monitoring ADC ICs (U21, U12) using 150 mΩ shunt resistors (R49, R48) in series with the regulator outputs. This allows the VIO currents for each port to be measured over I2C. The voltage sense pin on each INA233 is exposed on the port connector (VA_SENS, VB_SENS), allowing for two useful configurations:"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:140
+msgid "The sense input may be connected directly to the VIO rail for that port (e.g. VA_SENSE to VIOA), enabling you to monitor the VIO rail voltage precisely and utilise the INA233's inbuilt power calculation feature to measure total power consumption for that VIO rail."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:141
+msgid "The sense input may be connected to any arbitrary voltage in the range 0.0 V to 36.0 V, essentially using the INA233's voltage sensing input as a generic 16-bit ADC input. In this configuration the VIO rail current can still be measured but the inbuilt VIO rail power calculation feature will not be available."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:143
+msgid "Additional 330 mΩ resistors (R56, R7) in series with the regulator outputs ensure recovery in the event that a VIO rail is shorted to ground - see `GitHub issue #135 <https://github.com/GlasgowEmbedded/glasgow/issues/135>`__ for details."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:145
+msgid "Each VIO rail is protected against overvoltage and ESD by two parallel elements of a SP3012-06UTG diode array. VIOA is protected by D22 and VIOB is protected by D20. These diode arrays also feature a 6.0 V zener diode clamp."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:147
+msgid "The VIOA rail is used to power the following devices:"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:152
+msgid "Logic level translators for port A. VIOA powers external side (VCCB)"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:154
+msgid "I2C I/O expander for programmable pullup/pulldown resistors on port A. VIOA powers IO ports."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:158
+msgid "The VIOB rail is used to power the following devices:"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:163
+msgid "Logic level translators for port B. VIOB powers external side (VCCB)"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:165
+msgid "I2C I/O expander for programmable pullup/pulldown resistors on port A. VIOB powers IO ports."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:172 ../../src/revisions/revC3.rst:392
+msgid "VIO_AUX"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:174
+msgid "Ports A and B are the primary connectors which are expected to be used with Glasgow. The LVDS connector is a secondary connector that can be used for special addons that require additional IOs. While the IOs on ports A and B are well-protected against ESD and utilise separate logic level translation with their own VIO rails, the LVDS connector is directly connected to the iCE40 FPGA without any logic level translation or discrete protection, and without a programmable IO voltage. The supply for the IOs exposed on the LVDS connector must be externally provided via VIO_AUX on pin 44. This voltage is directly fed to ``VCCIO_3`` on the FPGA. Voltages between 1.8 V and 3.3 V are supported. See the iCE40HX8K-BG121 datasheet for more information."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:180
+msgid "Decoupling capacitors"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:182
+msgid "Two values of MLCC decoupling capacitor are used across the Glasgow design."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:185
+msgid "4.7 uF capacitors are `Taiyo Yuden LMK107BJ475KAHT <https://ds.yuden.co.jp/TYCOMPAS/eu/detail?pn=MBASL168SB5475KTNA01&u=M>`__, with the following DC bias characteristics:"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:188 ../../src/revisions/revC3.rst:204
+msgid "DC bias voltage"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:188 ../../src/revisions/revC3.rst:204
+msgid "Effective Capacitance"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:190
+msgid "1.93 uF"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:192
+msgid "2.82 uF"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:194
+msgid "3.39 uF"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:196
+msgid "3.92 uF"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:198 ../../src/revisions/revC3.rst:214
+msgid "1.2 V"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:198
+msgid "4.37 uF"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:201
+msgid "100 nF capacitors are `Taiyo Yuden TMK105BJ104KV-F <https://ds.yuden.co.jp/TYCOMPAS/eu/detail?pn=MSAST105SB5104KFNA01&u=M>`__ (now renamed to MSAST105SB5104KFNA01), with the following DC bias characteristics:"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:206
+msgid "93 nF"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:208
+msgid "98 nF"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:210
+msgid "99 nF"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:212 ../../src/revisions/revC3.rst:214
+msgid "100 nF"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:221
+msgid "Power-on sequencing"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:223
+msgid "The power-on sequence is as follows:"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:225
+msgid "5.0 V becomes present on the VUSB pin of the USB-C connector."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:226
+msgid "After VUSB exceeds the enable threshold (nominally 1.45 V) of the TPD3S014 current limit switch (U15) for approximately 1.0 ms to 2.2 ms (nominally 1.6 ms) the switch turns on and the +5V rail begins to rise."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:227
+msgid "TPD3S014 performs soft-start and inrush limiting while charging the 150 uF bulk capacitor (C87) on the +5V rail. Charging takes around 2 ms, during which up to 850 mA is drawn."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:228
+msgid "When the +5V rail reaches approximately 1.3 V, the TLV73312PQDRVR linear regulator (U36) leaves disabled mode and enters dropout mode. During this time the +1.2V rail will have a voltage equal to the +5V rail minus the 450 mV dropout voltage of the regulator. When the +5V rail exceeds 1.65 V, the regulator enters normal mode and the +1.2V rail voltage becomes stable at 1.2 V."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:229
+msgid "APX811-40UG-7 (U7) monitors the +5V rail and asserts a reset signal (active low) while the +5V rail is below 4.0 V nominal."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:230
+msgid "Once the +5V rail exceeds this threshold for at least 240 ms, U7's reset signal is no longer asserted. As a result, the TLV75533PDRVR linear regulator (U8) switches on and powers the +3.3V rail."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:231
+msgid "The +3.3V rail and reset signal from U7 are connected to a common-anode dual-Schottky diode package (D24) in such a way that ``CY_RESET`` is asserted (active low) if U7 is outputting a reset state or the +3.3V rail is not present. The `CY_RESET` signal is low-pass filtered using R4, R5, and C88 to ensure that ``CY_RESET`` remains asserted for 5 ms after the +3.3V rail turns on."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:232
+msgid "All rails are now at nominal and ``CY_RESET`` is de-asserted, allowing the FX2 USB controller to start operating. The FX2 de-asserts ``FPGA_RESET``, allowing the iCE40 FPGA (U30) to operate."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:233
+msgid "During power-on, ``ENVA`` and ``ENVB`` are pulled down, disabling the TPS73101DBV adjustable linear regulators (U31, U14) which provide the VIO voltages for ports A and B. The DAC081C081CIMK DACs (U20, U13) provide an adjustable feedback voltage to the regulators. These are programmed over I2C as required to adjust the voltage of the VIO regulators, after which the FX2 can assert ``ENVA`` and/or ``ENVB`` to enable the regulators which, in turn, power the VIO outputs."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:239
+msgid "Connectors"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:245
+msgid "Port A Connector Layout"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:248
+msgid "**VIOA**"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:248 ../../src/revisions/revC3.rst:262
+msgid "**GND**"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:248 ../../src/revisions/revC3.rst:250
+#: ../../src/revisions/revC3.rst:260 ../../src/revisions/revC3.rst:262
+msgid "**NC**"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:250
+msgid "**VA_SENS**"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:250
+msgid "**PA_IO0**"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:250
+msgid "**PA_IO1**"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:250
+msgid "**PA_IO2**"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:250
+msgid "**PA_IO3**"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:250
+msgid "**PA_IO4**"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:250
+msgid "**PA_IO5**"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:250
+msgid "**PA_IO6**"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:250
+msgid "**PA_IO7**"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:257
+msgid "Port B Connector Layout"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:260
+msgid "**PB_IO7**"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:260
+msgid "**PB_IO6**"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:260
+msgid "**PB_IO5**"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:260
+msgid "**PB_IO4**"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:260
+msgid "**PB_IO3**"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:260
+msgid "**PB_IO2**"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:260
+msgid "**PB_IO1**"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:260
+msgid "**PB_IO0**"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:260
+msgid "**VIOB**"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:262
+msgid "**VB_SENS**"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:269
+msgid "Ports A/B Pinout"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:272 ../../src/revisions/revC3.rst:348
+msgid "Number"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:272 ../../src/revisions/revC3.rst:348
+#: ../../src/revisions/revC3.rst:411
+msgid "Name"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:272
+msgid "Wire Colour"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:272 ../../src/revisions/revC3.rst:411
+msgid "Description"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:274 ../../src/revisions/revC3.rst:350
+msgid "1"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:274
+msgid "SENSE"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:274 ../../src/revisions/revC3.rst:417
+#: ../../src/revisions/revC3.rst:423 ../../src/revisions/revC3.rst:431
+msgid "Blue"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:274
+msgid "Voltage sense, connected to VBUS pin of INA233. Tie to pin 2 to enable VIO power measurement feature, or use as an arbitrary 0-36V 16-bit ADC input."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:276 ../../src/revisions/revC3.rst:350
+msgid "2"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:276
+msgid "VIO"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:276 ../../src/revisions/revC3.rst:421
+msgid "Red"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:276
+msgid "Logic level voltage output. Generated by TPS73101DBV linear regulator, voltage level configured at runtime by DAC081C081CIMK DAC."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:278 ../../src/revisions/revC3.rst:352
+msgid "3"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:278
+msgid "IO0"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:278 ../../src/revisions/revC3.rst:419
+msgid "Orange"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:278
+msgid "IO pin 0."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:280 ../../src/revisions/revC3.rst:352
+msgid "4"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:280 ../../src/revisions/revC3.rst:284
+#: ../../src/revisions/revC3.rst:288 ../../src/revisions/revC3.rst:292
+#: ../../src/revisions/revC3.rst:296 ../../src/revisions/revC3.rst:300
+#: ../../src/revisions/revC3.rst:304 ../../src/revisions/revC3.rst:308
+#: ../../src/revisions/revC3.rst:350 ../../src/revisions/revC3.rst:352
+#: ../../src/revisions/revC3.rst:354 ../../src/revisions/revC3.rst:356
+#: ../../src/revisions/revC3.rst:360 ../../src/revisions/revC3.rst:362
+#: ../../src/revisions/revC3.rst:366 ../../src/revisions/revC3.rst:368
+#: ../../src/revisions/revC3.rst:372 ../../src/revisions/revC3.rst:374
+#: ../../src/revisions/revC3.rst:378 ../../src/revisions/revC3.rst:380
+#: ../../src/revisions/revC3.rst:384 ../../src/revisions/revC3.rst:386
+#: ../../src/revisions/revC3.rst:390 ../../src/revisions/revC3.rst:392
+msgid "GND"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:280 ../../src/revisions/revC3.rst:284
+#: ../../src/revisions/revC3.rst:288 ../../src/revisions/revC3.rst:292
+#: ../../src/revisions/revC3.rst:296 ../../src/revisions/revC3.rst:300
+#: ../../src/revisions/revC3.rst:304 ../../src/revisions/revC3.rst:308
+msgid "Black"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:280 ../../src/revisions/revC3.rst:284
+#: ../../src/revisions/revC3.rst:288 ../../src/revisions/revC3.rst:292
+#: ../../src/revisions/revC3.rst:296 ../../src/revisions/revC3.rst:300
+#: ../../src/revisions/revC3.rst:304 ../../src/revisions/revC3.rst:308
+msgid "Ground."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:282 ../../src/revisions/revC3.rst:354
+msgid "5"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:282
+msgid "IO1"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:282 ../../src/revisions/revC3.rst:413
+#: ../../src/revisions/revC3.rst:433 ../../src/revisions/revC3.rst:435
+msgid "Green"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:282
+msgid "IO pin 1."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:284 ../../src/revisions/revC3.rst:354
+msgid "6"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:286 ../../src/revisions/revC3.rst:356
+msgid "7"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:286
+msgid "IO2"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:286
+msgid "Grey"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:286
+msgid "IO pin 2."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:288 ../../src/revisions/revC3.rst:356
+msgid "8"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:290 ../../src/revisions/revC3.rst:358
+msgid "9"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:290
+msgid "IO3"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:290
+msgid "Brown"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:290
+msgid "IO pin 3."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:292 ../../src/revisions/revC3.rst:358
+msgid "10"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:294 ../../src/revisions/revC3.rst:360
+msgid "11"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:294
+msgid "IO4"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:294 ../../src/revisions/revC3.rst:425
+#: ../../src/revisions/revC3.rst:429
+msgid "Pink"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:294
+msgid "IO pin 4."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:296 ../../src/revisions/revC3.rst:360
+msgid "12"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:298 ../../src/revisions/revC3.rst:362
+msgid "13"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:298
+msgid "IO5"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:298
+msgid "Yellow"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:298
+msgid "IO pin 5."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:300 ../../src/revisions/revC3.rst:362
+msgid "14"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:302 ../../src/revisions/revC3.rst:364
+msgid "15"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:302
+msgid "IO6"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:302 ../../src/revisions/revC3.rst:415
+#: ../../src/revisions/revC3.rst:427
+msgid "White"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:302
+msgid "IO pin 6."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:304 ../../src/revisions/revC3.rst:364
+msgid "16"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:306 ../../src/revisions/revC3.rst:366
+msgid "17"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:306
+msgid "IO7"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:306
+msgid "Purple"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:306
+msgid "IO pin 7."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:308 ../../src/revisions/revC3.rst:366
+msgid "18"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:310 ../../src/revisions/revC3.rst:368
+msgid "19"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:310 ../../src/revisions/revC3.rst:312
+msgid "NC"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:310 ../../src/revisions/revC3.rst:312
+msgid "N/A"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:310 ../../src/revisions/revC3.rst:312
+msgid "Not connected."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:312 ../../src/revisions/revC3.rst:368
+msgid "20"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:315
+msgid "Wire colours described here are correct for the 1BitSquared wiring looms and are not innate to Glasgow itself."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:317
+msgid "Note that each of the IOs has a GND pin opposite. This provides a ground reference plane for return currents, which helps improve signal integrity and reduces crosstalk in higher speed signals. Where possible, connect each ground wire to GND on the target device, physically close to the signal connection."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:319
+msgid "Each IO is driven by an SN74LVC1T45DCKR bus transceiver, which converts between the port's logic voltage (VIO) and the 3.3 V used by the FPGA IO ports. Each IO can be independently configured as an input or output. Each IO pin can source or sink up to 4 mA at 1.8 V, 8 mA at 2.5 V, 24 mA at 3.3 V, or 32 mA at 5.0 V."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:321
+msgid "The SN74LVC1T45DCKR itself provides limited isolation between the FPGA and the IO pins, and a modicum of ESD protection. Additional ESD and overvoltage protection is provided by an SP3012-06UTG diode array and a 33Ω series termination resistor."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:323
+msgid "The VSENSE pin is protected by a CDSOD323-T36S unidirectional TVS diode which helps protect the INA233 ICs against overvoltage."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:329
+msgid "SYNC Connector"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:331
+msgid "The SYNC connector is used to synchronise multiple Glasgows together. As of March 2024 this has not been used for much, but we expect folks will come up with interesting ways to use it."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:333
+msgid "The SYNC pin is weakly pulled up to the +3.3V rail and is buffered by a SN74LVC1T45DCKR bus transceiver. The input-low threshold is 0.8 V and the input-high threshold is 2.0 V, making it directly compatible with 2.5 V, 3.3 V, and 5.0 V logic."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:335
+msgid "The SYNC pin is protected by a ESD5Z5.0T1G ESD protection diode with a standoff voltage of 5.0 V and a breakdown of 6.2 V, and a 47 Ω series resistor."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:341
+msgid "LVDS Connector"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:343
+msgid "The LVDS port is a secondary connector used for specially designed addons. It is directly wired to the FPGA rather than using bus transceivers, and has limited ESD protection, so you should be careful when plugging things into it and only do so when the device is fully powered off."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:345
+msgid "The LVDS port will be replaced with different connectors in future hardware revisions of Glasgow, so its use is not preferred for addon boards."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:350
+msgid "+3.3V"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:352
+msgid "Z11_N"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:354
+msgid "Z11_P"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:356
+msgid "Z12_P"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:358
+msgid "Z10_P"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:358
+msgid "Z12_N"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:360
+msgid "Z10_N"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:362
+msgid "Z9_N"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:364
+msgid "Z8_P"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:364
+msgid "Z9_P"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:366
+msgid "Z8_N"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:368
+msgid "Z7_N"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:370
+msgid "21"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:370
+msgid "Z6_P"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:370
+msgid "22"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:370
+msgid "Z7_P"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:372
+msgid "23"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:372
+msgid "Z6_N"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:372
+msgid "24"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:374
+msgid "25"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:374
+msgid "26"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:374
+msgid "Z5_N"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:376
+msgid "27"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:376
+msgid "Z3_P"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:376
+msgid "28"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:376
+msgid "Z5_P"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:378
+msgid "29"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:378
+msgid "Z3_N"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:378
+msgid "30"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:380
+msgid "31"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:380
+msgid "32"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:380
+msgid "Z4_P"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:382
+msgid "33"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:382
+msgid "Z2_N"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:382
+msgid "34"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:382
+msgid "Z4_N"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:384
+msgid "35"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:384
+msgid "Z2_P"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:384
+msgid "36"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:386
+msgid "37"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:386
+msgid "38"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:386
+msgid "Z1_N"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:388
+msgid "39"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:388
+msgid "Z0_P"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:388
+msgid "40"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:388
+msgid "Z1_P"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:390
+msgid "41"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:390
+msgid "Z0_N"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:390
+msgid "42"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:392
+msgid "43"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:392
+msgid "44"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:396
+msgid "The +3.3V pin provides 3.3 V power from the onboard +3.3V rail."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:398
+msgid "To use the LVDS connector you must provide ``VIO_AUX``, an IO voltage between 1.8 V and 3.3 V, on pin 44. This pin is tied directly to ``VCCIO_3`` on the FPGA. See the iCE40HX8K-BG121 datasheet for more information about the power requirements."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:400
+msgid "The pins can be used in differential mode (N/P pairs) or in single-ended mode (independent signals on N and P)."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:402
+msgid "No termination resistors are included. You should include termination resistors on your board if you use the LVDS connector. See the Lattice document `FPGA-TN-02213 \"Using Differential I/O (LVDS, Sub-LVDS) in iCE40 LP/HX Devices\" <https://www.latticesemi.com/view_document?document_id=47960>`__ for details."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:408
+msgid "LEDs"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:411
+msgid "Colour"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:413
+msgid "PWR"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:413
+msgid "Powered by +3.3V rail"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:415
+msgid "FX2"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:415
+msgid "D2"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:415 ../../src/revisions/revC3.rst:427
+msgid "NCD0603W1"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:415
+msgid "Connected to pin 47 (PD2/FD10) of Cypress FX2 (U1). Pulses during enumeration. Lights when the FX2 has initialised."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:417
+msgid "ICE"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:417
+msgid "D3"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:417 ../../src/revisions/revC3.rst:423
+#: ../../src/revisions/revC3.rst:431
+msgid "ORH-B36G"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:417
+msgid "Connected to pin 48 (PD3/FD11) of Cypress FX2 (U1). Lights when the FPGA is ready."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:419
+msgid "ACT"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:419
+msgid "D4"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:419
+msgid "NCD0603O1"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:419
+msgid "Connected to pin 49 (PD4/FD12) of Cypress FX2 (U1). Lights when activity is occurring."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:421
+msgid "ERR"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:421
+msgid "D5"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:421
+msgid "NCD0603R1"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:421
+msgid "Connected to pin 50 (PD5/FD13) of Cypress FX2 (U1). Lights when an error occurs."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:423
+msgid "D6"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:423
+msgid "Connected to ball G9 (IOR_128) of iCE40 FPGA (U30)"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:425
+msgid "D7"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:425 ../../src/revisions/revC3.rst:429
+msgid "OSK40603C1E"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:425
+msgid "Connected to ball G8 (IOR_118) of iCE40 FPGA (U30)"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:427
+msgid "D8"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:427
+msgid "Connected to ball E9 (IOR_144) of iCE40 FPGA (U30)"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:429
+msgid "U4"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:429
+msgid "D9"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:429
+msgid "Connected to ball D9 (IOR_147) of iCE40 FPGA (U30)"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:431
+msgid "D10"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:431
+msgid "Connected to ball E8 (IOR_146) of iCE40 FPGA (U30)"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:433
+msgid "VIO A"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:433
+msgid "D15"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:433
+msgid "Lights when VIO A regulator (U31) is enabled"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:435
+msgid "VIO B"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:435
+msgid "D14"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:435
+msgid "Lights when VIO B regulator (U14) is enabled"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:438
+msgid "The system LEDs (FX2, ICE, ACT, ERR) are under control of the FX2 firmware, which is responsible for producing the behaviour described above. In the event that the FX2 firmware does not run (e.g. no firmware is present), the LED IO pins default to a high-impedance input state and will all be off."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:440
+msgid "The user LEDs (U1-U5) are under control of the gateware. In most cases they go unused and the FPGA defaults the pins to be inputs with weak pullups, which results in the user LEDs lighting dimly."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:446
+msgid "I²C bus"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:448
+msgid "Glasgow uses I2C internally for controlling the VIO voltages, measuring VIO current and voltage (or an external voltage input), and for communicating with the FX2 and iCE40 EEPROMs. The SDA and SCL signals can be accessed via test points on the front and rear of the board."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:454
+msgid "I²C bus addresses"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:457
+msgid "Address"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:457
+msgid "Function"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:459
+msgid "101001X [1]_"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:459
+msgid "1 Mbit [4]_ flash memory for ICE40 FPGA"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:461
+msgid "1010001"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:461
+msgid "Flash memory for FX2 USB controller"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:463
+msgid "0001110"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:463
+msgid "DAC for setting VIO voltage on port A"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:465
+msgid "1000000"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:465
+msgid "Voltage/current measurement ADC for port A"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:467
+msgid "0100000 [2]_"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:467
+msgid "I/O expander for programmable pullup/pulldowns on port A"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:469
+msgid "0001101"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:469
+msgid "DAC for setting VIO voltage on port B"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:471
+msgid "1000001"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:471
+msgid "Voltage/current measurement ADC for port B"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:473
+msgid "0100001 [3]_"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:473
+msgid "I/O expander for programmable pullup/pulldowns on port B"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:477
+msgid "The X in this address indicates that the device responds to two addresses (0 or 1 in the last bit position). In this case each address acts as a 512 Kbit flash device, providing 1 Mbit in total. Refer to the product datasheet for more information."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:480 ../../src/revisions/revC3.rst:483
+msgid "PCA6408APW is an SMBus device. The SMBus Alert Response Address (ARA) is 0001100 for both U19 (port A) and U5 (port B)."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:486
+msgid "The iCE40HX8K bitstream is actually about 3 KB bigger than 1 Mbit, so the tail end of the bitstream lives in U3 as a workaround."
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:492
+msgid "Recovery"
+msgstr ""
+
+#: ../../src/revisions/revC3.rst:494
+msgid "Two pads can be found on the board marked \"RECOVER\", next to the FX2 EEPROM (U2). This footprint is R40 in the schematic. To initiate recovery, short these pads together and press the reset button, then remove the short. This temporarily changes the I2C address of the FX2 EEPROM so that it boots without firmware, placing it into a recovery mode where it enumerates with the default FX2 device descriptor. The ``fx2tool`` utility can then be used to make a backup copy of the FX2 EEPROM, and the ``glasgow factory`` command can be used to re-provision the device configuration block and the firmware"
+msgstr ""
+
+#~ msgid "This document provides a technical description of the Glasgow revC3 XXX hardware."
+#~ msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/use/basic.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/use/basic.po
@@ -1,0 +1,208 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/use/basic.rst:2
+msgid "Basic usage"
+msgstr ""
+
+#: ../../src/use/basic.rst:6
+msgid "Getting started with Glasgow"
+msgstr ""
+
+#: ../../src/use/basic.rst:8
+msgid "After :ref:`installing <initial-setup>` the Glasgow software, the ``glasgow`` utility should be operational.  The ``glasgow`` utility is the most common (but not the only) way to interact with Glasgow hardware.  Test to see if ``glasgow`` is installed correctly with:"
+msgstr ""
+
+#: ../../src/use/basic.rst:14
+msgid "``glasgow`` has a number of subcommands. At all times, the ``--help`` argument may be appended for more details."
+msgstr ""
+
+#: ../../src/use/basic.rst:18
+msgid "As you build up the ``glasgow`` tool's command line, the `context` changes --- for example, the output of each of the following ``--help`` s are all different:"
+msgstr ""
+
+#: ../../src/use/basic.rst:26
+msgid "The upshot of this is that different arguments need to be placed at different positions in the command line. The help section at each level should clarify where each argument should be placed. For example, the ``--serial`` parameter is recognized by the top-level ``glasgow`` command, and not by the third-level ``glasgow run uart`` command."
+msgstr ""
+
+#: ../../src/use/basic.rst:38
+msgid "Returning Glasgow to a safe state"
+msgstr ""
+
+#: ../../src/use/basic.rst:40
+msgid "To begin with, use the ``glasgow safe`` command to make sure that the ``glasgow`` utility can communicate with your Glasgow hardware.   The ``glasgow safe`` command sets all I/O to a `safe` state --- it disables voltage outputs, and sets all I/O pins to a high impedance state.  Try it with:"
+msgstr ""
+
+#: ../../src/use/basic.rst:46
+msgid "This command has the same effect as pressing the physical `E-STOP / RESET` button that is present on ``revC3`` and later hardware revisions.  You may prefer to get in the habit of using the physical button if you're sitting next to your Glasgow; the button gives tactile feedback that the device has entered a safe state, in a way that ``glasgow safe`` cannot!"
+msgstr ""
+
+#: ../../src/use/basic.rst:48
+msgid "You can use this command at any time to put your Glasgow hardware into a `safe` state; if it is successful, it will provide the output:"
+msgstr ""
+
+#: ../../src/use/basic.rst:57
+msgid "If the ``glasgow`` tool cannot detect your connected Glasgow hardware, look at the LEDs.  A Glasgow device that is unable to establish a USB connection will slowly fade the `FX2` LED on and off to indicate a failure. This most commonly occurs if you use a power-only USB cable to connect the Glasgow device to your computer."
+msgstr ""
+
+#: ../../src/use/basic.rst:61
+msgid "Working with applets"
+msgstr ""
+
+#: ../../src/use/basic.rst:63
+msgid "``glasgow`` is based around the concept of `applets`, with each implementing a particular mode of operation or interface. For example, there are applets such as ``uart``, ``i2c-controller``, and ``spi-controller`` --- each implementing the gateware (which runs on the FPGA) and software (which runs on the host PC). The Glasgow software framework coordinates building, caching, and operating these applets for you."
+msgstr ""
+
+#: ../../src/use/basic.rst:65
+msgid "A list of available applets [#applet_sources]_ can be shown by running ``glasgow run --help``.  You can interact with applets from the ``glasgow`` tool in one of four ways:"
+msgstr ""
+
+#: ../../src/use/basic.rst:67
+msgid "**Running an applet**.  Most applets come with command line programs that perform a specific task related to the gateware that they interface with; ``glasgow run`` ning an applet allows you to invoke one or more of these applet-associated programs.  This usage is described below."
+msgstr ""
+
+#: ../../src/use/basic.rst:69
+msgid "**Using an applet from the REPL.**  Applets provide a Python programming interface.  ``glasgow repl`` launches a Python prompt (a \"REPL\") that you can use to interactively explore the gateware implemented by an applet, and hardware connected to it.  This is described in the :ref:`REPL & script operation <repl-script>` section."
+msgstr ""
+
+#: ../../src/use/basic.rst:71
+msgid "**Scripting an applet**.  It is often useful to use an applet's Python programming interface non-interactively, to run a stored set of operations using the Glasgow platform.  This is described in the :ref:`script usage <script-usage>` section."
+msgstr ""
+
+#: ../../src/use/basic.rst:73
+msgid "**Using an offline tool**.  Some applets come with offline tools that do not use the Glasgow hardware at all.  For instance, the ``memory-floppy`` applet has a tool to manipulate raw disk images that may have been captured by ``glasgow run`` ning the applet.  This is not currently described in this document, but can be accessed with the ``glasgow tool`` command."
+msgstr ""
+
+#: ../../src/use/basic.rst:75
+msgid "In this basic usage, we describe only using ``glasgow run`` to run an applet."
+msgstr ""
+
+#: ../../src/use/basic.rst:79
+msgid "Using ``glasgow run``"
+msgstr ""
+
+#: ../../src/use/basic.rst:81
+msgid "Applets that have ``run`` nable programs often have `subcommands` to specify what task you would like to accomplish.  For instance, the ``uart`` applet has three subcommands -- ``tty``, which attaches the UART to stdin; ``pty``, which creates a UNIX pseudoterminal; and ``socket``, which attaches the UART to either a UNIX or TCP socket.  You can get a list of an applet's subcommands by using the ``--help`` argument; each subcommand may also have arguments of its own:"
+msgstr ""
+
+#: ../../src/use/basic.rst:100
+msgid "Applets also can have `build arguments` that specify how the gateware is constructed, and `run arguments` that modify the behavior of the applet as a whole; these are also listed in the ``--help`` output."
+msgstr ""
+
+#: ../../src/use/basic.rst:102
+msgid "A common run argument is ``-V ...``, which sets the I/O voltage, as well as setting the supply output voltage. Be careful that you set the correct voltage for your connected devices! The following are the possible syntaxes for configuring voltage:"
+msgstr ""
+
+#: ../../src/use/basic.rst:104
+msgid "all ports:        ``-V 3.3``"
+msgstr ""
+
+#: ../../src/use/basic.rst:105
+msgid "one port:         ``-V A=3.3``"
+msgstr ""
+
+#: ../../src/use/basic.rst:106
+msgid "several ports:    ``-V A=3.3,B=5.0`` or ``-V A=3.3 -V B=5.0``"
+msgstr ""
+
+#: ../../src/use/basic.rst:107
+msgid "sense and repeat: ``-V A=SA`` or ``-V AB=SA``"
+msgstr ""
+
+#: ../../src/use/basic.rst:109
+msgid "Putting it together, the following command will run the ``uart`` applet, with an I/O voltage of 3.3 V, and will configure pin ``A0`` to be `Tx` (Glasgow transmitting), and pin ``A1`` to be `Rx` (Glasgow receiving).  It uses the ``socket`` subcommand to bridge the UART to a socket:"
+msgstr ""
+
+#: ../../src/use/basic.rst:120
+msgid "As the applet's output suggests, you can connect to TCP port 4321 using a tool of your choice --- ``nc`` or PuTTY will both work."
+msgstr ""
+
+#: ../../src/use/basic.rst:124
+msgid "Inverting pins"
+msgstr ""
+
+#: ../../src/use/basic.rst:126
+msgid "Any pin can be inverted via the command-line interface using one of the following syntaxes:"
+msgstr ""
+
+#: ../../src/use/basic.rst:128
+msgid "single pin: ``--x A0#``"
+msgstr ""
+
+#: ../../src/use/basic.rst:129
+msgid "pin range:  ``--x A0:7#``         (inverts the entire range)"
+msgstr ""
+
+#: ../../src/use/basic.rst:130
+msgid "pin list:   ``--x A0,A1#,A2#,A3`` (inverts only specified pins)"
+msgstr ""
+
+#: ../../src/use/basic.rst:132
+msgid "Pull-ups configured for a pin with inversion get converted to pull-downs and vice versa."
+msgstr ""
+
+#: ../../src/use/basic.rst:136
+msgid "Examples"
+msgstr ""
+
+#: ../../src/use/basic.rst:140
+msgid "UART"
+msgstr ""
+
+#: ../../src/use/basic.rst:142
+msgid "The ``uart`` applet provides a basic full-duplex UART interface that can operate at virtually any reasonable baudrate, and also supports automatically detecting the baudrate based on frames sent by the remote device. The transmit and receive signals can also be easily inverted."
+msgstr ""
+
+#: ../../src/use/basic.rst:144
+msgid "By running the applet using the ``tty`` mode, you will be delivered a direct pipe to the UART --- characters you enter into the terminal will be transmitted by the Glasgow hardware, and characters received by the Glasgow hardware will appear in the terminal."
+msgstr ""
+
+#: ../../src/use/basic.rst:146
+msgid "The baud rate can be set using ``-b 57600``, and automatic baud rate detection can be enabled with ``-a``. Although reliable and particularly convenient for devices that change their baud rate as they boot, this detection mechanism is not perfect, and sometimes you may have to set the baud rate manually."
+msgstr ""
+
+#: ../../src/use/basic.rst:148
+msgid "Aside from the ``tty`` mode, others are available (``pty``, ``socket``), which are explained further by the help text."
+msgstr ""
+
+#: ../../src/use/basic.rst:156
+msgid "SPI controller"
+msgstr ""
+
+#: ../../src/use/basic.rst:158
+msgid "The ``spi-controller`` applet implements an SPI controller, allowing full-duplex transfer to an SPI device. The following command will assert `CS#`, send the five bytes ``03 01 23 5f f5``, and then de-assert `CS#`, before printing the received data to the console."
+msgstr ""
+
+#: ../../src/use/basic.rst:167
+msgid "I²C controller"
+msgstr ""
+
+#: ../../src/use/basic.rst:169
+msgid "The ``i2c-controller`` applet implements an I²C controller, which features a simple bus scan operation from the command line, using the on-board pull-up resistors."
+msgstr ""
+
+#: ../../src/use/basic.rst:175
+msgid "Using the :ref:`repl or script modes <repl-script>`, it's possible to easily communicate with devices, obeying clock stretching and other factors that are often ignored with bit-banged interfaces."
+msgstr ""
+
+#: ../../src/use/basic.rst:177
+msgid "In the current Glasgow software, all applets are packaged as part of the Glasgow software distribution; future versions of Glasgow :ref:`may support out-of-tree applets <applet>`.  For the curious, the list of applets is retrieved from the `installed package's metadata <https://packaging.python.org/en/latest/guides/creating-and-discovering-plugins/#using-package-metadata>`_; this list, in turn, comes from the |pyproject_toml|_ file's ``project.entry-points.\"glasgow.applet\"`` section."
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/use/index.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/use/index.po
@@ -1,0 +1,24 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/use/index.rst:2
+msgid "Using the device"
+msgstr ""
+

--- a/docs/manual/locale/cn/LC_MESSAGES/use/repl-script.po
+++ b/docs/manual/locale/cn/LC_MESSAGES/use/repl-script.po
@@ -1,0 +1,164 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2020—2026, Glasgow Interface Explorer contributors
+# This file is distributed under the same license as the Glasgow Interface Explorer package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Glasgow Interface Explorer \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-25 07:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cn\n"
+"Language-Team: cn <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.17.0\n"
+
+#: ../../src/use/repl-script.rst:4
+msgid "REPL & script operation"
+msgstr ""
+
+#: ../../src/use/repl-script.rst:7
+msgid "What is \"*REPL*\"?"
+msgstr ""
+
+#: ../../src/use/repl-script.rst:9
+msgid "If you've ever typed ``python3`` into a terminal, or found yourself looking at the three angle brackets (``>>>``), then you'll have some idea of what we're referring to. It stands for \"`Read Eval Print Loop`\", and is a fundamental way of interacting with many interpreted languages (including Bash and JavaScript, alongside Python)."
+msgstr ""
+
+#: ../../src/use/repl-script.rst:11
+msgid "By invoking ``glasgow repl ...`` you can gain interactive code-level access to the applet of your choice."
+msgstr ""
+
+#: ../../src/use/repl-script.rst:14
+msgid "As always, please make sure you select the correct I/O and supply voltage for whatever you have connected to your Glasgow."
+msgstr ""
+
+#: ../../src/use/repl-script.rst:26
+msgid "What happens now is entirely up to you --- ``glasgow script ...`` is given an identical environment, except that it will run the nominated script rather than present control to you."
+msgstr ""
+
+#: ../../src/use/repl-script.rst:28
+msgid "The Glasgow framework provides us with access to the ``device`` and ``args`` variables, plus another variable that is named differently depending on the applet being used. For example, the I²C applet calls it ``i2c_iface``."
+msgstr ""
+
+#: ../../src/use/repl-script.rst:36
+msgid "Some examples are maintained in the `examples <https://github.com/GlasgowEmbedded/glasgow/tree/main/examples>`_ directory."
+msgstr ""
+
+#: ../../src/use/repl-script.rst:38
+msgid "One further note --- a lot of the Glasgow framework uses ``asyncio``, with the most apparent impact to users being that the ``await`` keyword must be used. You are provided with an async-capable environment, so no additional setup work is required on your part --- just use the ``await`` keyword... if you ever see a ``<coroutine object ....>``, try using ``await``."
+msgstr ""
+
+#: ../../src/use/repl-script.rst:42
+msgid "How do I use this interface?"
+msgstr ""
+
+#: ../../src/use/repl-script.rst:44
+msgid "The exact usage will depend heavily on the applet you've requested, some examples are provided below with explanations."
+msgstr ""
+
+#: ../../src/use/repl-script.rst:46
+msgid "As the startup prompt suggests, investigating ``help(applet_iface)`` and ``help(device)`` are good places to start... after that, have a look at the applet's code."
+msgstr ""
+
+#: ../../src/use/repl-script.rst:49
+msgid "I²C"
+msgstr ""
+
+#: ../../src/use/repl-script.rst:51
+msgid "For this example, I will be using the `Sparkfun BMP085 <https://web.archive.org/web/20230206233109/https://www.sparkfun.com/products/retired/9694>`_ (a now-retired breakout for an I²C barometric pressure sensor), which supports 3.3v operation."
+msgstr ""
+
+#: ../../src/use/repl-script.rst:54
+msgid "I²C busses are implemented using open-drain, meaning that pull-up resistors are `required`... Glasgow's onboard 10kΩ pull-ups are enabled by default --- while they will generally be enough, they may not suffice for fast or long busses. This particular breakout board has on-board pull-ups already, so it's not necessary to use them."
+msgstr ""
+
+#: ../../src/use/repl-script.rst:66
+msgid "Let's start with a bus scan:"
+msgstr ""
+
+#: ../../src/use/repl-script.rst:74
+msgid "Address ``119`` has responded, which is ``0x77`` --- and this matches the datasheet!"
+msgstr ""
+
+#: ../../src/use/repl-script.rst:76
+msgid "This sensor isn't the easiest to operate directly (you need to read a number of calibration variables and perform long calculations), so this is a great example of when you might want to start writing a script instead of using the REPL interface... however, to prove the point, we're going to read a register and leave the rest as an exercise for the reader."
+msgstr ""
+
+#: ../../src/use/repl-script.rst:78
+msgid "If you're familiar with I²C, you'll know that a common convention is for the target register address to be conveyed as the first portion of a write's payload, with a subsequent read accessing the data from that location, with addresses incrementing automatically. Here we read the ``AC1`` value, which is a 16-bit integer stored at addresses ``0xAA`` and ``0xAB`` --- first by writing the ``0xAA`` base address, and then performing a 2-byte read."
+msgstr ""
+
+#: ../../src/use/repl-script.rst:88
+msgid "UART"
+msgstr ""
+
+#: ../../src/use/repl-script.rst:90
+msgid "To demonstrate a simple UART loopback, I've connected pin 0 and 1 of Port A together... i.e: anything that we transmit, will be immediately received again by us."
+msgstr ""
+
+#: ../../src/use/repl-script.rst:102
+msgid "Again, we simply call the ``uart_iface.write()`` and ``uart_iface.read()`` functions to handle transmit and receive..."
+msgstr ""
+
+#: ../../src/use/repl-script.rst:112
+msgid "WS2812"
+msgstr ""
+
+#: ../../src/use/repl-script.rst:114
+msgid "I've got a `quarter of an Adafruit 60 LED ring <https://www.adafruit.com/product/1768>`_... that's 15x WS2812 RGB LEDs."
+msgstr ""
+
+#: ../../src/use/repl-script.rst:118
+msgid "Due to some buffering artifacts, make sure you write a whole frame at once!"
+msgstr ""
+
+#: ../../src/use/repl-script.rst:130
+msgid "Next, we just write pixel data! Glasgow handles the pixel format mapping for us, and because we requested ``RGB-xBRG``, the conversion from RGB24 (three bytes per pixel) will be handled in hardware. The ``xBRG`` indicates that we're giving a constand ``0`` for the White channel, followed by the required order of Red, Green, and Blue."
+msgstr ""
+
+#: ../../src/use/repl-script.rst:133
+msgid "They're bright, so be careful of your eyes (I used ``1`` for a reason)... here's a strip of green pixels:"
+msgstr ""
+
+#: ../../src/use/repl-script.rst:140
+msgid "A 3-bit rainbow: (black, red, green, yellow, blue, magenta, cyan, white)"
+msgstr ""
+
+#: ../../src/use/repl-script.rst:152
+msgid "And all off again, followed by a full power-down of the I/O:"
+msgstr ""
+
+#: ../../src/use/repl-script.rst:160
+msgid "Hopefully this example starts to show you the power you have available."
+msgstr ""
+
+#: ../../src/use/repl-script.rst:166
+msgid "How do I use a script?"
+msgstr ""
+
+#: ../../src/use/repl-script.rst:168
+msgid "Scripts operate in exactly the same way as the REPL interface --- the only real difference is that instead of you typing (or copy/pasting) the code, it will be read from the nominated file. This allows you to build up much more sophisticated things, harnessing the power of Glasgow without touching any applet code directly."
+msgstr ""
+
+#: ../../src/use/repl-script.rst:171
+msgid "See the `PCF8574 <https://github.com/GlasgowEmbedded/glasgow/blob/main/examples/i2c-pcf8574.py>`_ example for a simple demo."
+msgstr ""
+
+#: ../../src/use/repl-script.rst:175
+msgid "Can I use command line arguments?"
+msgstr ""
+
+#: ../../src/use/repl-script.rst:177
+msgid "Yes! The ``args`` variable that is passed into the REPL and script environments contains all command line arguments that Glasgow sets up (including any defaults), along with a ``script_args`` member which contains anything after the first terminating ``--``."
+msgstr ""
+
+#: ../../src/use/repl-script.rst:179
+msgid "Of course you're also able to setup ``argparse`` or do whatever argument parsing you need to do --- see the `script args <https://github.com/GlasgowEmbedded/glasgow/blob/main/examples/script_args.py>`_ example."
+msgstr ""
+

--- a/docs/manual/pdm.lock
+++ b/docs/manual/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default"]
 strategy = []
 lock_version = "4.5.0"
-content_hash = "sha256:8b2e50a2b778fe650abb26fdcb3943897b1af7abc613fda539026757fbd6ee56"
+content_hash = "sha256:f27fda33647c6d9d95511f61484d98129713018698c52dd090bf426f5cf36687"
 
 [[metadata.targets]]
 requires_python = "~=3.13"
@@ -408,13 +408,13 @@ files = [
 
 [[package]]
 name = "fx2"
-version = "0.13"
+version = "0.16"
 summary = "A Python package for interacting with Cypress EZ-USB FX2 series chips"
 dependencies = [
     "libusb1>=1.0",
 ]
 files = [
-    {file = "fx2-0.13-py3-none-any.whl", hash = "sha256:1d0f5507e94927de4c558d5d40a8b3986eec1259c773a83dae05795614d15b0e"},
+    {file = "fx2-0.16-py3-none-any.whl", hash = "sha256:dd85604b11072787c9e7554fdefe1126c6190ec3542dbca862a077c0b16c9b7c"},
 ]
 
 [[package]]
@@ -426,8 +426,9 @@ summary = "Software for the Glasgow Interface Explorer, a digital interface mult
 dependencies = [
     "amaranth<0.6,>=0.5.8",
     "cobs>=1.2.1",
-    "fx2<1,>=0.11",
-    "importlib-resources~=6.5.2",
+    "enum-tools==0.13.0",
+    "fx2<1,>=0.16",
+    "importlib-resources~=7.1.0",
     "libusb1>=3.3.0; sys_platform != \"emscripten\"",
     "packaging>=23.0",
     "platformdirs<5,>=3.0.0",
@@ -482,15 +483,15 @@ files = [
 
 [[package]]
 name = "importlib-resources"
-version = "6.5.2"
-requires_python = ">=3.9"
+version = "7.1.0"
+requires_python = ">=3.10"
 summary = "Read resources from Python packages"
 dependencies = [
     "zipp>=3.1.0; python_version < \"3.10\"",
 ]
 files = [
-    {file = "importlib_resources-6.5.2-py3-none-any.whl", hash = "sha256:789cfdc3ed28c78b67a06acb8126751ced69a3d5f79c095a98298cd8a760ccec"},
-    {file = "importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c"},
+    {file = "importlib_resources-7.1.0-py3-none-any.whl", hash = "sha256:1bd7b48b4088eddb2cd16382150bb515af0bd2c70128194392725f82ad2c96a1"},
+    {file = "importlib_resources-7.1.0.tar.gz", hash = "sha256:0722d4c6212489c530f2a145a34c0a7a3b4721bc96a15fada5930e2a0b760708"},
 ]
 
 [[package]]
@@ -1000,6 +1001,21 @@ dependencies = [
 files = [
     {file = "sphinx_inline_tabs-2025.12.21.14-py3-none-any.whl", hash = "sha256:e685c782b58d4e01490bcc4e2367cf7135ec28e7283a05e89095394e4ca6e81a"},
     {file = "sphinx_inline_tabs-2025.12.21.14.tar.gz", hash = "sha256:c71a75800326e613fb4e410eed92a0934214741326aca9897c18018b9f968cb6"},
+]
+
+[[package]]
+name = "sphinx-intl"
+version = "2.3.2"
+requires_python = ">=3.9"
+summary = "Sphinx utility that make it easy to translate and to apply translation."
+dependencies = [
+    "babel>=2.9.0",
+    "click>=8.0.0",
+    "sphinx",
+]
+files = [
+    {file = "sphinx_intl-2.3.2-py3-none-any.whl", hash = "sha256:f0082f9383066bab8406129a2ed531d21c38706d08467bf5ca3714e8914bb2be"},
+    {file = "sphinx_intl-2.3.2.tar.gz", hash = "sha256:04b0d8ea04d111a7ba278b17b7b3fe9625c58b6f8ffb78bb8a1dd1288d88c1c7"},
 ]
 
 [[package]]

--- a/docs/manual/pyproject.toml
+++ b/docs/manual/pyproject.toml
@@ -6,6 +6,7 @@ dependencies = [
     "sphinx-autobuild",
     "sphinx-inline-tabs",
     "sphinx-copybutton",
+    "sphinx-intl",
     "sphinxcontrib-autoprogram",
     "enum-tools[sphinx]",
     # If you change the version of Furo, check out the repository, apply the following patch
@@ -21,4 +22,10 @@ dependencies = [
 [tool.pdm.scripts]
 live.cmd = "sphinx-autobuild src build --watch ../../software/glasgow"
 build.cmd = "sphinx-build src build -b html"
+live-cn.cmd = "sphinx-autobuild -D language=cn src build-cn --watch ../../software/glasgow"
+build-cn.cmd = "sphinx-build -D language=cn src build-cn -b html"
+
 check.cmd = "sphinx-build src check -b linkcheck"
+gettext.cmd = "sphinx-build src locale/pot -b gettext"
+intl-update.cmd = "sphinx-intl update -d locale -l cn -w 0"
+i18n = {composite = ["gettext", "intl-update"]}

--- a/docs/manual/src/conf.py
+++ b/docs/manual/src/conf.py
@@ -49,6 +49,9 @@ copybutton_prompt_is_regexp = True
 copybutton_prompt_text = r">>> |\.\.\. |\$ |> "
 copybutton_copy_empty_lines = False
 
+locale_dirs = ["../locale/"]
+gettext_compact = False
+
 html_use_modindex = False
 html_use_index = False
 


### PR DESCRIPTION
To regenerate all translations:

```console
$ pdm i18n
```

To browse a live version of the translated site:

```console
$ pdm live-cn
```