### PR TITLE
Add HyperRAM (RAM-Pak) support to `octoram` driver

### DIFF
--- a/software/glasgow/applet/internal/memtest/__init__.py
+++ b/software/glasgow/applet/internal/memtest/__init__.py
@@ -292,8 +292,8 @@ class MemoryTestApplet(GlasgowAppletV2):
             help="end of region, exclusive (default: 64 MB)")
         parser.add_argument(
             "-s", "--block-size", metavar="SIZE", type=int,
-            choices=tuple(1<<n for n in range(1, 12)), default=2048,
-            help="block size (power of two, 2..2048, default: 2048)")
+            choices=tuple(1<<n for n in range(1, 12)), default=1024,
+            help="block size (power of two, 2..2048, default: %(default)s)")
         parser.add_argument(
             "-n", "--cycles", metavar="COUNT", type=int, default=1,
             help="repeat memory test COUNT times")

--- a/software/glasgow/gateware/octoram.py
+++ b/software/glasgow/gateware/octoram.py
@@ -13,7 +13,8 @@ from .iostream import IOStreamer, HalfRateIOStreamer
 
 __all__ = [
     "Operation", "Enframer", "Deframer", "Streamer",
-    "Command", "Signature", "Controller", "SimulationController", "InterfaceQueue",
+    "Command", "Signature", "MemoryType", "Controller", "SimulationController",
+    "InterfaceQueue",
 ]
 
 
@@ -189,8 +190,12 @@ class Streamer(wiring.Component):
         return m
 
 
+class MemoryType(enum.Enum, shape=2):
+    OctalSPI = 0
+    HyperRAM = 1
+
+
 class Command(enum.Enum, shape=3):
-    # All Read/Write command codes are swapped between -OBx and and -OCx series!
     GlobalReset  = 0
     ReadMemWrap  = 1
     WriteMemWrap = 2
@@ -201,7 +206,7 @@ class Command(enum.Enum, shape=3):
 
 
 class Signature(wiring.Signature):
-    """Native OPI memory bus."""
+    """Native Octal DDR PSRAM memory bus signature."""
 
     def __init__(self):
         super().__init__({
@@ -222,13 +227,19 @@ class Signature(wiring.Signature):
     @property
     def max_burst_size(self):
         """Largest burst supported by the interface; equal to DRAM row size."""
-        return 2048
+        # AP Memory APSxxx08N-OBR
+        # return 2048
+        # Winbond W957D8MFYA
+        return 1024
 
 
 class Controller(wiring.Component):
-    """OPI PSRAM controller.
+    """Octal DDR PSRAM controller.
 
-    Supports only AP Memory APSxxx08N-OBR devices.
+    The following devices have been tested with this controller:
+
+    * AP Memory APSxxx08N-OBR devices (OctalSPI)
+    * Winbond W957D8MFYA (HyperRAM)
 
     ECP5 Platform Support
     ---------------------
@@ -273,6 +284,8 @@ class Controller(wiring.Component):
     # controller edge clock frequency, which is convenient.
 
     bus: In(Signature())
+
+    mem_type: In(MemoryType)
     latency: In(range(32))
 
     def __init__(self, ports, *, offset: int = 0, half_rate: bool):
@@ -320,8 +333,6 @@ class Controller(wiring.Component):
             if ready is not None:
                 m.d.comb += ready.eq(ram_i_buffer.i.ready)
 
-        # on APS*-OBx and APS*-OCx devices, the command encoding differs by flipping high bit;
-        # we implement -OBx semantics only
         command = Signal(8)
         with m.Switch(self.bus.commands.p.type):
             with m.Case(Command.GlobalReset):   m.d.comb += command.eq(0xFF)
@@ -332,43 +343,66 @@ class Controller(wiring.Component):
             with m.Case(Command.ReadReg):       m.d.comb += command.eq(0x40)
             with m.Case(Command.WriteReg):      m.d.comb += command.eq(0xC0)
 
-        address = Signal(32)
-        # on APS*-OBx devices, RA and CA have no gaps, and on APS*-OCx devices there is a gap
-        # within the column address; we implement -OBx semantics only
-        m.d.comb += address.eq(self.bus.commands.p.addr)
+        address = self.bus.commands.p.addr
+
+        cmd_addr = Signal(48)
+        with m.Switch(self.mem_type):
+            with m.Case(MemoryType.OctalSPI):
+                # on APS*-OBx devices, the 1st negedge must have the same data as the posedge
+                m.d.comb += cmd_addr[40:48].eq(command)
+                m.d.comb += cmd_addr[32:40].eq(command)
+                # on APS*-OBx devices, RA and CA have no gaps
+                m.d.comb += cmd_addr[ 0:32].eq(address)
+
+            with m.Case(MemoryType.HyperRAM):
+                # on APS*-OBx and HyperRAM devices, the command encoding differs by flipping
+                # the high bit, and the address encroaches on the 1st (command) byte; note that
+                # there is no `GlobalReset` command
+                m.d.comb += cmd_addr[40:48].eq(command ^ 0x80)
+                # on HyperRAM devices, the address encoding contains a gap within the CA part;
+                # the code below works with W957D8MFYA
+                m.d.comb += cmd_addr[16:45].eq(address[ 4:32])
+                m.d.comb += cmd_addr[ 0: 3].eq(address[ 1: 4])
+                # on APS*-OCx, yet another encoding is used :(
 
         count = Signal(range(max_burst_size + 1))
         m.d.comb += fifo.i.payload.eq(count)
 
         with m.FSM(name="wr_fsm"):
-            t_lat = Signal.like(self.latency)   # latency timer
-            t_rec = Signal(range(16))           # CE recovery timer
+            t_lat = Signal(len(self.latency) + 1) # latency timer
+            t_rec = Signal(range(16))             # CE recovery timer
 
-            with m.State("Command"):
+            with m.State("Command/Address[32:48]"):
                 m.d.sync += count.eq(
                     Mux(self.bus.commands.p.size == 0, max_burst_size, self.bus.commands.p.size))
                 m.d.sync += t_rec.eq(3)
-                perform(Operation.Write,
-                    # on APS*-OBx devices, the 1st negedge valids to be INST as well
-                    # on APS*-OCx devices, the 1st negedge is don't care
-                    data=(command, command),
-                    valid=self.bus.commands.valid,
-                )
-                with m.If(ram_i_buffer.i.valid & ram_i_buffer.i.ready):
-                    m.next = "Address 3/2"
+                with m.If(self.bus.commands.valid):
+                    with m.If((self.mem_type == MemoryType.HyperRAM) &
+                              (self.bus.commands.p.type == Command.GlobalReset)):
+                        m.next = "Deselect"
+                    with m.Else():
+                        perform(Operation.Write, data=(cmd_addr[40:48], cmd_addr[32:40]))
+                        with m.If(ram_i_buffer.i.valid & ram_i_buffer.i.ready):
+                            m.next = "Command/Address[16:32]"
 
-            with m.State("Address 3/2"):
+            with m.State("Command/Address[16:32]"):
                 # these bits are Don't Care for `Command.GlobalReset`
-                perform(Operation.Write, data=(address[24:32], address[16:24]))
+                perform(Operation.Write, data=(cmd_addr[24:32], cmd_addr[16:24]))
                 with m.If(ram_i_buffer.i.valid & ram_i_buffer.i.ready):
-                    m.next = "Address 1/0"
+                    m.next = "Command/Address[ 0:16]"
 
-            with m.State("Address 1/0"):
+            with m.State("Command/Address[ 0:16]"):
                 # these bits are Don't Care for `Command.GlobalReset`
-                perform(Operation.Write, data=(address[ 8:16], address[ 0: 8]))
+                perform(Operation.Write, data=(cmd_addr[ 8:16], cmd_addr[ 0: 8]))
                 with m.If(ram_i_buffer.i.valid & ram_i_buffer.i.ready):
-                    # Latency Code table:
-                    # - Memory Read:    LC to LC×2
+                    # Latency Code table (HyperRAM):
+                    # - Memory Read:    LC or LC×2 (exact) (variable latency mode)
+                    #                         LC×2 (exact) (fixed latency mode)
+                    # - Memory Write:   as above
+                    # - Register Read:  as above
+                    # - Register Write: 0
+                    # Latency Code table (APS*-OBx):
+                    # - Memory Read:    LC to LC×2 (range)
                     # - Memory Write:   LC
                     # - Register Read:  LC
                     # - Register Write: 0
@@ -384,7 +418,11 @@ class Controller(wiring.Component):
                         with m.Case(Command.ReadReg):
                             m.next = "Read Sync"
                         with m.Case(Command.WriteMemWrap, Command.WriteMemRow):
-                            m.d.sync += t_lat.eq(self.latency - 1)
+                            with m.Switch(self.mem_type):
+                                with m.Case(MemoryType.OctalSPI):
+                                    m.d.sync += t_lat.eq(self.latency - 1)
+                                with m.Case(MemoryType.HyperRAM):
+                                    m.d.sync += t_lat.eq((self.latency << 1) - 1)
                             m.next = "Write Latency"
                         with m.Case(Command.ReadMemWrap, Command.ReadMemRow):
                             m.next = "Read Sync"
@@ -434,7 +472,7 @@ class Controller(wiring.Component):
                     m.d.sync += t_rec.eq(t_rec - 1)
                     with m.If(t_rec == 0):
                         m.d.comb += self.bus.commands.ready.eq(1)
-                        m.next = "Command"
+                        m.next = "Command/Address[32:48]"
 
             with m.State("Error"):
                 pass

--- a/software/glasgow/gateware/ports.py
+++ b/software/glasgow/gateware/ports.py
@@ -49,3 +49,4 @@ def AmaranthPort_with_direction(self, direction):
 
 io.SimulationPort.with_direction = AmaranthPort_with_direction
 io.SingleEndedPort.with_direction = AmaranthPort_with_direction
+io.DifferentialPort.with_direction = AmaranthPort_with_direction

--- a/software/glasgow/hardware/assembly.py
+++ b/software/glasgow/hardware/assembly.py
@@ -614,7 +614,7 @@ class HardwareAssembly(AbstractAssembly):
         if options.size is None:
             options = dataclasses.replace(options, size=64 * 0x100000)
         assert self._artifact is None, "cannot add a dynamic memory to a sealed assembly"
-        assert self._revision >= "D0", "DRAM is not available prior to revision D0"
+        assert self._revision >= "C0", "DRAM is not available prior to revision D0"
         assert len(self._memories) < 2, "only two memory channels are available"
         assert options.size <= 64 * 0x100000, "memory size must be no more than 64 MB"
         self._current_logger.debug(f"allocating DRAM channel {len(self._memories)}")
@@ -704,7 +704,7 @@ class HardwareAssembly(AbstractAssembly):
                 register_addr = i2c_registers.add_existing_ro(Value.cast(signal))
             assert register_addr == register._address
 
-        if self._memories:
+        if self._memories and "D0" <= self.revision < "E0":
             # The location constraint should not be needed with new enough nextpnr-ecp5, but is
             # included here as insurance. TODO: remove this once nextpnr-0.11 is used.
             plan = pll.ClockPlan(self.sys_clk_period, location="X70/Y49/EHXPLL_LR")
@@ -726,8 +726,9 @@ class HardwareAssembly(AbstractAssembly):
                 mem_ports = self._platform.request("octoram", channel,
                     dir={"cs": "-", "clk": "-", "dq": "-", "dqs": "-"})
                 m.submodules[f"mem_ctrl{channel}"] = mem_ctrl = DomainRenamer({
-                    "edge": "dram_edge", "sync": "dram_sync",
+                    "sync": "dram_sync", "edge": "dram_edge",
                 })(octoram.Controller(mem_ports, half_rate=False))
+                m.d.comb += mem_ctrl.mem_type.eq(octoram.MemoryType.OctalSPI)
                 m.d.comb += mem_ctrl.latency.eq(5)
                 m.submodules[f"mem_queue{channel}"] = mem_queue = octoram.InterfaceQueue(
                     i_domain=domain.name,
@@ -737,6 +738,39 @@ class HardwareAssembly(AbstractAssembly):
                 )
                 wiring.connect(m, mem_queue.o, mem_ctrl.bus)
                 wiring.connect(m, wiring.flipped(mem_bus), mem_queue.i)
+
+        elif self._memories and "C0" <= self.revision < "D0":
+            if os.getenv("GLASGOW_REVC_DRAM", "no") == "yes":
+                logger.warning("DRAM support on revC is experimental, use at your own risk")
+            else:
+                logger.error("DRAM support on revC is not enabled without GLASGOW_REVC_DRAM=yes")
+                os._exit(1)
+
+            self._platform.add_ram_pak_resources()
+
+            plan = pll.ClockPlan(self.sys_clk_period)
+            m.domains.dram_sync = plan.add_domain(pll.Channel(period=1/(64e6)))
+            m.submodules.dram_pll = plan.create(self._platform)
+
+            for channel, (domain, mem_bus, options) in enumerate(self._memories):
+                mem_ports = self._platform.request("octoram", channel,
+                    dir={"cs": "-", "clk": "-", "dq": "-", "dqs": "-"})
+                m.submodules[f"mem_ctrl{channel}"] = mem_ctrl = DomainRenamer({
+                    "sync": "dram_sync",
+                })(octoram.Controller(mem_ports, half_rate=True))
+                m.d.comb += mem_ctrl.mem_type.eq(octoram.MemoryType.HyperRAM)
+                m.d.comb += mem_ctrl.latency.eq(7)
+                m.submodules[f"mem_queue{channel}"] = mem_queue = octoram.InterfaceQueue(
+                    i_domain=domain.name,
+                    o_domain="dram_sync",
+                    w_buffer_depth=options.w_buffer_size,
+                    r_buffer_depth=options.r_buffer_size,
+                )
+                wiring.connect(m, mem_queue.o, mem_ctrl.bus)
+                wiring.connect(m, wiring.flipped(mem_bus), mem_queue.i)
+
+        elif self._memories:
+            assert False, "DRAM not available on this hardware revision"
 
         m.submodules.fx2_crossbar = fx2_crossbar = FX2Crossbar(fx2_pins)
 

--- a/software/glasgow/hardware/platform/rev_c.py
+++ b/software/glasgow/hardware/platform/rev_c.py
@@ -121,6 +121,27 @@ class _GlasgowRevCPlatform(GlasgowICE40Platform):
                              "F2 -  -  E3 E1 E2 D1 -  -  D2 C1 D3 C2 -  -  C3 B1 C4 B2 -  -  -  "),
     ]
 
+    def add_ram_pak_resources(self):
+        """The RAM addon is sold separately and uses the LVDS connector."""
+        self.add_resources([
+            Resource("octoram", 0,
+                Subsignal("rst", PinsN("21", dir="o", conn=("lvds", 0))),
+                Subsignal("cs",  PinsN("8", dir="o", conn=("lvds", 0))),
+                Subsignal("clk", DiffPairs("5", "3", dir="o", conn=("lvds", 0))),
+                Subsignal("dqs", Pins("10", dir="io", conn=("lvds", 0))),
+                Subsignal("dq",  Pins("16 15 9 11 14 17 20 22", dir="io", conn=("lvds", 0))),
+                Attrs(IO_STANDARD="SB_LVCMOS18")
+            ),
+            Resource("octoram", 1,
+                Subsignal("rst", PinsN("23", dir="o", conn=("lvds", 0))),
+                Subsignal("cs",  PinsN("27", dir="o", conn=("lvds", 0))),
+                Subsignal("clk", DiffPairs("28", "26", dir="o", conn=("lvds", 0))),
+                Subsignal("dqs", Pins("29", dir="io", conn=("lvds", 0))),
+                Subsignal("dq",  Pins("35 38 32 34 33 40 39 41", dir="io", conn=("lvds", 0))),
+                Attrs(IO_STANDARD="SB_LVCMOS18")
+            ),
+        ])
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._init_glasgow_pins(


### PR DESCRIPTION
Working with HyperBUS feels like having a stroke in slow motion, so I'd really rather not, but given the shortages, we may not be able to pick and choose.