### PR TITLE
applet: add `__name__` in script/REPL context

### DIFF
--- a/software/glasgow/applet/__init__.py
+++ b/software/glasgow/applet/__init__.py
@@ -111,6 +111,7 @@ class GlasgowAppletV2(metaclass=ABCMeta):
 
     def _code_locals(self, args):
         return {
+            "__name__": "<eval>",
             "asyncio": asyncio,
             "self": self,
             "args": args,


### PR DESCRIPTION
This allows using `bitstruct` definitions in it.