### PR TITLE
Report whether an alert has happened just now or in the past

### DIFF
--- a/firmware/fx2/glasgow_config.h
+++ b/firmware/fx2/glasgow_config.h
@@ -32,7 +32,7 @@ enum {
   /// The board revision and the API compatibility level are combined in the `bcdDevice` field
   /// of the device descriptor, which the software uses to determine if a device is compatible
   /// without having to actively interrogate the hardware.
-  GLASGOW_API_LEVEL = 0x08,
+  GLASGOW_API_LEVEL = 0x09,
 };
 
 enum {

--- a/firmware/fx2/glasgow_mgmt.h
+++ b/firmware/fx2/glasgow_mgmt.h
@@ -203,6 +203,7 @@ struct mgmt_packet {
     // REQ_GET_ALERTS
     // REQ_CLR_ALERTS
     struct mgmt_alert {
+      uint8_t realtime; // actually [bool]
       uint8_t ports[4]; // actually [enum port_alerts]
       uint8_t fpga;
     } alert;

--- a/firmware/fx2/mgmt.c
+++ b/firmware/fx2/mgmt.c
@@ -211,6 +211,9 @@ void mgmt_init() {
   EP1OUTBC  = 0;             // arm EP1OUT
   SYNCDELAY;
   EP1INCS   = _BUSY;         // force disarm EP1IN
+
+  // Indicate that the next pending alert may contain outdated status information.
+  alert.realtime = false;
 }
 
 void mgmt_poll()
@@ -228,6 +231,10 @@ void mgmt_poll()
     mgmt_rsp_len = sizeof(mgmt_rsp.alert);
     goto enqueue;
   }
+
+  // Next unsolicited alert packet will be up-to-date, unless the host stops polling EP1IN in
+  // between now and the next alert.
+  alert.realtime = true;
 
   if (EP01STAT & _EP1OUTBSY)
     return; // EP1OUT empty

--- a/software/glasgow/hardware/device.py
+++ b/software/glasgow/hardware/device.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 VID_QIHW         = 0x20b7
 PID_GLASGOW      = 0x9db1
 
-CUR_API_LEVEL    = 0x08
+CUR_API_LEVEL    = 0x09
 
 
 class _Request(enum.IntEnum):
@@ -718,7 +718,8 @@ class GlasgowDevice:
 
     async def get_faults(self, spec: str) -> GlasgowPortAlerts:
         """Get fault alerts on port ``spec``."""
-        result, pa, pb, pc, pd, _fpga = await self._command_fmt("<B", "<B4BB", _Request.GET_ALERTS)
+        result, _realtime, pa, pb, pc, pd, _fpga = \
+            await self._command_fmt("<B", "<BB4BB", _Request.GET_ALERTS)
         if result == _Result.ERROR:
             raise GlasgowDeviceError(f"cannot get I/O port {spec} fault alerts")
         assert result == _Result.ACK, f"unexpected result {result:02x}"
@@ -727,8 +728,8 @@ class GlasgowDevice:
     async def clear_faults(self, spec: str, alerts = GlasgowPortAlerts.ALL_POSSIBLE):
         """Clear fault alerts on port(s) ``spec``."""
         mask = self._iospec_to_mask(spec)
-        result, = await self._command_fmt("<B4BB", "<B",
-            _Request.CLR_ALERTS, *(alerts.value if mask & (1<<i) else 0 for i in range(4)), 0)
+        result, = await self._command_fmt("<BB4BB", "<B",
+            _Request.CLR_ALERTS, 0, *(alerts.value if mask & (1<<i) else 0 for i in range(4)), 0)
         if result == _Result.ERROR:
             raise GlasgowDeviceError(f"cannot clear I/O port {spec} fault alerts")
         assert result == _Result.ACK, f"unexpected result {result:02x}"
@@ -737,7 +738,7 @@ class GlasgowDevice:
         # Currently only alert responses are supported, but other types of unsolicited responses
         # could be added in the future.
         assert result[0] == _Result.ALERT, f"unexpected result {result[0]:02x}"
-        pa, pb, pc, pd, _fpga = struct.unpack("<4BB", result[1:])
+        realtime, pa, pb, pc, pd, _fpga = struct.unpack("<B4BB", result[1:])
         for index, port_alerts in enumerate([pa, pb, pc, pd]):
             faults = []
             for flag in GlasgowPortAlerts(port_alerts):
@@ -751,8 +752,11 @@ class GlasgowDevice:
                     case _:
                         assert False, "unknown fault"
             if faults:
-                logger.warning(
-                    f"fault: port {self._index_to_iospec(index)}: {', '.join(faults)}")
+                spec = self._index_to_iospec(index)
+                if realtime:
+                    logger.warning(f"fault: port {spec}: {', '.join(faults)}")
+                else:
+                    logger.warning(f"fault: port {spec}: {', '.join(faults)} (before this command)")
 
     async def set_pulls(self, spec: str, low: set[int] = set(), high: set[int] = set(),
                         keep: set[int] = set()):


### PR DESCRIPTION
This avoids confusion when e.g. there's an alert shown by `glasgow safe`.

Now the messages are:

```
W: g.hardware.device: fault: port A: supply overcurrent
```

and (if it happened before the current command was executed):

```
W: g.hardware.device: fault: port A: supply overcurrent (before this command)
```