### PR TITLE
applet.interface.spi_analyzer: actually throw exception on overflow

### DIFF
--- a/software/glasgow/applet/interface/spi_analyzer/__init__.py
+++ b/software/glasgow/applet/interface/spi_analyzer/__init__.py
@@ -205,6 +205,9 @@ class SPIAnalyzerInterface:
             When the FPGA buffer overflows. The last few transactions before the overflow occurred
             may be dropped as well.
         """
+        if await self._overflow:
+            raise SPIAnalyzerOverflow("overflow")
+
         packet = cobs.decode((await self._pipe.recv_until(b"\0"))[:-1])
         chip, copi_data, cipo_data = packet[0], packet[1::2], packet[2::2]
         self._log("capture chip=%d copi=<%s> cipo=<%s>",


### PR DESCRIPTION
This change is untested, as I do not have any hardware on which I could easily perform a capture, while the test API doesn't emulate backpressure, which makes the overflow condition impossible to trigger within a testbench.