### PR TITLE
VGA: convert to V2 applet API

### DIFF
--- a/software/glasgow/applet/video/vga_output/__init__.py
+++ b/software/glasgow/applet/video/vga_output/__init__.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import assert_never
 
 from amaranth import *
-from amaranth.lib import enum, data, wiring, io
+from amaranth.lib import enum, data, io
 
 from glasgow.support import logging
 from glasgow.gateware import pll

--- a/software/glasgow/applet/video/vga_output/__init__.py
+++ b/software/glasgow/applet/video/vga_output/__init__.py
@@ -1,9 +1,12 @@
+from dataclasses import dataclass
+from typing import assert_never
+
 from amaranth import *
-from amaranth.lib import enum, data, io
+from amaranth.lib import enum, data, wiring, io
 
 from glasgow.support import logging
 from glasgow.gateware import pll
-from glasgow.applet import *
+from glasgow.applet import GlasgowAppletError, GlasgowAppletV2
 
 
 class VGATestPattern(enum.Enum):
@@ -16,22 +19,31 @@ class VGATestPattern(enum.Enum):
         return self.value
 
 
-class VGAOutputSubtarget(Elaboratable):
-    def __init__(self, ports, h_front, h_sync, h_back, h_active, v_front, v_sync, v_back, v_active,
-                 pix_clk_freq, test_pattern=VGATestPattern.Quilt):
-        self.ports    = ports
+@dataclass(frozen=True)
+class Modeline:
+    h_front_px:     int
+    h_sync_px:      int
+    h_back_px:      int
+    h_active_px:    int
+    v_front_lines:  int
+    v_sync_lines:   int
+    v_back_lines:   int
+    v_active_lines: int
 
-        self.h_front  = h_front
-        self.h_sync   = h_sync
-        self.h_back   = h_back
-        self.h_active = h_active
-        self.v_front  = v_front
-        self.v_sync   = v_sync
-        self.v_back   = v_back
-        self.v_active = v_active
+    @property
+    def h_total_px(self):
+        return self.h_active_px + self.h_front_px + self.h_sync_px + self.h_back_px
 
-        self.pix_clk_freq = pix_clk_freq
+    @property
+    def v_total_lines(self):
+        return self.v_active_lines + self.v_front_lines + \
+               self.v_sync_lines + self.v_back_lines
 
+
+class VGAOutputGenerator(Elaboratable):
+    def __init__(self, ports, modeline, test_pattern=VGATestPattern.Quilt):
+        self.ports        = ports
+        self.modeline     = modeline
         self.test_pattern = test_pattern
 
     def elaborate(self, platform):
@@ -43,73 +55,84 @@ class VGAOutputSubtarget(Elaboratable):
         m.submodules.g  = g_buf  = io.FFBuffer("o", self.ports.g)
         m.submodules.b  = b_buf  = io.FFBuffer("o", self.ports.b)
 
-        plan = pll.ClockPlan(1/platform.default_clk_frequency)
-        m.domains.pix = plan.add_domain(pll.Channel(period=1/self.pix_clk_freq, tolerance=0.01))
-        m.submodules += plan.create(platform)
+        h_ctr = Signal(range(self.modeline.h_total_px))
+        v_ctr = Signal(range(self.modeline.v_total_lines))
 
-        h_ctr = Signal(range(self.h_active + self.h_front + self.h_sync + self.h_back))
-        v_ctr = Signal(range(self.v_active + self.v_front + self.v_sync + self.v_back))
-
-        h_en  = Signal()
-        v_en  = Signal()
-
-        m.d.pix += h_ctr.eq(h_ctr + 1)
-        with m.If(h_ctr == (self.h_active) - 1):
-            m.d.pix += h_en.eq(0)
-        with m.Elif(h_ctr == (self.h_active + self.h_front) - 1):
-            m.d.pix += hs_buf.o.eq(1)
-        with m.Elif(h_ctr == (self.h_active + self.h_front + self.h_sync) - 1):
-            m.d.pix += hs_buf.o.eq(0)
-        with m.Elif(h_ctr == (self.h_active + self.h_front + self.h_sync + self.h_back) - 1):
-            m.d.pix += h_en.eq(1)
-            m.d.pix += h_ctr.eq(0)
-
-            m.d.pix += v_ctr.eq(v_ctr + 1)
-            with m.If(v_ctr == (self.v_active - 1)):
-                m.d.pix += v_en.eq(0)
-            with m.Elif(v_ctr == (self.v_active + self.v_front - 1)):
-                m.d.pix += vs_buf.o.eq(1)
-            with m.Elif(v_ctr == (self.v_active + self.v_front + self.v_sync - 1)):
-                m.d.pix += vs_buf.o.eq(0)
-            with m.Elif(v_ctr == (self.v_active + self.v_front + self.v_sync + self.v_back - 1)):
-                m.d.pix += v_en.eq(1)
-                m.d.pix += v_ctr.eq(0)
+        m.d.sync += h_ctr.eq(h_ctr + 1)
+        with m.If(h_ctr == self.modeline.h_total_px - 1):
+            m.d.sync += [
+                h_ctr.eq(0),
+                v_ctr.eq(Mux(v_ctr == self.modeline.v_total_lines - 1, 0, v_ctr + 1)),
+            ]
 
         pix = Signal(data.StructLayout({"r": 1, "g": 1, "b": 1}))
-        if self.test_pattern == VGATestPattern.Quilt:
-            m.d.comb += pix.eq(h_ctr[5:] + v_ctr[5:])
-        elif self.test_pattern == VGATestPattern.Rect:
-            with m.If(
-                (h_ctr == 0) |
-                (v_ctr == 0) |
-                (h_ctr == self.h_active - 1) |
-                (v_ctr == self.v_active - 1)
-            ):
-                m.d.comb += pix.eq(0b111)
-        elif self.test_pattern == VGATestPattern.Grid:
-            with m.If((h_ctr[:5] == 0) | (v_ctr[:5] == 0)):
-                m.d.comb += pix.eq(0b111)
-        elif self.test_pattern == VGATestPattern.Flag:
-            phase = Signal(range(5))
-            with m.If(0):
-                pass
-            for index in range(5):
-                with m.Elif(v_ctr == index * (self.v_active // 5)):
-                    m.d.pix += phase.eq(index)
-            m.d.comb += pix.eq(Array([0b110, 0b101, 0b111, 0b101, 0b110])[phase])
-        else:
-            assert False
+        match self.test_pattern:
+            case VGATestPattern.Quilt:
+                m.d.comb += pix.eq(h_ctr[5:] + v_ctr[5:])
+            case VGATestPattern.Rect:
+                with m.If(
+                    (h_ctr == 0) |
+                    (v_ctr == 0) |
+                    (h_ctr == self.modeline.h_active_px - 1) |
+                    (v_ctr == self.modeline.v_active_lines - 1)
+                ):
+                    m.d.comb += pix.eq(0b111)
+            case VGATestPattern.Grid:
+                with m.If((h_ctr[:5] == 0) | (v_ctr[:5] == 0)):
+                    m.d.comb += pix.eq(0b111)
+            case VGATestPattern.Flag:
+                phase = Signal(range(5))
+                for index in range(1, 5):
+                    stripe_start = (index * self.modeline.v_active_lines + 4) // 5
+                    with m.If(v_ctr >= stripe_start):
+                        m.d.comb += phase.eq(index)
+                m.d.comb += pix.eq(Array([0b110, 0b101, 0b111, 0b101, 0b110])[phase])
+            case _ as unreachable:
+                assert_never(unreachable)
 
-        with m.If(v_en & h_en):
-            m.d.pix += Cat(r_buf.o, g_buf.o, b_buf.o).eq(Cat(pix.r, pix.g, pix.b))
-        with m.Else():
-            m.d.pix += Cat(r_buf.o, g_buf.o, b_buf.o).eq(0)
+        h_active = h_ctr < self.modeline.h_active_px
+        v_active = v_ctr < self.modeline.v_active_lines
+        m.d.comb += [
+            hs_buf.o.eq(
+                (h_ctr >= self.modeline.h_active_px + self.modeline.h_front_px) &
+                (h_ctr < self.modeline.h_active_px + self.modeline.h_front_px +
+                 self.modeline.h_sync_px)
+            ),
+            vs_buf.o.eq(
+                (v_ctr >= self.modeline.v_active_lines + self.modeline.v_front_lines) &
+                (v_ctr < self.modeline.v_active_lines + self.modeline.v_front_lines +
+                 self.modeline.v_sync_lines)
+            ),
+            Cat(r_buf.o, g_buf.o, b_buf.o).eq(Mux(h_active & v_active, pix, 0)),
+        ]
 
         return m
 
 
-# video video graphics adapter is dumb, so the applet is just called VGAOutputApplet
-class VGAOutputApplet(GlasgowApplet):
+class VGAOutputComponent(Elaboratable):
+    def __init__(self, ports, modeline, pix_clk_freq, test_pattern=VGATestPattern.Quilt):
+        self.ports = ports
+        self.modeline = modeline
+        self.pix_clk_freq = pix_clk_freq
+        self.test_pattern = test_pattern
+
+    def elaborate(self, platform):
+        m = Module()
+
+        plan = pll.ClockPlan(1 / platform.default_clk_frequency)
+        m.domains.pix = plan.add_domain(pll.Channel(period=1 / self.pix_clk_freq, tolerance=0.01))
+        m.submodules += plan.create(platform)
+
+        m.submodules.generator = DomainRenamer("pix")(VGAOutputGenerator(
+            ports=self.ports,
+            modeline=self.modeline,
+            test_pattern=self.test_pattern,
+        ))
+
+        return m
+
+
+class VGAOutputApplet(GlasgowAppletV2):
     logger = logging.getLogger(__name__)
     help = "display video via VGA"
     description = """
@@ -129,13 +152,16 @@ class VGAOutputApplet(GlasgowApplet):
         * r ---[ 350R ]-- RED
         * g ---[ 350R ]-- GREEN
         * b ---[ 350R ]-- BLUE
+
+    Horizontal and vertical sync pulses are active-high. Append ``#`` to either pin name to
+    select active-low sync, for example: ``--hs A0# --vs A1#``.
     """
 
     __default_refresh_rate = 60.0
 
     @classmethod
     def add_build_arguments(cls, parser, access):
-        super().add_build_arguments(parser, access)
+        access.add_voltage_argument(parser)
 
         access.add_pins_argument(parser, "hs", default=True)
         access.add_pins_argument(parser, "vs", default=True)
@@ -182,10 +208,35 @@ class VGAOutputApplet(GlasgowApplet):
             choices=list(VGATestPattern), default=VGATestPattern.Quilt,
             help="use the specific test pattern (choices: %(choices)s, default: %(default)s)")
 
-    def build(self, target, args, test_pattern=True):
-        h_dots  = args.h_active + args.h_front + args.h_sync + args.h_back
-        v_lines = args.v_active + args.v_front + args.v_sync + args.v_back
-        dots_per_frame = h_dots * v_lines
+    def build(self, args):
+        for name in ("h_active", "h_sync", "v_active", "v_sync"):
+            value = getattr(args, name)
+            if value <= 0:
+                raise GlasgowAppletError(
+                    f"{name.replace('_', ' ')} must be positive, not {value}")
+        for name in ("h_front", "h_back", "v_front", "v_back"):
+            value = getattr(args, name)
+            if value < 0:
+                raise GlasgowAppletError(
+                    f"{name.replace('_', ' ')} must not be negative, not {value}")
+        if args.pix_clk_freq is not None and args.pix_clk_freq <= 0:
+            raise GlasgowAppletError(
+                f"pixel clock frequency must be positive, not {args.pix_clk_freq}")
+        if args.refresh_rate is not None and args.refresh_rate <= 0:
+            raise GlasgowAppletError(
+                f"refresh rate must be positive, not {args.refresh_rate}")
+
+        modeline = Modeline(
+            h_front_px=args.h_front,
+            h_sync_px=args.h_sync,
+            h_back_px=args.h_back,
+            h_active_px=args.h_active,
+            v_front_lines=args.v_front,
+            v_sync_lines=args.v_sync,
+            v_back_lines=args.v_back,
+            v_active_lines=args.v_active,
+        )
+        dots_per_frame = modeline.h_total_px * modeline.v_total_lines
         if args.pix_clk_freq is not None:
             pix_clk_freq = args.pix_clk_freq * 1e6
             refresh_rate = pix_clk_freq / dots_per_frame
@@ -198,33 +249,23 @@ class VGAOutputApplet(GlasgowApplet):
         self.logger.info("%dx%d @ %.1f Hz: pixel clock %.3f MHz (ideal)",
             args.h_active, args.v_active, refresh_rate, pix_clk_freq / 1e6)
 
-        self.mux_interface = iface = target.multiplexer.claim_interface(self, args)
-        subtarget = iface.add_subtarget(VGAOutputSubtarget(
-            ports=iface.get_port_group(
-                hs = args.hs,
-                vs = args.vs,
-                r  = args.r,
-                g  = args.g,
-                b  = args.b
-            ),
-            h_front=args.h_front,
-            h_sync=args.h_sync,
-            h_back=args.h_back,
-            h_active=args.h_active,
-            v_front=args.v_front,
-            v_sync=args.v_sync,
-            v_back=args.v_back,
-            v_active=args.v_active,
-            pix_clk_freq=pix_clk_freq,
-            test_pattern=args.pattern,
-        ))
-        return subtarget
+        with self.assembly.add_applet(self):
+            self.assembly.use_voltage(args.voltage)
+            self.assembly.add_submodule(VGAOutputComponent(
+                ports=self.assembly.add_port_group(
+                    hs=args.hs,
+                    vs=args.vs,
+                    r=args.r,
+                    g=args.g,
+                    b=args.b,
+                ),
+                modeline=modeline,
+                pix_clk_freq=pix_clk_freq,
+                test_pattern=args.pattern,
+            ))
 
-    async def run(self, device, args):
-        return await device.demultiplexer.claim_interface(self, self.mux_interface, args)
-
-    async def interact(self, device, args, vga):
-        pass
+    async def run(self, args):
+        pass # no host interface; nothing to do
 
     @classmethod
     def tests(cls):

--- a/software/glasgow/applet/video/vga_output/test.py
+++ b/software/glasgow/applet/video/vga_output/test.py
@@ -1,8 +1,106 @@
-from ... import *
-from . import VGAOutputApplet
+from types import SimpleNamespace
+
+from amaranth import Cat
+from amaranth.lib import io
+from amaranth.sim import Simulator
+
+from glasgow.applet import GlasgowAppletError, GlasgowAppletV2TestCase, synthesis_test
+from glasgow.simulation.assembly import SimulationAssembly
+
+from . import Modeline, VGAOutputApplet, VGAOutputGenerator, VGATestPattern
 
 
-class VGAOutputAppletTestCase(GlasgowAppletTestCase, applet=VGAOutputApplet):
+class VGAOutputAppletTestCase(GlasgowAppletV2TestCase, applet=VGAOutputApplet):
     @synthesis_test
     def test_build(self):
         self.assertBuilds()
+
+    def test_invalid_mode(self):
+        for arguments in (
+            "--h-active 0",
+            "--h-sync 0",
+            "--v-active 0",
+            "--v-sync 0",
+            "--h-front -1",
+            "--h-back -1",
+            "--v-front -1",
+            "--v-back -1",
+            "--pix-clk-freq 0",
+            "--refresh-rate 0",
+        ):
+            with self.subTest(arguments=arguments):
+                args = self._parse_args(arguments, mode="build")
+                applet = VGAOutputApplet(SimulationAssembly())
+                with self.assertRaises(GlasgowAppletError):
+                    applet.build(args)
+
+    def test_timing_and_patterns(self):
+        h_active_px = 36
+        h_front_px = 1
+        h_sync_px = 2
+        h_back_px = 1
+        v_active_lines = 5
+        v_front_lines = 1
+        v_sync_lines = 1
+        v_back_lines = 1
+        h_total_px = h_active_px + h_front_px + h_sync_px + h_back_px
+        v_total_lines = v_active_lines + v_front_lines + v_sync_lines + v_back_lines
+
+        def expected_pixel(pattern, x, y):
+            if x >= h_active_px or y >= v_active_lines:
+                return 0
+            match pattern:
+                case VGATestPattern.Quilt:
+                    return (x >> 5) + (y >> 5)
+                case VGATestPattern.Rect:
+                    return 0b111 if (
+                        x == 0 or y == 0 or
+                        x == h_active_px - 1 or y == v_active_lines - 1
+                    ) else 0
+                case VGATestPattern.Grid:
+                    return 0b111 if (x & 0x1f) == 0 or (y & 0x1f) == 0 else 0
+                case VGATestPattern.Flag:
+                    return (0b110, 0b101, 0b111, 0b101, 0b110)[y]
+
+        for pattern in VGATestPattern:
+            with self.subTest(pattern=pattern):
+                ports = SimpleNamespace(
+                    hs=io.SimulationPort("o", 1),
+                    vs=io.SimulationPort("o", 1),
+                    r=io.SimulationPort("o", 1),
+                    g=io.SimulationPort("o", 1),
+                    b=io.SimulationPort("o", 1),
+                )
+                dut = VGAOutputGenerator(ports=ports, modeline=Modeline(
+                    h_front_px=h_front_px,
+                    h_sync_px=h_sync_px,
+                    h_back_px=h_back_px,
+                    h_active_px=h_active_px,
+                    v_front_lines=v_front_lines,
+                    v_sync_lines=v_sync_lines,
+                    v_back_lines=v_back_lines,
+                    v_active_lines=v_active_lines,
+                ), test_pattern=pattern)
+
+                async def testbench(ctx, dut=dut, pattern=pattern, ports=ports):
+                    # Allow the output flip-flops to capture the first pixel.
+                    await ctx.tick()
+                    for y in range(v_total_lines):
+                        for x in range(h_total_px):
+                            hs_expected = \
+                                h_active_px + h_front_px <= x < \
+                                h_active_px + h_front_px + h_sync_px
+                            vs_expected = \
+                                v_active_lines + v_front_lines <= y < \
+                                v_active_lines + v_front_lines + v_sync_lines
+                            _, _, hs, vs, rgb = await ctx.tick().sample(
+                                ports.hs.o, ports.vs.o, Cat(ports.r.o, ports.g.o, ports.b.o))
+                            self.assertEqual(hs, hs_expected, (x, y))
+                            self.assertEqual(vs, vs_expected, (x, y))
+                            self.assertEqual(
+                                rgb, expected_pixel(pattern, x, y), (x, y))
+
+                sim = Simulator(dut)
+                sim.add_clock(1e-6)
+                sim.add_testbench(testbench)
+                sim.run()


### PR DESCRIPTION
This PR converts the VGA applet to the V2 applet API

This also adds additional tests and fixes existing tests:
- Make pattern test meaningful with enough pixels to verify the pattern.
- Add additional parameter validation test.
- Fixed a bug where the first frame after init was blank because h_en and v_en were reset to zero
- Fix a bug where the flag pattern's phase was updated synchronously, causing the first pixel of each stripe to retain the previous stripe's colour.
- Add additional parameter validation.
- Document setting active-low sync (some VGA modes require it).
- Rename variables to be more consistent with other video modules.