### PR TITLE
manual: revisions: initial zh_CN localisation

### DIFF
--- a/docs/manual/locale/zh/LC_MESSAGES/revisions/index.po
+++ b/docs/manual/locale/zh/LC_MESSAGES/revisions/index.po
@@ -20,27 +20,27 @@ msgstr ""
 
 #: ../../src/revisions/index.rst:2
 msgid "Hardware revisions"
-msgstr ""
+msgstr "硬件修订版"
 
 #: ../../src/revisions/index.rst:6
 msgid "The devices manufactured by 1BitSquared and :ref:`sold by CrowdSupply and Mouser <purchasing>` use the hardware revision `revC3`_."
-msgstr ""
+msgstr "由 1BitSquared 生产，:ref:`CrowdSupply 和 Mouser 销售 <purchasing>`\\ 的设备使用修订版本 `revC3`_"
 
 #: ../../src/revisions/index.rst:8
 msgid "The Glasgow hardware evolves over time, with each major milestone called a \"revision\". Although all revisions are, and will always be supported with the latest software stack, they vary significantly in their capabilities, and the revision that is being used will determine which tasks can be achieved using the hardware."
-msgstr ""
+msgstr "Glasgow 会随着时间演化，每个主要的里程碑称为一个“修订版”。虽然所有的修订版在现在和将来都会受到最新的软件栈的支持，但是它们的功能范围有显著不同。硬件所使用的修订版会决定它可以胜任哪些任务。"
 
 #: ../../src/revisions/index.rst:10
 msgid "Glasgow hardware revisions use the ``revXN`` format, where ``X`` is a revision letter (advanced alphabetically when major design changes are made) and ``N`` is a stepping number (incremented on any layout or component changes). For example, ``revC0`` is the first stepping of revision C."
-msgstr ""
+msgstr "Glasgow 的硬件修订版使用 ``revXN`` 格式。其中，``X`` 是一个修订版字母（每次在有大的设计修改时按字母顺序递增），``N`` 是步进编号（任何布线和元件变更时递增）。例如，``revC0`` 是修订版 C 的首个步进。"
 
 #: ../../src/revisions/index.rst:14
 msgid "Technical descriptions"
-msgstr ""
+msgstr "技术细节"
 
 #: ../../src/revisions/index.rst:16
 msgid "In-depth technical descriptions are available for certain hardware revisions:"
-msgstr ""
+msgstr "部分硬件修订版提供技术细节描述，如下："
 
 #: ../../src/revisions/index.rst:27
 msgid "revD"
@@ -48,11 +48,11 @@ msgstr ""
 
 #: ../../src/revisions/index.rst:29
 msgid "Revision D is the latest revision, currently in `pre-launch stage on CrowdSupply <https://www.crowdsupply.com/fully-automated/glasgow-interface-explorer-revd>`_. It provides 32 I/O pins with a data rate up to approx. 100 Mbps/pin (50 MHz) [#]_, independent direction control and independently programmable pull-up/pull-down resistors. The I/O pins are grouped into four I/O ports, each of which can use any I/O standard from 1.2 V to 5 V, sense and monitor I/O voltage of the device under test, provide up to 300 mA of power, and measure analog voltages on two dedicated pins (single-ended or differential; 24 bit @ 500 kSPS across all enabled channels). The board uses USB 2 for power, configuration, and communication, achieving up to 336 Mbps (42 MB/s) of sustained combined throughput. Except for USB connectivity, every aspect of the device has been significantly improved compared to revC."
-msgstr ""
+msgstr "修订版 D 是最新的修订版，目前在 `CrowdSupply 上处于预发售阶段 <https://www.crowdsupply.com/fully-automated/glasgow-interface-explorer-revd>`_。它提供了 32 个 I/O 引脚，最高数据速率约 100 Mbps/pin (50 MHz) [#]_，每个引脚有独立的方向控制和独立的可编程上拉/下拉电阻。I/O 引脚分为四个 I/O 端口，每个端口都可以使用任何从 1.2 V 到 5 V 的 I/O 标准，采集和监控被测设备的 I/O 电压，提供 300 mA 供电，在两个单独的引脚上进行模拟电压测量（单端或差分；24 bit @ 500 kSPS，所有使能的通道共用）。板上使用 USB 2 供电、配置、通信，实现最高 336 Mbps (42 MB/s) 持续通信吞吐量。除了 USB 通信能力以外，设备的每个方面相比 revC 来说都有显著改善。"
 
 #: ../../src/revisions/index.rst:31 ../../src/revisions/index.rst:77
 msgid "Data rate achievable in practice depends on many factors and will vary greatly with specific interface and applet design. 12 Mbps/pin (6 MHz) can be achieved with minimal development effort; reaching higher data rates requires careful HDL coding and a good understanding of timing analysis."
-msgstr ""
+msgstr "实际可以达到的数据速率取决于很多因素，并且会在很大程度上受具体接口和小程序设计影响。开发时不太费力即可以达到 12 Mbps/pin (6 MHz) 的速率；如果希望达到更高的速率，需要谨慎地编写 HDL 代码，并充分理解时序分析。"
 
 #: ../../src/revisions/index.rst:41
 msgid "revC"
@@ -60,53 +60,53 @@ msgstr ""
 
 #: ../../src/revisions/index.rst:43
 msgid "Revision C was first mass produced by `1bitSquared`_ at stepping ``revC3``. It provides 16 I/O pins with a data rate up to approx. 100 Mbps/pin (50 MHz) [#]_, independent direction control and independently programmable pull-up/pull-down resistors. The I/O pins are grouped into two I/O ports, each of which can use any I/O standard from 1.8 V to 5 V, sense and monitor I/O voltage of the device under test, as well as provide up to 150 mA of power. The board uses USB 2 for power, configuration, and communication, achieving up to 336 Mbps (42 MB/s) of sustained combined throughput."
-msgstr ""
+msgstr "修订版 C 由 `1bitSquared`_ 首次量产，所生产的步进为 ``revC3``。它提供了 16 个 I/O 引脚，最高数据速率约为 100 Mbps/pin (50 MHz) [#]_，每个引脚有独立的方向控制和独立的可编程上拉/下拉电阻。I/O 引脚分为两个 I/O 端口，每个端口都可以使用任何从 1.8 V 到 5 V 的 I/O 标准，采集和监控被测设备的 I/O 电压，提供 150 mA 供电。板上使用 USB 2 供电、配置、通信，实现最高 336 Mbps (42 MB/s) 持续通信吞吐量。"
 
 #: ../../src/revisions/index.rst
 msgid "Overview of the Glasgow PCB (front)"
-msgstr ""
+msgstr "Glasgow 电路板概览（正面）"
 
 #: ../../src/revisions/index.rst
 msgid "Overview of the Glasgow PCB (back)"
-msgstr ""
+msgstr "Glasgow 电路板概览（背面）"
 
 #: ../../src/revisions/index.rst
 msgid "Description of functional blocks on the Glasgow PCB"
-msgstr ""
+msgstr "Glasgow 电路板上的功能模块的描述"
 
 #: ../../src/revisions/index.rst:62 ../../src/revisions/index.rst:88
 msgid "Design and fabrication files are located in the Git repository:"
-msgstr ""
+msgstr "设计和生产文件在 Git 仓库中："
 
 #: ../../src/revisions/index.rst:64
 msgid "`revC0 (design) <https://github.com/GlasgowEmbedded/glasgow/tree/revC0/hardware/boards/glasgow>`_, `revC0 (schematics) <https://github.com/GlasgowEmbedded/glasgow/blob/main/hardware/boards/glasgow/revC0/schematics.pdf>`_, `revC0 (fabrication) <https://github.com/GlasgowEmbedded/glasgow/tree/main/hardware/boards/glasgow/revC0>`_."
-msgstr ""
+msgstr "`revC0（设计） <https://github.com/GlasgowEmbedded/glasgow/tree/revC0/hardware/boards/glasgow>`_、`revC0（原理图） <https://github.com/GlasgowEmbedded/glasgow/blob/main/hardware/boards/glasgow/revC0/schematics.pdf>`_、`revC0（生产） <https://github.com/GlasgowEmbedded/glasgow/tree/main/hardware/boards/glasgow/revC0>`_。"
 
 #: ../../src/revisions/index.rst:67
 msgid "`revC1 (design) <https://github.com/GlasgowEmbedded/glasgow/tree/revC1/hardware/boards/glasgow>`_, `revC1 (schematics) <https://github.com/GlasgowEmbedded/glasgow/blob/main/hardware/boards/glasgow/revC1/schematics.pdf>`_, `revC1 (fabrication) <https://github.com/GlasgowEmbedded/glasgow/tree/main/hardware/boards/glasgow/revC1>`_."
-msgstr ""
+msgstr "`revC1（设计） <https://github.com/GlasgowEmbedded/glasgow/tree/revC1/hardware/boards/glasgow>`_、`revC1（原理图） <https://github.com/GlasgowEmbedded/glasgow/blob/main/hardware/boards/glasgow/revC1/schematics.pdf>`_、`revC1（生产） <https://github.com/GlasgowEmbedded/glasgow/tree/main/hardware/boards/glasgow/revC1>`_。"
 
 #: ../../src/revisions/index.rst:70
 msgid "`revC2 (design) <https://github.com/GlasgowEmbedded/glasgow/tree/revC2/hardware/boards/glasgow>`_, `revC2 (schematics) <https://github.com/GlasgowEmbedded/glasgow/blob/main/hardware/boards/glasgow/revC2/schematics.pdf>`_, `revC2 (fabrication) <https://github.com/GlasgowEmbedded/glasgow/tree/main/hardware/boards/glasgow/revC2>`_."
-msgstr ""
+msgstr "`revC2（设计） <https://github.com/GlasgowEmbedded/glasgow/tree/revC2/hardware/boards/glasgow>`_、`revC2（原理图） <https://github.com/GlasgowEmbedded/glasgow/blob/main/hardware/boards/glasgow/revC2/schematics.pdf>`_、`revC2（生产） <https://github.com/GlasgowEmbedded/glasgow/tree/main/hardware/boards/glasgow/revC2>`_。"
 
 #: ../../src/revisions/index.rst:73
 msgid "`revC3 (design) <https://github.com/GlasgowEmbedded/glasgow/tree/revC3/hardware/boards/glasgow>`_, `revC3 (schematics) <https://github.com/GlasgowEmbedded/glasgow/blob/main/hardware/boards/glasgow/revC3/schematics.pdf>`_, `revC3 (fabrication) <https://github.com/GlasgowEmbedded/glasgow/tree/main/hardware/boards/glasgow/revC3>`_."
-msgstr ""
+msgstr "`revC3（设计） <https://github.com/GlasgowEmbedded/glasgow/tree/revC3/hardware/boards/glasgow>`_、`revC3（原理图） <https://github.com/GlasgowEmbedded/glasgow/blob/main/hardware/boards/glasgow/revC3/schematics.pdf>`_、`revC3（生产） <https://github.com/GlasgowEmbedded/glasgow/tree/main/hardware/boards/glasgow/revC3>`_。"
 
 #: ../../src/revisions/index.rst:84
 msgid "revA, revB"
-msgstr ""
+msgstr "revA、revB"
 
 #: ../../src/revisions/index.rst:86
 msgid "Revisions A and B have not been produced in significant numbers, have major design issues, and are therefore mostly of historical interest. Nevertheless, anyone who has one of the revA/revB boards can keep using them—forever."
-msgstr ""
+msgstr "修订版 A 和 B 并未实际生产多少件，并且有重大设计缺陷，因此基本上仅对感兴趣历史者有意义。尽管如此，持有 revA/revB 板子的用户可以继续使用它们，并且是永久可以。"
 
 #: ../../src/revisions/index.rst:90
 msgid "`revA (design) <https://github.com/GlasgowEmbedded/glasgow/tree/revA/hardware/boards/glasgow>`_, `revA (schematics) <https://github.com/GlasgowEmbedded/glasgow/blob/main/hardware/boards/glasgow/revA/schematics.pdf>`_, `revA (fabrication) <https://github.com/GlasgowEmbedded/glasgow/tree/main/hardware/boards/glasgow/revA>`_."
-msgstr ""
+msgstr "`revA（设计） <https://github.com/GlasgowEmbedded/glasgow/tree/revA/hardware/boards/glasgow>`_、`revA（原理图） <https://github.com/GlasgowEmbedded/glasgow/blob/main/hardware/boards/glasgow/revA/schematics.pdf>`_、`revA（生产） <https://github.com/GlasgowEmbedded/glasgow/tree/main/hardware/boards/glasgow/revA>`_。"
 
 #: ../../src/revisions/index.rst:93
 msgid "`revB (design) <https://github.com/GlasgowEmbedded/glasgow/tree/revB/hardware/boards/glasgow>`_, `revB (schematics) <https://github.com/GlasgowEmbedded/glasgow/blob/main/hardware/boards/glasgow/revB/schematics.pdf>`_, `revB (fabrication) <https://github.com/GlasgowEmbedded/glasgow/tree/main/hardware/boards/glasgow/revB>`_."
-msgstr ""
+msgstr "`revB（设计） <https://github.com/GlasgowEmbedded/glasgow/tree/revB/hardware/boards/glasgow>`_、`revB（原理图） <https://github.com/GlasgowEmbedded/glasgow/blob/main/hardware/boards/glasgow/revB/schematics.pdf>`_、`revB（生产） <https://github.com/GlasgowEmbedded/glasgow/tree/main/hardware/boards/glasgow/revB>`_。"
 


### PR DESCRIPTION
---

These are for the tabs, when translations for tab labels are enabled

- Front: 正面
- Back: 背面
- Legend: 图例

  ... well I'm not sure it *is* legends, in the sense of explaining symbols used in a diagram/chart? An alternate could be

  - Block diagram: 框图