### PR TITLE
`SWDProbeInterface` improvements

### DIFF
--- a/software/glasgow/applet/interface/swd_probe/__init__.py
+++ b/software/glasgow/applet/interface/swd_probe/__init__.py
@@ -348,7 +348,7 @@ class SWDProbeInterface:
         await self._select_ap_addr(ap, reg)
         return await self._raw_write(ap_ndp=1, addr=reg & 0xf, data=data)
 
-    async def initialize(self) -> DP_DPIDR:
+    async def initialize(self, CSYSPWRUP: bool = False) -> DP_DPIDR:
         """Initialize the SW-DP or SWJ-DP.
 
         The initialization process is:
@@ -359,11 +359,13 @@ class SWDProbeInterface:
         4. Write ``DP_ABORT`` to clear all errors.
         5. Write ``CTRL_STAT`` to request debug power-up.
         6. Read ``CTRL_STAT`` to ensure acknowledge of debug power-up.
+        7. **If :py:`CSYSPWRUP`:** Write ``CTRL_STAT`` to request system power-up.
+        8. **If :py:`CSYSPWRUP`:** Read ``CTRL_STAT`` to ensure acknowledge of system power-up.
 
         Raises
         ------
         SWDProbeException
-            On communication error, or if debug power-up request isn't acknowledged.
+            On communication error, or if a power-up request isn't acknowledged.
         """
         await self.jtag_to_swd_v2()
         await self.jtag_to_swd_v1()
@@ -376,6 +378,13 @@ class SWDProbeInterface:
         ctrl_stat = DP_CTRL_STAT.from_int(await self.dp_read(reg=DP_CTRL_STAT_addr))
         if not ctrl_stat.CDBGPWRUPACK:
             raise SWDProbeException(message="target failed to acknowledge debug power-up request")
+        if CSYSPWRUP:
+            await self.dp_write(reg=DP_CTRL_STAT_addr,
+                data=DP_CTRL_STAT(CDBGPWRUPREQ=1, CSYSPWRUPREQ=1).to_int())
+            ctrl_stat = DP_CTRL_STAT.from_int(await self.dp_read(reg=DP_CTRL_STAT_addr))
+            if not ctrl_stat.CSYSPWRUPACK:
+                raise SWDProbeException(
+                    message="target failed to acknowledge system power-up request")
         return dpidr
 
     async def iter_aps(self) -> AsyncIterator[tuple[int, AP_IDR]]:

--- a/software/glasgow/applet/interface/swd_probe/__init__.py
+++ b/software/glasgow/applet/interface/swd_probe/__init__.py
@@ -258,7 +258,8 @@ class SWDProbeInterface:
             await self._recv_ack()
             self._log(f"wr {'ap' if ap_ndp else 'dp'} addr={addr:#x} data={data:#010x}")
         except SWDProbeException as exn:
-            self._log(f"wr {'ap' if ap_ndp else 'dp'} addr={addr:#x} {exn.kind.value}")
+            self._log(f"wr {'ap' if ap_ndp else 'dp'} addr={addr:#x} data={data:#010x} "
+                      f"{exn.kind.value}")
             raise
 
     async def _update_select(self, **kwargs):

--- a/software/glasgow/applet/interface/swd_probe/__init__.py
+++ b/software/glasgow/applet/interface/swd_probe/__init__.py
@@ -527,6 +527,9 @@ class SWDProbeApplet(GlasgowAppletV2):
 
             case "dump-memory":
                 ap_cfg = MEM_AP_CFG.from_int(await self.swd_iface.ap_read(args.ap, MEM_AP_CFG_addr))
+                ap_csw = MEM_AP_CSW.from_int(await self.swd_iface.ap_read(args.ap, MEM_AP_CSW_addr))
+                if not ap_csw.DeviceEn:
+                    raise SWDProbeException(message="MEM-AP is disabled")
 
                 data = []
                 addr = args.address

--- a/software/glasgow/applet/interface/swd_probe/__init__.py
+++ b/software/glasgow/applet/interface/swd_probe/__init__.py
@@ -405,8 +405,15 @@ class SWDProbeInterface:
             yield ap, ap_idr
 
     async def _mem_ap_setup_access(self, ap: int, addr: int):
-        await self.ap_write(ap, MEM_AP_CSW_addr,
-            MEM_AP_CSW(Size=2).to_int())
+        # The problem here is the value of `Prot`: the exact meaning depends on the specific bus
+        # architecture, and getting it wrong will likely result in faults for certain accesses.
+        # For example, using an Unprivileged access to core debug registers will fault.
+        # ARM guarantees that the reset value of MEM-AP CSR contains the "right" value, so we're
+        # eating the cost of an RMW to reuse that value. A more mature debugger would do something
+        # more involved, likely by examining the bus type. This will require an AP abstraction.
+        ap_csw = MEM_AP_CSW.from_int(await self.ap_read(ap, MEM_AP_CSW_addr))
+        ap_csw.Size = 2
+        await self.ap_write(ap, MEM_AP_CSW_addr, ap_csw.to_int())
         await self.ap_write(ap, MEM_AP_TAR_addr, addr)
 
     async def mem_ap_read_word(self, ap: int, addr: int):

--- a/software/glasgow/arch/arm/dap/ap.py
+++ b/software/glasgow/arch/arm/dap/ap.py
@@ -61,7 +61,7 @@ MEM_AP_CSW = bitstruct("MEM_AP_CSW", 32, [
     ("MTE",         1),
     (None,          7),
     ("SPIDEN",      1),
-    (None,          7),
+    ("Prot",        7),
     ("DbgSwEnable", 1),
 ])
 


### PR DESCRIPTION
This is just enough behavior to read/write the core debug registers manually in a pinch.